### PR TITLE
docs(git-vibe): document shared runtime plumbing

### DIFF
--- a/docs/git-vibe/cli-reference.md
+++ b/docs/git-vibe/cli-reference.md
@@ -40,6 +40,8 @@ Options:
 - `--agent <agent>`: attach session metadata such as `codex`
 - `--task <task>`: attach a short task description
 
+Fresh vibes also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. By default that means `node_modules`, which helps a new vibe feel immediately runnable when the base checkout is already set up.
+
 ### `git vibe issue <number>`
 
 Open or create a vibe from a GitHub issue number.
@@ -112,7 +114,7 @@ git vibe diff 42
 
 ### `git vibe check [name]`
 
-Show branch, path, compare target, PR state, check summary, session context, and repository settings.
+Show branch, path, compare target, PR state, check summary, session context, shared path plumbing, and repository settings.
 
 ```sh
 git vibe check

--- a/docs/git-vibe/configuration.md
+++ b/docs/git-vibe/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 titleTemplate: Git Vibe
-description: Configure Git Vibe with checked-in vibe.toml settings, release versioning, and lifecycle hooks.
+description: Configure Git Vibe with checked-in vibe.toml settings, shared runtime plumbing, release versioning, and lifecycle hooks.
 prev:
   text: Release and versioning
   link: /git-vibe/release-and-versioning
@@ -30,6 +30,7 @@ openEditor = "auto"
 openWorkspaceWith = "auto"
 deleteRemoteOnFinish = true
 issueBranchStyle = "number-and-title"
+sharedPaths = "node_modules, .venv"
 
 [release]
 versioning = "npm"
@@ -49,6 +50,7 @@ pre-release = "npm test"
 - `openWorkspaceWith`
 - `deleteRemoteOnFinish`
 - `issueBranchStyle`
+- `sharedPaths`
 
 ## Release settings
 
@@ -71,11 +73,37 @@ git config vibe.releaseFile VERSION
 
 In `auto`, Git Vibe prefers Codex Desktop inside a Codex shell and otherwise uses VS Code when the `code` CLI is available.
 
+## Shared runtime paths
+
+`vibe.sharedPaths` is a comma-separated list of relative repo paths that Git Vibe should symlink from the primary checkout into a fresh vibe before `post-create` runs.
+
+By default, Git Vibe uses:
+
+```sh
+git config --global vibe.sharedPaths node_modules
+```
+
+That default makes a practical difference for Node projects: if your main checkout already has `node_modules`, a fresh vibe can usually run `npm run dev`, `npm test`, and local CLIs immediately.
+
+Useful examples:
+
+```toml
+[vibe]
+sharedPaths = "node_modules, .venv"
+```
+
+```sh
+git config vibe.sharedPaths "node_modules,.direnv"
+git config vibe.sharedPaths none
+```
+
+Use `none` when you want to disable automatic runtime plumbing for a repo.
+
 ## Lifecycle hooks
 
 Hooks live under `[hooks]` and run through `sh -c`.
 
-- `post-create` runs after Git Vibe creates or attaches a fresh worktree
+- `post-create` runs after Git Vibe creates or attaches a fresh worktree and after shared path plumbing is linked
 - `pre-finish` runs after merge verification and before cleanup
 - `pre-release` runs after release validation and before version updates, commit creation, and tagging
 

--- a/docs/git-vibe/getting-started.md
+++ b/docs/git-vibe/getting-started.md
@@ -91,7 +91,12 @@ That creates:
 
 - a branch like `feat/fix-login-redirect`
 - a dedicated worktree under `../.vibe/<repo>/fix-login-redirect`
+- shared runtime plumbing such as `node_modules` from the main checkout when it already exists
 - a context summary showing the path, compare target, and current change state
+
+That last part matters in real day-to-day work. If your base checkout already has the project ready to run, a fresh vibe should feel ready too. For Node projects, Git Vibe links `node_modules` into new vibes by default so commands like `npm run dev`, `npm test`, or framework CLIs can work without a manual fix.
+
+If your project needs more than that, configure `vibe.sharedPaths` in `vibe.toml` for paths like `.venv`, `.direnv`, or `vendor/bundle`.
 
 If you work from issues, you can start directly from the issue number:
 


### PR DESCRIPTION
## Summary
- explain that fresh vibes inherit shared runtime paths like node_modules from the base checkout
- document vibe.sharedPaths, its defaults, and its hook timing
- update the Git Vibe getting started, configuration, and CLI reference pages

## Testing
- npm run build

Related: sailscastshq/git-vibe#24