### PR TITLE
feat: add durable ui docs hub

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -813,6 +813,20 @@ function durableUiGuide() {
           link: '/durable-ui/progress/wizard-draft'
         }
       ]
+    },
+    {
+      text: 'URL',
+      collapsed: false,
+      items: [
+        {
+          text: 'Overview',
+          link: '/durable-ui/url'
+        },
+        {
+          text: 'query-state',
+          link: '/durable-ui/url/query-state'
+        }
+      ]
     }
   ]
 }

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -53,6 +53,7 @@ export default {
       '/sails-quest/': SailsQuestGuide(),
       '/sentry-sails/': SentrySailsGuide(),
       '/pellicule/': pelliculeGuide(),
+      '/durable-ui/': durableUiGuide(),
       '/sails-ai/': sailsAiGuide(),
       '/sails-flare/': sailsFlareGuide()
     },
@@ -771,6 +772,47 @@ function pelliculeGuide() {
       text: 'AI',
       collapsed: false,
       items: [{ text: 'Agent Skills', link: '/pellicule/agent-skills' }]
+    }
+  ]
+}
+
+function durableUiGuide() {
+  return [
+    {
+      text: 'Philosophy',
+      collapsed: false,
+      items: [
+        {
+          text: 'What is Durable UI?',
+          link: '/durable-ui/what-is-durable-ui'
+        }
+      ]
+    },
+    {
+      text: 'Introduction',
+      collapsed: false,
+      items: [
+        { text: 'Overview', link: '/durable-ui/' },
+        { text: 'Getting Started', link: '/durable-ui/getting-started' }
+      ]
+    },
+    {
+      text: 'Progress',
+      collapsed: false,
+      items: [
+        {
+          text: 'Overview',
+          link: '/durable-ui/progress'
+        },
+        {
+          text: 'form-draft',
+          link: '/durable-ui/progress/form-draft'
+        },
+        {
+          text: 'wizard-draft',
+          link: '/durable-ui/progress/wizard-draft'
+        }
+      ]
     }
   ]
 }

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -128,6 +128,8 @@ function soundingGuide() {
       items: [
         { text: 'Trials', link: '/sounding/trials' },
         { text: 'Trial context', link: '/sounding/trial-context' },
+        { text: 'Factories', link: '/sounding/factories' },
+        { text: 'Scenarios', link: '/sounding/scenarios' },
         { text: 'Worlds', link: '/sounding/worlds' },
         { text: 'Auth and actors', link: '/sounding/auth-and-actors' },
         { text: 'Suite structure', link: '/sounding/organizing-your-suite' }
@@ -142,6 +144,16 @@ function soundingGuide() {
         { text: 'Inertia', link: '/sounding/testing-inertia' },
         { text: 'Browser', link: '/sounding/browser-testing' },
         { text: 'Mail', link: '/sounding/mail-testing' }
+      ]
+    },
+    {
+      text: 'Reference',
+      collapsed: false,
+      items: [
+        {
+          text: 'Request clients and transport',
+          link: '/sounding/request-clients'
+        }
       ]
     }
   ]

--- a/docs/.vitepress/data/projects.data.js
+++ b/docs/.vitepress/data/projects.data.js
@@ -25,6 +25,14 @@ export default {
           popular: true
         },
         {
+          name: 'Durable UI',
+          description:
+            'State-placement utilities for UI that survives refreshes, navigation, and real users. Built around progress drafts and wizard flows.',
+          link: '/durable-ui/',
+          github: 'https://github.com/sailscastshq/durable-ui',
+          popular: true
+        },
+        {
           name: 'Sails AI',
           description:
             'Multi-provider AI hook for Sails.js with a clean adapter pattern. Chat, stream, and reason with any LLM.',

--- a/docs/.vitepress/data/projects.data.js
+++ b/docs/.vitepress/data/projects.data.js
@@ -27,7 +27,7 @@ export default {
         {
           name: 'Durable UI',
           description:
-            'State-placement utilities for UI that survives refreshes, navigation, and real users. Built around progress drafts and wizard flows.',
+            'State-placement utilities for progress drafts, shareable URL state, and cleanup rules that survive real users.',
           link: '/durable-ui/',
           github: 'https://github.com/sailscastshq/durable-ui',
           popular: true

--- a/docs/boring-stack/ascent.md
+++ b/docs/boring-stack/ascent.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/boring-stack-social.png
 title: Ascent
 titleTemplate: The Boring JavaScript Stack
-description: Ascent is a production-ready SaaS template built on The Boring JavaScript Stack. Available with React or Vue frontends. Ship products with battle-tested technologies and focus on actual real users instead of wrestling with complex build tools.
+description: Ascent is a SaaS template built on The Boring JavaScript Stack and available with React or Vue frontends.
 prev:
   text: Mellow
   link: '/boring-stack/mellow'
@@ -17,16 +17,14 @@ editLink: true
 
 # Ascent
 
-**Ship products with battle-tested technologies. Say no to chasing JavaScript trends.**
-
-Ascent is a production-ready SaaS template built on The Boring JavaScript Stack. Available with **React** or **Vue** frontends. Focus on shipping to actual real users instead of wrestling with complex build tools and trendy frameworks.
+Ascent is a SaaS template built on The Boring JavaScript Stack and available with **React** or **Vue** frontends.
 
 ## The Boring Stack Philosophy
 
-- **Focus on Your Product** - Effortlessly focus on what really matters: shipping to actual real users
+- **Server-centric product development** - Build product features without maintaining a separate API layer
 - **No API Required** - Each page receives the necessary data as props from your Sails backend
-- **Battle-Tested Technologies** - Built with reliable, proven technologies that just work
-- **Ship Fast** - Iterate quickly and move easily from MVP to scale
+- **Established tools** - Use stable framework and infrastructure choices
+- **One codebase** - Keep routing, data access, and UI work in the same application
 
 ## Tech Stack
 

--- a/docs/boring-stack/coolify.md
+++ b/docs/boring-stack/coolify.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Deploy on Coolify
 
-Let's deploy your app on [Coolify](https://coolify.io) :rocket:
+This page covers deploying a Boring Stack app on [Coolify](https://coolify.io).
 
 ## GitHub Repo
 
@@ -119,10 +119,4 @@ Depending on the template you're using, you may need to set additional environme
 
 Click **Deploy** in Coolify. Your app will be built using the Dockerfile and deployed automatically.
 
-That's it! Your app will be live on your Coolify domain as soon as the build finishes :tada:
-
-## Celebrate with a :star:
-
-::: tip Star The Boring JavaScript Stack repo on GitHub :star:
-Let's celebrate deploying your app on Coolify by giving **The Boring JavaScript Stack** [a star on GitHub](https://github.com/sailscastshq/boring-stack).
-:::
+After the build finishes, Coolify deploys the app to the configured domain.

--- a/docs/boring-stack/flash-messages.md
+++ b/docs/boring-stack/flash-messages.md
@@ -19,7 +19,7 @@ editLink: true
 
 Flash messages let you send one-time data to users after redirects. Unlike regular props, flash data isn't persisted in browser history - when a user clicks the back button, they won't see old flash messages reappear.
 
-This makes flash perfect for success notifications, error messages, newly created IDs, or any temporary values.
+Use flash for success notifications, error messages, newly created IDs, or any other temporary values.
 
 ## Sending flash messages
 

--- a/docs/boring-stack/index.md
+++ b/docs/boring-stack/index.md
@@ -9,7 +9,7 @@ titleTemplate:
 hero:
   name: The Boring JavaScript Stack
   text: The reliable full-stack JavaScript stack
-  tagline: Ship products with battle-tested technologies. Say no to chasing JavaScript trends.
+  tagline: Full-stack JavaScript with Sails, Inertia, Tailwind CSS, and Vue, React, or Svelte.
   actions:
     - theme: brand
       text: Get Started
@@ -22,15 +22,15 @@ hero:
     alt: The Boring JavaScript Stack
 features:
   - icon: 🎯
-    title: Focus on Your Product
-    details: Effortlessly focus on what really matters - shipping to actual real users.
+    title: Server-centric product development
+    details: Build product features without maintaining a separate API layer for the frontend.
   - icon: 🙅🏾‍♀️
     title: No API required for your SPA
     details: Each page receives the necessary data as props from your Sails backend.
   - icon: 🫱🏾‍🫲🏿
     title: Bring Your own UI framework
-    details: You can use your favorite frontend framework for your UI be it Vue, React, or Svelte.
+    details: Use Vue, React, or Svelte for the UI layer.
   - icon: 🚀
-    title: Ship Fast
-    details: With The Boring Stack you can iterate quickly and move easily from MVP to scale.
+    title: One codebase
+    details: Keep routing, data access, and UI work in the same application.
 ---

--- a/docs/boring-stack/locals.md
+++ b/docs/boring-stack/locals.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Locals
 
-Locals let you pass data from your actions to the root EJS template (`views/app.ejs`). They're perfect for SEO meta tags, page titles, Open Graph images, and anything that belongs in the HTML `<head>`.
+Locals let you pass data from your actions to the root EJS template (`views/app.ejs`). Use them for SEO meta tags, page titles, Open Graph images, and anything else that belongs in the HTML `<head>`.
 
 Unlike props which go to your React/Vue/Svelte components, locals only go to the EJS template on the initial full-page load — which is exactly when search engines and social media crawlers read your HTML.
 

--- a/docs/boring-stack/once-props.md
+++ b/docs/boring-stack/once-props.md
@@ -23,7 +23,7 @@ Once props solve this. They're sent to the client on the first request, then aut
 
 ## When to use once props
 
-Once props are ideal for:
+Common uses for once props are:
 
 - **User permissions** - Fetched once at login, skipped until they change
 - **Feature flags** - App-wide settings that rarely update

--- a/docs/boring-stack/railway.md
+++ b/docs/boring-stack/railway.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Deploy on Railway
 
-Let's deploy your app on [Railway](https://railway.com) :rocket:
+This page covers deploying a Boring Stack app on [Railway](https://railway.com).
 
 You have two options to deploy your app on Railway...
 
@@ -183,10 +183,4 @@ Add the following evironment variables to your web service:
 - `REDIS_URL`: This should point to the connection string to the Redis instance you created.
 - `SESSION_SECRET`: A unique production session secret to override the one in `config/session.js`.
 
-That’s it! Your app will be live on your Railway URL as soon as the build finishes :tada:
-
-## Celebrate with a :star:
-
-::: tip Star The Boring JavaScript Stack repo on GitHub :star:
-Let's celebrate deploying your app on Railway by giving **The Boring JavaScript Stack** [a star on GitHub](https://github.com/sailscastshq/boring-stack).
-:::
+After the build finishes, Railway deploys the app to the assigned URL.

--- a/docs/boring-stack/render.md
+++ b/docs/boring-stack/render.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Deploy on Render
 
-Let's deploy your app on [Render](https://render.com) :rocket:
+This page covers deploying a Boring Stack app on [Render](https://render.com).
 
 ## GitHub Repo
 
@@ -116,10 +116,4 @@ Add the following evironment variables to your web service:
 - `REDIS_URL`: This should point to the connection string to the Redis instance you created.
 - `SESSION_SECRET`: A unique production session secret to override the one in `config/session.js`.
 
-That’s it! Your app will be live on your Render URL as soon as the build finishes :tada:
-
-## Celebrate with a :star:
-
-::: tip Star The Boring JavaScript Stack repo on GitHub :star:
-Let's celebrate deploying your app on Render by giving **The Boring JavaScript Stack** [a star on GitHub](https://github.com/sailscastshq/boring-stack).
-:::
+After the build finishes, Render deploys the app to the assigned URL.

--- a/docs/boring-stack/slipway.md
+++ b/docs/boring-stack/slipway.md
@@ -17,12 +17,12 @@ editLink: true
 
 # Deploy on Slipway
 
-Let's deploy your app on [Slipway](https://github.com/sailscastshq/slipway) :rocket:
+This page covers deploying a Boring Stack app on [Slipway](https://github.com/sailscastshq/slipway).
 
 ::: tip Recommended for self-hosting
-Slipway is our recommended deployment platform for self-hosting. It's built from the ground up for The Boring JavaScript Stack — it understands your Sails app, your Dockerfile, your database, and your Redis out of the box.
+Slipway is the recommended self-hosting option in these docs. It detects the app's Sails setup, Dockerfile, database, and Redis configuration.
 
-No glue code, no adapters, no translating between your stack and your platform. Just push your code and Slipway handles the rest — with push-to-deploy, automatic SSL, preview environments, database management, background jobs monitoring, and a full operational dashboard all running on your own server.
+It also provides push-to-deploy, automatic SSL, preview environments, database management, and background job monitoring on the same server.
 :::
 
 ## Install Slipway
@@ -59,8 +59,8 @@ Slipway reads your app's `package.json` and generates a **deployment checklist**
 
 Each checklist item comes with an actionable button — **Add database**, **Add Redis**, **Generate** — so you can fix issues directly from the checklist without hunting through settings. Once everything is configured, the checklist shows a green "Environment is configured correctly" status.
 
-::: tip No more guesswork
-On other platforms, you have to remember what env vars and services your app needs and set them up manually. Slipway inspects your code and tells you what's missing — then lets you fix it in one click.
+::: tip Deployment checklist
+Slipway inspects the app and reports missing services or environment variables so you can fix them from the checklist.
 :::
 
 ## Connect your GitHub repo
@@ -80,8 +80,8 @@ See the [Git integration guide](/slipway/git-integration) and [auto-deploy](/sli
 
 In your project's environment, click **Add Service** and select the database you need. Slipway supports [PostgreSQL, MySQL, and MongoDB](/slipway/database-services) as one-click services.
 
-::: tip Zero configuration
-When you create a database service, Slipway automatically sets `DATABASE_URL` as an environment variable on your app. No need to copy connection strings around — it just works.
+::: tip Automatic `DATABASE_URL`
+When you create a database service, Slipway automatically sets `DATABASE_URL` as an environment variable on the app.
 :::
 
 ## Add Redis
@@ -184,11 +184,11 @@ slipway slide
 The Boring Stack templates come with a production-ready Dockerfile, so you don't need to create one manually. Slipway detects and uses it automatically.
 :::
 
-That's it! Your app will be live on your domain as soon as the build finishes :tada:
+After the build finishes, Slipway deploys the app to the configured domain.
 
 ## What you get with Slipway
 
-Beyond deployment, Slipway gives you a full operational dashboard purpose-built for your Boring Stack app:
+Slipway also provides operational tools for the deployed app:
 
 - **[Push-to-deploy](/slipway/auto-deploy)** — automatic deployments from GitHub on every push
 - **[Preview environments](/slipway/auto-deploy)** — automatic environments for pull requests
@@ -201,9 +201,3 @@ Beyond deployment, Slipway gives you a full operational dashboard purpose-built 
 - **[Lookout](/slipway/lookout)** — real-time observability with request tracing, exceptions, and metrics
 - **[Rollbacks](/slipway/rollbacks)** — one-click rollback to any previous deployment
 - **[Notifications](/slipway/notifications)** — get alerted on deployment status, container issues, and more
-
-## Celebrate with a :star:
-
-::: tip Star The Boring JavaScript Stack repo on GitHub :star:
-Let's celebrate deploying your app on Slipway by giving **The Boring JavaScript Stack** [a star on GitHub](https://github.com/sailscastshq/boring-stack).
-:::

--- a/docs/boring-stack/whats-in-the-stack.md
+++ b/docs/boring-stack/whats-in-the-stack.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/boring-stack-social.png
 title: What's in the stack?
 titleTemplate: The Boring JavaScript Stack 🥱
-description: The Boring JavaScript comes with Sails, Inertia, Tailwind CSS, and Vue, React, or Svelte. It's about proven technologies prioritizing stability and efficiency, letting you focus on solving real web development problems without the noise of constant updates.
+description: The Boring JavaScript Stack combines Sails, Inertia, Tailwind CSS, and Vue, React, or Svelte.
 prev:
   text: 'Who is it for?'
   link: '/boring-stack/who-is-it-for'
@@ -17,27 +17,23 @@ editLink: true
 
 # What's in The Boring JavaScript Stack?
 
-Alright, let's peel back the layers and take a look at what makes up **The Boring JavaScript Stack**.
+The Boring JavaScript Stack combines Sails, Inertia, Tailwind CSS, and your choice of Vue, React, or Svelte.
 
 ## Vue, React, or Svelte
 
-Whether you prefer the simplicity of [Vue](https://vuejs.org/), the flexibility of [React](https://reactjs.org/), or the efficiency of [Svelte](https://svelte.dev/), **The Boring JavaScript Stack** accommodates your choice. With The Boring JavaScript Stack, the UI of your app are simply the components of your chosen UI framework.
-
-So if you enjoy writing React's JSX, you'd love The Boring JavaScript Stack as that's the only thing you have to know from React - writing components. Same thing with Vue and Svelte.
+Pick one UI framework for the app's pages and components. Inertia uses those components as the client-side view layer.
 
 ## Tailwind CSS
 
-[Tailwind CSS](https://tailwindcss.com/), the utility-first CSS framework makes styling feels like cheating. It serves as the styling backbone of this stack.
-
-Since The Boring JavaScript Stack is about being pragmatic, what's better than Tailwind CSS in practicality, efficiency, and ensuring your styles are predictable and easy to manage?
+[Tailwind CSS](https://tailwindcss.com/) provides the utility classes used for styling pages and components.
 
 ## Inertia
 
-[Inertia](https://inertiajs.com/) allows you to build modern single-page apps without the need for a full-blown API. It keeps things simple and straightforward, emphasizing stability in your UI(frontend) development.
+[Inertia](https://inertiajs.com/) lets Sails controllers return pages and props without building a separate JSON API.
 
 ## Sails
 
-At the core of this stack is [Sails](https://sailsjs.com/), a web framework that's been around the block and has proven itself. It's not trying to reinvent the wheel; instead, it focuses on providing a solid foundation for building scalable and maintainable web applications.
+At the core of this stack is [Sails](https://sailsjs.com/), which handles routing, policies, models, helpers, sessions, scripts, and other server-side behavior.
 
 Because we’re using Sails as the web framework, we can leverage a lot of its features including:
 
@@ -48,5 +44,5 @@ Because we’re using Sails as the web framework, we can leverage a lot of its f
 - [WebSocket support](https://sailsjs.com/documentation/concepts/realtime): Sails apps are capable of full-duplex, realtime communication between the client and server.
 - [File uploads](https://sailsjs.com/documentation/concepts/file-uploads): [Skipper](https://github.com/sailshq/skipper) makes it easy to implement streaming file uploads to disk, Amazon S3, Cloudflare R2, DigitalOcean Spaces or any supported file upload adapters.
 - [Shell scripts](https://sailsjs.com/documentation/concepts/shell-scripts): Sails lets you run JavaScript functions as shell scripts. This can be useful for running scheduled jobs with [Sails Quest](https://docs.sailscasts.com/sails-quest) (cron, Heroku scheduler), worker processes, and any other custom, one-off scripts that need access to your Sails app's models, configuration, and helpers.
-- [Sails Mail](https://docs.sailscasts.com/mail/): Sails Mail provides an amazing and elegant API for sending emails.
+- [Sails Mail](https://docs.sailscasts.com/mail/): Send email through a Sails hook and helper-based API.
 - [Sails Quest](https://docs.sailscasts.com/sails-quest): Schedule background jobs in your Sails applications with human-readable intervals, cron expressions, and full access to your app's context.

--- a/docs/boring-stack/who-is-it-for.md
+++ b/docs/boring-stack/who-is-it-for.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/boring-stack-social.png
 title: Who is it for?
 titleTemplate: The Boring JavaScript Stack 🥱
-description: Wondering who vibes with The Boring JavaScript Stack? If you're all about practicality over trends, a business owner aiming for consistent services, or a team lead striving for efficiency – this stack is your jam. It's for startups with a long-term vision and devs craving problem-solving excitement.
+description: Teams and products that are a good fit for The Boring JavaScript Stack.
 prev:
   text: Why the name
   link: '/boring-stack/why-the-name'
@@ -17,34 +17,17 @@ editLink: true
 
 # Who is The Boring JavaScript Stack for?
 
-So, you're probably wondering, "Who would benefit from embracing **The Boring JavaScript Stack**?" Well, let me break it down for you.
+The Boring JavaScript Stack is a good fit for teams that want a server-centric full-stack JavaScript setup built around Sails and Inertia.
 
-## Pragmatic Developers
+## Good fit
 
-If you're a developer who values practicality over chasing the latest shiny tool in the JavaScript playground, this stack is for you. **The Boring JavaScript Stack** is tailored for those who understand the importance of stability, reliability, and predictability in their tech choices.
+- developers who want Sails on the server and Vue, React, or Svelte on the client without maintaining a separate API
+- teams that want predictable onboarding and fewer framework migrations
+- products that value maintainability and long-lived codebases
+- startups that want one codebase for most product work
 
-## Business Owners and Entrepreneurs
+## Probably not a fit
 
-Running a business comes with its own set of challenges. For those focused on solving real-world problems through web software, a "boring" tech stack can be a game-changer.
-
-If you're more interested in delivering consistent services to your users than constantly adapting to ever-changing technologies, this stack aligns perfectly with your business mindset.
-
-## Team Leads and Managers
-
-Efficiency and collaboration are key components of a successful development team. If you're leading a group of talented individuals, a "boring" tech stack facilitates smoother onboarding, reduced maintenance overhead, and a shared understanding among team members.
-
-It allows you to focus on delivering value to users rather than grappling with the complexities of bleeding-edge technologies.
-
-## Startups with a Long-Term Vision
-
-Startups often find themselves in a whirlwind of choices, trying to find the perfect tech stack that aligns with their vision. **The Boring JavaScript Stack** is particularly well-suited for startups with a long-term perspective. It provides a solid foundation, enabling you to concentrate on solving exciting problems and building a sustainable business.
-
-## Developers Who Crave Problem-Solving Excitement
-
-Yes, you read that right! If you're a developer seeking excitement, look no further than the problems you're solving, not the tools you're using.
-
-**The Boring JavaScript Stack** allows you to let the tools fade into the background, giving you the freedom to dive deep into the exciting challenges of web development without constantly being distracted by the latest tech trends.
-
-In essence, this stack is for those who understand that the real excitement in web development comes from creating solutions that make a difference.
-
-If you're tired of the constant rat race in the JavaScript ecosystem and want to focus on building amazing things with dependable technologies, then **The Boring JavaScript Stack** is your ticket to a more grounded and purposeful development journey.
+- teams that prefer a fully decoupled frontend and backend architecture
+- projects that want to optimize for the newest frontend patterns first
+- teams that prefer assembling separate services for routing, auth, rendering, and deployment

--- a/docs/boring-stack/why-the-name.md
+++ b/docs/boring-stack/why-the-name.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/boring-stack-social.png
 title: Why the name?
 titleTemplate: The Boring JavaScript Stack 🥱
-description: Discover the philosophy behind The Boring JavaScript Stack. It's a nod to stability, a rebellion against chasing trends. Embrace reliability for efficient web development without constant distractions.
+description: Why the stack uses the word boring and what that means in practice.
 next:
   text: Who is it for
   link: '/boring-stack/who-is-it-for'
@@ -14,64 +14,29 @@ editLink: true
 
 # Why the name?
 
-The JavaScript ecosystem is so exciting - we are always coming up with newer ways to build web software.
+The name emphasizes stable, well-understood tools over frequent framework churn.
 
-I don't know about you, but one of the reasons why I opted to base my career in web development on JavaScript was to build things quickly and easily.
+## What "boring" means
 
-But with the constant state of chasing the next trend or reinventing the wheel, or in most cases ignoring that the wheel ever existed, we've been busy glorifying our hammers ⚒️ instead of building amazing things with them.
-
-## Boring technology
-
-We don't build web software in a vacuum; we do it to solve problems in our workplace, create an MVP for that killer idea, and so on.
-
-There are so many exciting problems to be solved with web software that it begs the question: Why are we wasting time and resources on what to build with?
-
-There are amazing technologies that have been tried and tested, which you can depend on.
-
-There is a school of thought that calls tried, tested, and stable technologies "boring tech," and **The Boring JavaScript Stack** is a tribute to that school of thought. It is also a contrarian movement against the trend in the JS ecosystem of chasing the shiny.
-
-With **The Boring JavaScript Stack**, you can get off the rat race in the JavaScript ecosystem and move fast by building with stable and boring technologies.
-
-## Boring is good
-
-Someone once expressed concerns with the name - **The Boring JavaScript Stack**. Their concern is that "...many will still be scared of the name."
-
-The fact that many people get scared by the name actually proves my point about glorifying the hammer instead of the building. It seems like the focus is on the wrong things.
-
-We've got to stop getting excited about tools and start getting excited about the problems we are solving with them.
-
-Boring technologies are...
+In this docs set, "boring" means tools that are:
 
 - stable
-- tried
-- tested
-- stable(trust me, it's worth saying again.)
-- predictable
+- widely used
+- predictable to operate
+- well documented
 
-## Boring is good for business
+## Why that matters
 
-I'm pretty sure that when you solve problems via web software in your business, you are not in the business of burning through tools to build your solutions with.
+A stable stack reduces time spent evaluating replacements, migrating between trends, and re-teaching the same ideas on every project.
 
-Rapidly evolving technologies can be more of a hindrance than a help. Instead of propelling your business forward, they can become stumbling blocks, impeding progress and diverting attention from what truly matters – delivering the services that your users depend on you for.
+## For businesses
 
-In the realm of business, the reliability and steadiness of a "boring" tech stack can be a secret weapon, allowing you to stay focused on your core objectives and ensuring the sustained success of your venture.
+Stable tools reduce operational risk and make maintenance easier to plan.
 
-## Boring is good for teams
+## For teams
 
-Because your tech stack is boring, onboarding new teammates becomes easy because they can quickly get started. The technologies in the stack are stable, allowing them to hit the ground running.
+Stable tools make onboarding easier, reduce unexpected maintenance work, and make shared conventions easier to keep over time.
 
-In addition to the ease of onboarding, a "boring" tech stack often translates to reduced maintenance overhead. Stability and predictability in technology choices mean fewer surprises and less time spent troubleshooting unexpected issues.
+## The point
 
-This allows the team to focus on delivering value to users rather than constantly grappling with the latest trendy tools or dealing with the complexities of bleeding-edge technologies.
-
-Moreover, a standardized and well-established tech stack fosters collaboration and knowledge sharing within the team. Team members can easily support each other, as they share a common understanding of the tools and processes in place.
-
-This uniformity also facilitates the creation of best practices, enabling the team to optimize their workflows and maintain a cohesive and efficient development environment. In the long run, a "boring" tech stack can contribute to a more sustainable and productive team dynamic.
-
-## Solve exciting problems
-
-Want excitements? Who doesn't 😁! Don't look to your tools for that excitement, look to the problems you are solving.
-
-For example, [Lemon Squeezy](https://lemonsqueezy.com/) using a flavor of The Boring JavaScript Stack - Laravel is the web framework of choice, not Sails. They are busy solving the exciting problem of enabling creators to receive payments on the internet. I am also building [Hagfish](https://hagfish.io/) and [Sailscasts](https://sailscasts.com/) on The Boring JavaScript Stack!
-
-In fact, the more boring your stack is, the quicker you can let the tools fade into the background while you zoom in on the problems you are solving. Your tools are supposed to enable you to be awesome, not for them to be awesome in your eyes.
+The stack focuses on shipping application features with established tools rather than optimizing for novelty.

--- a/docs/clearance/index.md
+++ b/docs/clearance/index.md
@@ -17,11 +17,11 @@ hero:
 features:
   - icon: 🔒
     title: Simple Role Management
-    details: Easily define and manage roles with numeric clearance levels, from guest access to superadmin privileges.
+    details: Define roles with numeric clearance levels, from guest access to superadmin privileges.
   - icon: 🛡️
     title: Flexible Permissions
-    details: Configure route-specific access controls using wildcard patterns and clearance levels for granular permission management.
+    details: Configure route-specific access controls with wildcard patterns and clearance levels.
   - icon: ⚡
     title: Easy Integration
-    details: Seamlessly integrate with Sails.js policies and session management for robust authentication and authorization.
+    details: Integrate with Sails policies and session-based authentication.
 ---

--- a/docs/connect-sqlite/getting-started.md
+++ b/docs/connect-sqlite/getting-started.md
@@ -57,7 +57,7 @@ The parent directory will be created automatically if it doesn't exist.
 
 - **No external dependencies** - No Redis or Memcached server to manage
 - **Persistent storage** - Sessions survive server restarts
-- **Low memory footprint** - Perfect for single-instance deployments
+- **Low memory footprint** - Suitable for single-instance deployments
 - **Fast** - better-sqlite3 is one of the fastest SQLite bindings for Node.js
 
 ## Next Steps

--- a/docs/content/collections.md
+++ b/docs/content/collections.md
@@ -33,7 +33,7 @@ From the above config we are specifying that our content collections will be in 
 
 ## Content Collections
 
-Content Collections help to organize your documents and makes querying your content via [Waterline queries](/content/querying-collections) easy.
+Content Collections organize your documents and make them queryable via [Waterline queries](/content/querying-collections).
 
 ### What are Content Collections?
 

--- a/docs/content/querying-collections.md
+++ b/docs/content/querying-collections.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Querying collections
 
-Sails Content provides the `sails-content` adapter which makes querying your content collections with Waterline queries super easy.
+Sails Content provides the `sails-content` adapter so you can query content collections with Waterline queries.
 
 ## Entries from a collection
 

--- a/docs/create-sails/index.md
+++ b/docs/create-sails/index.md
@@ -2,16 +2,16 @@
 layout: home
 features:
   - title: Inertia.js
-    details: powered by inertia-sails
+    details: Generated projects include inertia-sails.
   - title: Choose your frontend
-    details: Vue, React or Svelte
+    details: Generate Vue, React, or Svelte pages.
   - title: Webpack 5
-    details: Webpack 5 takes care of your frontend assets
+    details: Webpack 5 handles the frontend asset pipeline.
 
 hero:
   name: create-sails
   text: Scaffold a modern full-stack Sails project.
-  tagline: Gain all the benefit of an SPA while maintaining a server-centric development
+  tagline: Generate a Sails app with Inertia and your choice of Vue, React, or Svelte.
   actions:
     - theme: brand
       text: Get Started

--- a/docs/create-sails/what-is-create-sails.md
+++ b/docs/create-sails/what-is-create-sails.md
@@ -5,12 +5,10 @@ editLink: true
 
 # What is create-sails?
 
-An easy way to start a modern full-stack Sails project.
+create-sails scaffolds a full-stack Sails project.
 
-## Motivation
+## What it scaffolds
 
-We all love the feeling of an SPA but the SPA/frontend JavaScript ecosytem is not without it's drawback with the vast tooling it needs.
+Use `npx create-sails <project-name>` to generate a Sails app with Inertia already configured.
 
-create-sails aims to simplify building rich SPA with Sails powering it all.
-
-With the create-sails scaffolding tool you can simplify creating SPAs with a single command `npx create-sails <project-name>` and then pick your frontend framework - Vue, React or Svelte - and you'd be on your way to creating a modern monolith with access to Sails.js routing, policies and data from Waterline you've come to love.
+The generated project includes Sails routing, policies, Waterline models, and a frontend setup for Vue, React, or Svelte.

--- a/docs/durable-ui/getting-started.md
+++ b/docs/durable-ui/getting-started.md
@@ -1,0 +1,75 @@
+---
+title: Getting Started
+description: Start using Durable UI progress drafts with Vue composables or React hooks.
+---
+
+# Getting Started
+
+Durable UI organizes client state by durability category. Start with Progress when private work should survive refreshes until the user submits.
+
+Install the package for the app you are building.
+
+::: code-group
+
+```sh [Vue]
+npm install @durable-ui/vue
+```
+
+```sh [React]
+npm install @durable-ui/react
+```
+
+:::
+
+## Use The Progress Primitives
+
+Vue APIs use composables and refs. React APIs use hooks.
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+import { useFormDraft, useWizardDraft } from '@durable-ui/vue'
+
+const draft = useFormDraft('students:details', () => form.data(), {
+  clearWhen: () => form.recentlySuccessful,
+  restore: (data) => Object.assign(form, data)
+})
+
+const wizard = useWizardDraft('students:import', {
+  details: { name: '', email: '' },
+  import: { rows: [] }
+})
+</script>
+```
+
+```jsx [React]
+import { useFormDraft, useWizardDraft } from '@durable-ui/react'
+
+const steps = {
+  details: { name: '', email: '' },
+  import: { rows: [] }
+}
+
+export function StudentImport({ form }) {
+  const draft = useFormDraft('students:details', form.data, {
+    clearWhen: form.recentlySuccessful,
+    onRestore: form.setData
+  })
+
+  const wizard = useWizardDraft('students:import', steps)
+
+  // Render restore/discard UI from draft.hasDraft.
+  // Render step UI from wizard.currentStep and wizard.steps.
+}
+```
+
+:::
+
+## Choose The Right Primitive
+
+Use [form-draft](/durable-ui/progress/form-draft) for private field values in one form.
+
+Use [wizard-draft](/durable-ui/progress/wizard-draft) for private multi-step progress, such as step number, selected method, student rows, or parsed CSV rows.
+
+If the state has already been submitted, belongs in records, or must be shared across devices, put it in the database instead.

--- a/docs/durable-ui/getting-started.md
+++ b/docs/durable-ui/getting-started.md
@@ -1,11 +1,11 @@
 ---
 title: Getting Started
-description: Start using Durable UI progress drafts with Vue composables or React hooks.
+description: Start using Durable UI progress and URL primitives with Vue composables or React hooks.
 ---
 
 # Getting Started
 
-Durable UI organizes client state by durability category. Start with Progress when private work should survive refreshes until the user submits.
+Durable UI organizes client state by durability category. Use Progress when private work should survive refreshes until the user submits. Use URL when the view itself should be shareable and bookmarkable.
 
 Install the package for the app you are building.
 
@@ -17,6 +17,36 @@ npm install @durable-ui/vue
 
 ```sh [React]
 npm install @durable-ui/react
+```
+
+:::
+
+## Use The URL Primitive
+
+Vue APIs use composables and refs. React APIs use hooks and state tuples.
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+import { useQueryState } from '@durable-ui/vue'
+
+const activeTab = useQueryState('tab', 'profile')
+const search = useQueryState('search', '', { history: 'replace' })
+</script>
+```
+
+```jsx [React]
+import { useQueryState } from '@durable-ui/react'
+
+export function SettingsPage() {
+  const [activeTab, setActiveTab] = useQueryState('tab', 'profile')
+  const [search, setSearch] = useQueryState('search', '', {
+    history: 'replace'
+  })
+
+  return null
+}
 ```
 
 :::
@@ -66,7 +96,9 @@ export function StudentImport({ form }) {
 
 :::
 
-## Choose The Right Primitive
+## Choose The Right Category
+
+Use [query-state](/durable-ui/url/query-state) for shareable tabs, filters, sorting, pagination, and modal state.
 
 Use [form-draft](/durable-ui/progress/form-draft) for private field values in one form.
 

--- a/docs/durable-ui/index.md
+++ b/docs/durable-ui/index.md
@@ -1,0 +1,36 @@
+---
+layout: home
+title: Durable UI
+titleTemplate: State placement for UI that survives real users
+description: Durable UI helps you place UI state where it belongs so interfaces survive refreshes, navigation, browser restarts, shared links, and failed submits.
+hero:
+  name: Durable UI
+  text: State placement for UI that survives real users.
+  tagline: Decide what survives refreshes, what becomes shareable, what belongs on the server, and when stale state should disappear.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /durable-ui/getting-started
+    - theme: alt
+      text: Watch the Durable UI Course
+      link: https://sailscasts.com/courses/durable-ui
+features:
+  - icon: 🧭
+    title: State placement
+    details: Decide whether state belongs in local progress, the URL, or the server.
+  - icon: 📝
+    title: Progress durability
+    details: Keep private form drafts and multi-step wizard progress alive until the user submits.
+  - icon: 🔗
+    title: URL durability
+    details: Keep shareable view state like filters, tabs, sorting, and pagination in the address bar.
+  - icon: 🧹
+    title: Cleanup contracts
+    details: Clear drafts after successful submits, expire stale progress, and avoid turning local drafts into permanent records.
+  - icon: ⚛️
+    title: Vue and React first
+    details: Vue gets composables. React gets hooks. Both follow the conventions developers expect in each ecosystem.
+  - icon: 🟨
+    title: Plain JavaScript
+    details: Durable UI ships JavaScript with JSDoc for editor hints. No TypeScript source, no build step, no generated dist.
+---

--- a/docs/durable-ui/progress.md
+++ b/docs/durable-ui/progress.md
@@ -1,0 +1,47 @@
+---
+title: Progress Durability
+description: Durable UI primitives for private work the user has not submitted yet.
+---
+
+# Progress Durability
+
+Progress durability protects work the user has already done but has not submitted yet.
+
+This is private, local progress. It should survive refreshes and browser restarts, but it is not a database record and it is not meant to be shared by URL.
+
+Progress is where real apps lose the most user trust: long forms, imports, onboarding flows, setup wizards, and any task where a refresh should not erase work.
+
+## Primitives
+
+Progress primitives solve different kinds of unfinished work:
+
+- [form-draft](/durable-ui/progress/form-draft) keeps one form's private field values alive.
+- [wizard-draft](/durable-ui/progress/wizard-draft) keeps multi-step progress alive, including the current step and per-step data.
+
+More progress primitives can live here as the category grows.
+
+## The Rule
+
+If losing the state would make the user repeat work they already did, it probably belongs in progress durability.
+
+If the state is already submitted, shared, auditable, or cross-device, it belongs on the server instead.
+
+## Good Examples
+
+Progress durability is a good fit for:
+
+- A React Hook Form draft restored with `reset()`.
+- An Inertia form draft restored with `form.setData()` or `Object.assign(form, data)`.
+- A long profile, invoice, expense, or student form that should not disappear on refresh.
+- The current step in an onboarding flow.
+- The selected import method in a student import wizard.
+- Student rows entered across multiple steps.
+- Parsed CSV rows that should survive refresh before final submit.
+
+## Do Not Use Progress Durability For
+
+- Submitted records.
+- Passwords, tokens, OTPs, card details, or secrets.
+- Raw files.
+- State that should be shared with another person.
+- State that should sync across devices.

--- a/docs/durable-ui/progress/form-draft.md
+++ b/docs/durable-ui/progress/form-draft.md
@@ -1,0 +1,94 @@
+---
+title: form-draft
+description: Persist private field values for one form with useFormDraft.
+---
+
+# form-draft
+
+`form-draft` protects private field values for one form.
+
+Use it when the fragile state is the user's unsaved form data and losing that data would make them repeat work.
+
+## Import
+
+::: code-group
+
+```vue [Vue]
+import { useFormDraft } from '@durable-ui/vue'
+```
+
+```jsx [React]
+import { useFormDraft } from '@durable-ui/react'
+```
+
+:::
+
+## Usage
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+import { useForm } from '@inertiajs/vue3'
+import { useFormDraft } from '@durable-ui/vue'
+
+const form = useForm({
+  name: '',
+  email: ''
+})
+
+const draft = useFormDraft('students:create', () => form.data(), {
+  clearWhen: () => form.recentlySuccessful,
+  restore: (data) => form.defaults(data).reset()
+})
+</script>
+```
+
+```jsx [React]
+import { useFormDraft } from '@durable-ui/react'
+
+export function StudentForm({ form }) {
+  const draft = useFormDraft('students:create', form.data, {
+    clearWhen: form.recentlySuccessful,
+    onRestore: form.setData
+  })
+
+  return null
+}
+```
+
+:::
+
+## When To Use It
+
+Use `useFormDraft` for:
+
+- One logical form.
+- Private field values.
+- Long forms where refresh should not erase work.
+- Failed submit flows where the user should not retype everything.
+
+Do not use it for submitted records, secrets, raw files, or state that should be shared by URL.
+
+## Properties
+
+`useFormDraft` returns the state needed to render restore, discard, and saved-at UI.
+
+In Vue, reactive values are returned as refs or computed refs. In React, they are returned as plain values.
+
+| Property       | Meaning                                      |
+| -------------- | -------------------------------------------- |
+| `draft`        | The saved draft envelope, or `null`.         |
+| `draftSavedAt` | A `Date` for when the draft was saved.       |
+| `hasDraft`     | Whether a restorable draft currently exists. |
+
+## Methods
+
+`useFormDraft` returns the actions needed to manage the draft.
+
+| Method        | When to call it                                                   |
+| ------------- | ----------------------------------------------------------------- |
+| `restore()`   | When the user chooses to restore the saved draft into the form.   |
+| `discard()`   | When the user chooses not to restore the saved draft.             |
+| `clear()`     | After the real submit succeeds and the server owns the data.      |
+| `save(data?)` | When you want to write a draft immediately instead of debouncing. |

--- a/docs/durable-ui/progress/wizard-draft.md
+++ b/docs/durable-ui/progress/wizard-draft.md
@@ -1,0 +1,150 @@
+---
+title: wizard-draft
+description: Persist private multi-step progress with useWizardDraft.
+---
+
+# wizard-draft
+
+`wizard-draft` protects private progress for a multi-step flow.
+
+Use it when the fragile state is bigger than one form: the current step, selected path, per-step data, parsed rows, or other workflow state the user has not submitted yet.
+
+## Import
+
+::: code-group
+
+```vue [Vue]
+import { useWizardDraft } from '@durable-ui/vue'
+```
+
+```jsx [React]
+import { useWizardDraft } from '@durable-ui/react'
+```
+
+:::
+
+## Usage
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+import { useWizardDraft } from '@durable-ui/vue'
+
+const wizard = useWizardDraft('students:import', {
+  details: { name: '', email: '' },
+  import: { rows: [] }
+})
+</script>
+```
+
+```jsx [React]
+import { useWizardDraft } from '@durable-ui/react'
+
+const steps = {
+  details: { name: '', email: '' },
+  import: { rows: [] }
+}
+
+export function StudentImport() {
+  const wizard = useWizardDraft('students:import', steps)
+
+  return null
+}
+```
+
+:::
+
+## When To Use It
+
+Use `useWizardDraft` for:
+
+- Multi-step onboarding.
+- Setup wizards.
+- Import flows.
+- Step-specific data.
+- Parsed CSV rows that should survive refresh before final submit.
+
+Do not use it for authoritative records. Once the user submits successfully, clear the draft and let the server own the submitted state.
+
+## Properties
+
+`useWizardDraft` returns state for rendering the wizard and its restore UI.
+
+In Vue, reactive values are returned as refs or computed refs. In React, they are returned as plain values.
+
+| Property         | Meaning                                                      |
+| ---------------- | ------------------------------------------------------------ |
+| `currentStep`    | The current 1-based step number.                             |
+| `currentStepKey` | The key for the current step, such as `details` or `import`. |
+| `totalSteps`     | The number of steps in the wizard.                           |
+| `stepKeys`       | The ordered step keys from the defaults object.              |
+| `steps`          | The data for each step.                                      |
+| `allData`        | All step data flattened into one object for final submit.    |
+| `canGoBack`      | Whether the wizard can move to the previous step.            |
+| `canGoNext`      | Whether the wizard can move to the next step.                |
+| `draft`          | The saved wizard draft envelope, or `null`.                  |
+| `draftSavedAt`   | A `Date` for when the wizard draft was saved.                |
+| `hasDraft`       | Whether a restorable wizard draft currently exists.          |
+| `restoredDraft`  | Whether a saved wizard draft has been restored.              |
+
+## Methods
+
+`useWizardDraft` returns navigation helpers, step-data helpers, and draft actions.
+
+| Method                    | When to call it                                                      |
+| ------------------------- | -------------------------------------------------------------------- |
+| `goBack()`                | Move to the previous step.                                           |
+| `goNext()`                | Move to the next step.                                               |
+| `goToStep(step)`          | Move to a step by number or key.                                     |
+| `updateStep(step, patch)` | Merge a patch into one step's existing data.                         |
+| `replaceStep(step, data)` | Replace one step's data entirely.                                    |
+| `restore()`               | Restore the saved wizard draft.                                      |
+| `discard()`               | Remove the saved draft without resetting the visible wizard state.   |
+| `clear()`                 | Remove the saved draft after final submit succeeds.                  |
+| `save()`                  | Write the current wizard progress immediately instead of debouncing. |
+| `reset()`                 | Return the wizard to defaults and clear the stored draft.            |
+
+## With form-draft
+
+`wizard-draft` does not always need `form-draft`.
+
+Use only `wizard-draft` when one component owns the whole flow and each step writes data into `wizard.steps` with `updateStep()` or `replaceStep()`.
+
+Pair `wizard-draft` with `form-draft` when each step owns a real form instance, such as an Inertia form or React Hook Form instance. In that setup, `wizard-draft` owns the orchestration state, while `form-draft` owns each form's private field draft.
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+const wizard = useWizardDraft('students:import', {
+  details: {},
+  import: {}
+})
+
+const detailsDraft = useFormDraft(
+  'students:import:details',
+  () => form.data(),
+  {
+    clearWhen: () => form.recentlySuccessful,
+    restore: (data) => form.defaults(data).reset()
+  }
+)
+</script>
+```
+
+```jsx [React]
+const wizard = useWizardDraft('students:import', {
+  details: {},
+  import: {}
+})
+
+const detailsDraft = useFormDraft('students:import:details', form.data, {
+  clearWhen: form.recentlySuccessful,
+  onRestore: form.setData
+})
+```
+
+:::
+
+On final successful submit, clear the wizard draft and any step-level form drafts that belong to that flow.

--- a/docs/durable-ui/url.md
+++ b/docs/durable-ui/url.md
@@ -1,0 +1,39 @@
+---
+title: URL Durability
+description: Durable UI primitives for shareable view state that belongs in the address bar.
+---
+
+# URL Durability
+
+URL durability protects view state that should be shareable, bookmarkable, and reproducible from a link.
+
+This is public navigation context, not private draft data. It belongs in the address bar because another person, another tab, or a future visit should be able to land on the same view.
+
+## Primitive
+
+- [query-state](/durable-ui/url/query-state) keeps one query parameter in sync with Vue or React state.
+
+## The Rule
+
+If the state changes what view the user is looking at, and that view should survive refreshes or shared links, it probably belongs in URL durability.
+
+If the state is private work, secrets, or unfinished form input, keep it out of the URL.
+
+## Good Examples
+
+URL durability is a good fit for:
+
+- The active settings tab.
+- A search term for a list or table.
+- Selected role, status, or date filters.
+- Sort key and sort direction.
+- The current page in pagination.
+- Shareable modal state like `?modal=invite-member`.
+
+## Do Not Use URL Durability For
+
+- Passwords, tokens, OTPs, or secrets.
+- Private form field values.
+- Parsed CSV rows or import drafts.
+- Large blobs or raw files.
+- Anything the user would not want copied into the address bar.

--- a/docs/durable-ui/url/query-state.md
+++ b/docs/durable-ui/url/query-state.md
@@ -1,0 +1,110 @@
+---
+title: query-state
+description: Keep one query parameter in sync with useQueryState.
+---
+
+# query-state
+
+`query-state` keeps one query parameter in sync with the current UI.
+
+Use it when the state belongs in the URL because the view should be shareable, bookmarkable, and restorable from a link.
+
+## Import
+
+::: code-group
+
+```vue [Vue]
+import { useQueryState } from '@durable-ui/vue'
+```
+
+```jsx [React]
+import { useQueryState } from '@durable-ui/react'
+```
+
+:::
+
+## Usage
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+import { useQueryState } from '@durable-ui/vue'
+
+const activeTab = useQueryState('tab', 'profile')
+</script>
+```
+
+```jsx [React]
+import { useQueryState } from '@durable-ui/react'
+
+export function SettingsTabs() {
+  const [activeTab, setActiveTab] = useQueryState('tab', 'profile')
+
+  return null
+}
+```
+
+:::
+
+## When To Use It
+
+Use `useQueryState` for:
+
+- Tabs.
+- Search terms.
+- Filters.
+- Sorting.
+- Pagination.
+- Shareable modal state.
+
+Do not use it for private drafts, secrets, raw files, or large structured data that should stay out of the URL.
+
+## Return Value
+
+In Vue, `useQueryState` returns a writable ref. Read the current value from `.value` and assign back to `.value` when you want to update the URL.
+
+In React, `useQueryState` returns a `[value, setValue]` tuple, following the `useState` shape developers already expect.
+
+## Options
+
+| Option    | Meaning                                                            |
+| --------- | ------------------------------------------------------------------ |
+| `history` | `'push'` creates a Back-button step. `'replace'` updates in place. |
+
+## Replace History For Typing
+
+Use `history: 'replace'` for state that changes rapidly, such as a search input.
+
+::: code-group
+
+```vue [Vue]
+<script setup>
+import { useQueryState } from '@durable-ui/vue'
+
+const search = useQueryState('search', '', { history: 'replace' })
+</script>
+```
+
+```jsx [React]
+import { useQueryState } from '@durable-ui/react'
+
+export function SearchInput() {
+  const [search, setSearch] = useQueryState('search', '', {
+    history: 'replace'
+  })
+
+  return null
+}
+```
+
+:::
+
+## Behavior
+
+`useQueryState`:
+
+- Reads the current query parameter on mount.
+- Removes the parameter when the value becomes `null`, `''`, or the default value.
+- Preserves unrelated query parameters and hash fragments.
+- Responds to Back and Forward navigation.

--- a/docs/durable-ui/what-is-durable-ui.md
+++ b/docs/durable-ui/what-is-durable-ui.md
@@ -21,9 +21,9 @@ Durable UI exists to make those state-placement decisions boring to use.
 
 Durable UI is organized by the kind of state being protected. The category tells you where that state should live, how long it should survive, and what should happen when the user returns.
 
-**Progress** is private work the user has already done but has not submitted yet. It should survive refreshes and browser restarts, but it should not become a shared URL or an authoritative database record.
+**Progress** is private work the user has already done but has not submitted yet. It should survive refreshes and browser restarts, but it should not become a shared URL or an authoritative database record. See [Progress durability](/durable-ui/progress).
 
-**URL** durability is state that should be shareable, bookmarkable, and reproducible from a link. It belongs in the address bar because another person, tab, or future visit should be able to land on the same view.
+**URL** durability is state that should be shareable, bookmarkable, and reproducible from a link. It belongs in the address bar because another person, tab, or future visit should be able to land on the same view. See [URL durability](/durable-ui/url).
 
 ## What It Is Not
 
@@ -31,7 +31,7 @@ Durable UI is organized by the kind of state being protected. The category tells
 - Durable UI is not a replacement for your server.
 - Durable UI is not permission to store everything forever.
 
-It is a small utility layer for UI state that has a real reason to survive and a clear place to live.
+It is a small utility layer for UI state that has a real reason to survive, a clear place to live, and a cleanup rule.
 
 ## Learn The Full Model
 

--- a/docs/durable-ui/what-is-durable-ui.md
+++ b/docs/durable-ui/what-is-durable-ui.md
@@ -1,0 +1,38 @@
+---
+title: What is Durable UI?
+description: The philosophy behind Durable UI and why it exists.
+---
+
+# What is Durable UI?
+
+Durable UI is state placement for interfaces that survive refreshes, navigation, and real users.
+
+It gives client-side state a clear survival contract: where the state lives, when it restores, when it becomes shareable, and when it should be cleaned up.
+
+The question is simple:
+
+> If the user refreshes, navigates away, opens another tab, or shares the link, what should this interface remember?
+
+Most durability bugs come from not answering that question. A form draft lives only in component state when it should survive a refresh. A multi-step import flow stores the visible step, but loses the parsed rows. A filtered table cannot be shared because its filters never made it into the URL.
+
+Durable UI exists to make those state-placement decisions boring to use.
+
+## Durable UI Categories
+
+Durable UI is organized by the kind of state being protected. The category tells you where that state should live, how long it should survive, and what should happen when the user returns.
+
+**Progress** is private work the user has already done but has not submitted yet. It should survive refreshes and browser restarts, but it should not become a shared URL or an authoritative database record.
+
+**URL** durability is state that should be shareable, bookmarkable, and reproducible from a link. It belongs in the address bar because another person, tab, or future visit should be able to land on the same view.
+
+## What It Is Not
+
+- Durable UI is not a state management framework.
+- Durable UI is not a replacement for your server.
+- Durable UI is not permission to store everything forever.
+
+It is a small utility layer for UI state that has a real reason to survive and a clear place to live.
+
+## Learn The Full Model
+
+The [Durable UI course](https://sailscasts.com/courses/durable-ui) walks through the philosophy, tradeoffs, and real app patterns behind these primitives.

--- a/docs/git-vibe/ai-workflows.md
+++ b/docs/git-vibe/ai-workflows.md
@@ -13,7 +13,7 @@ editLink: true
 
 # AI workflows
 
-Git Vibe is more than a wrapper around `git worktree`. It is a workflow designed for the way developers and teams now work across terminals, editors, bots, and AI agents.
+Git Vibe adds task-scoped branches, worktrees, and metadata on top of `git worktree`.
 
 ## Why AI-assisted work gets difficult in plain Git
 
@@ -34,7 +34,7 @@ When you open a vibe, Git Vibe creates a dedicated `feat/*` branch and worktree 
 - another agent can explore a documentation change
 - your `main` checkout remains clean for review, release, or urgent work
 
-This is the central idea behind Git Vibe: each task receives its own isolated workspace.
+Each task receives its own isolated workspace.
 
 ## Session memory for agents
 
@@ -56,12 +56,12 @@ git vibe diff 11
 git vibe check 11
 ```
 
-That keeps Codex Desktop and VS Code aligned with the worktree even when the shell or editor does not visibly switch in the way you expect.
+This keeps Codex Desktop and VS Code aligned with the same task-specific checkout.
 
 ## Safe parallelism
 
-The main benefit is operational as much as technical: isolated worktrees make it practical to run multiple AI-assisted tasks in parallel.
+Isolated worktrees make it practical to run multiple AI-assisted tasks in parallel.
 
 Instead of wondering whether an experiment will interfere with your current branch, you can open a separate vibe and keep the work contained.
 
-That is what makes Git Vibe useful for solo developers and teams using AI. It turns parallel AI work into a manageable Git workflow.
+This turns parallel AI work into manageable Git state.

--- a/docs/git-vibe/cli-reference.md
+++ b/docs/git-vibe/cli-reference.md
@@ -33,6 +33,8 @@ git vibe code fix-login-redirect
 
 Options:
 
+- `--solo`: force the vibe to open in the current checkout
+- `--worktree`: force the vibe to open in its own worktree
 - `--editor`: always open the workspace app after opening the vibe
 - `--no-editor`: never open the workspace app
 - `--codex`: prefer Codex Desktop for workspace opening
@@ -40,7 +42,7 @@ Options:
 - `--agent <agent>`: attach session metadata such as `codex`
 - `--task <task>`: attach a short task description
 
-Fresh vibes also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. By default that means `node_modules`, which helps a new vibe feel immediately runnable when the base checkout is already set up.
+`worktree` is the default mode. In `solo`, the command creates or switches the vibe branch in your current checkout instead. Fresh worktree-backed vibes also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. By default that means `node_modules`, which helps a new vibe feel immediately runnable when the base checkout is already set up.
 
 ### `git vibe issue <number>`
 
@@ -79,13 +81,16 @@ Options:
 - `--task <task>`: set or replace the task description
 - `--clear`: remove stored session metadata
 
-### `git vibe enter [name]`
+### `git vibe enter [--editor|--no-editor] [--codex|--vscode] [name]`
 
 Re-enter a vibe and print its context.
 
 ```sh
 git vibe enter 42
+git vibe enter --vscode 42
 ```
+
+In `worktree` mode, `enter` jumps back into the worktree path. In `solo` mode, it switches the current checkout back to the vibe branch, keeps the same path, and honors the normal editor-launch policy unless shell integration is driving it through `--shell-output`.
 
 ### `git vibe open [name]`
 
@@ -102,6 +107,8 @@ Options:
 - `--codex`: force Codex Desktop
 - `--vscode`: force VS Code
 
+In `solo` mode, `open` switches the branch first and then reopens the same checkout in the selected workspace app.
+
 ### `git vibe diff [name]`
 
 Show the vibe diff against its merge base, plus untracked files.
@@ -114,7 +121,7 @@ git vibe diff 42
 
 ### `git vibe check [name]`
 
-Show branch, path, compare target, PR state, check summary, session context, shared path plumbing, and repository settings.
+Show branch, path, backing, compare target, PR state, check summary, session context, shared path plumbing, mode, and repository settings.
 
 ```sh
 git vibe check
@@ -133,7 +140,7 @@ git vibe checks 42
 
 ### `git vibe path <name>`
 
-Print the filesystem path for a vibe worktree.
+Print the filesystem path for a vibe.
 
 ```sh
 git vibe path 42

--- a/docs/git-vibe/cli-reference.md
+++ b/docs/git-vibe/cli-reference.md
@@ -42,7 +42,7 @@ Options:
 - `--agent <agent>`: attach session metadata such as `codex`
 - `--task <task>`: attach a short task description
 
-`worktree` is the default mode. In `solo`, the command creates or switches the vibe branch in your current checkout instead. Fresh worktree-backed vibes also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. By default that means `node_modules`, which helps a new vibe feel immediately runnable when the base checkout is already set up.
+`worktree` is the default mode. In `solo`, the command creates or switches the vibe branch in your current checkout instead. Fresh worktree-backed vibes also inherit shared runtime paths from the primary checkout before any `post-create` hook runs. By default that includes `node_modules`, which lets a new vibe reuse dependencies from the base checkout.
 
 ### `git vibe issue <number>`
 

--- a/docs/git-vibe/configuration.md
+++ b/docs/git-vibe/configuration.md
@@ -23,6 +23,7 @@ This gives teams a shared repository-level source of truth while still working w
 
 ```toml
 [vibe]
+mode = "worktree"
 baseBranch = "main"
 branchPrefix = "feat/"
 worktreeRoot = "../.vibe"
@@ -43,6 +44,7 @@ pre-release = "npm test"
 
 ## Core `vibe` settings
 
+- `mode`
 - `baseBranch`
 - `branchPrefix`
 - `worktreeRoot`
@@ -67,15 +69,27 @@ git config vibe.releaseFile VERSION
 
 ## Workspace behavior
 
-`vibe.openEditor=auto|always|never` controls whether Git Vibe tries to launch a workspace app after opening a vibe.
+`vibe.mode=worktree|solo` controls whether Git Vibe opens vibes in separate worktrees or in the current checkout.
+
+- `worktree` is the built-in default and is the right choice for parallel human or AI lanes
+- `solo` is the better fit when you usually have one active branch at a time and want the editor to stay on the same checkout
+
+Examples:
+
+```sh
+git config --global vibe.mode solo
+git config vibe.mode worktree
+```
+
+`vibe.openEditor=auto|always|never` controls whether Git Vibe tries to launch a workspace app after opening a vibe. In `solo`, that applies to `git vibe code` and `git vibe enter`; in `worktree`, it applies to the vibe-opening commands while `enter` stays shell-oriented unless you explicitly force a launch.
 
 `vibe.openWorkspaceWith=auto|codex|vscode` controls which workspace app Git Vibe prefers.
 
-In `auto`, Git Vibe prefers Codex Desktop inside a Codex shell and otherwise uses VS Code when the `code` CLI is available.
+In `auto`, Git Vibe prefers Codex Desktop inside a Codex shell and otherwise uses VS Code when the `code` CLI is available. If your solo flow should usually reopen in VS Code, set `vibe.openWorkspaceWith=vscode`.
 
 ## Shared runtime paths
 
-`vibe.sharedPaths` is a comma-separated list of relative repo paths that Git Vibe should symlink from the primary checkout into a fresh vibe before `post-create` runs.
+`vibe.sharedPaths` is a comma-separated list of relative repo paths that Git Vibe should symlink from the primary checkout into a fresh worktree-backed vibe before `post-create` runs.
 
 By default, Git Vibe uses:
 
@@ -103,7 +117,7 @@ Use `none` when you want to disable automatic runtime plumbing for a repo.
 
 Hooks live under `[hooks]` and run through `sh -c`.
 
-- `post-create` runs after Git Vibe creates or attaches a fresh worktree and after shared path plumbing is linked
+- `post-create` runs after Git Vibe creates or attaches a fresh worktree-backed vibe and after shared path plumbing is linked
 - `pre-finish` runs after merge verification and before cleanup
 - `pre-release` runs after release validation and before version updates, commit creation, and tagging
 
@@ -120,6 +134,7 @@ Environment variables available to hooks:
 ## A few useful local overrides
 
 ```sh
+git config vibe.mode solo
 git config vibe.openEditor never
 git config vibe.openWorkspaceWith codex
 git config vibe.issueBranchStyle number-only

--- a/docs/git-vibe/daily-workflow.md
+++ b/docs/git-vibe/daily-workflow.md
@@ -1,7 +1,7 @@
 ---
 title: Daily workflow
 titleTemplate: Git Vibe
-description: The issue-to-PR loop that Git Vibe is designed to make natural.
+description: The issue-to-PR loop Git Vibe supports.
 prev:
   text: Getting started
   link: /git-vibe/getting-started
@@ -68,8 +68,6 @@ git vibe doctor
 git vibe doctor --repair
 ```
 
-The objective is simple: make the correct workflow easy to follow and easy to repeat.
-
 ## A full example
 
 ```sh
@@ -82,4 +80,4 @@ git vibe check
 git vibe finish --sync 42
 ```
 
-That is the full cycle: open a vibe, do the work, submit the PR, and clean up.
+This is the standard cycle: open a vibe, do the work, submit the PR, and clean up.

--- a/docs/git-vibe/daily-workflow.md
+++ b/docs/git-vibe/daily-workflow.md
@@ -13,7 +13,9 @@ editLink: true
 
 # Daily workflow
 
-Git Vibe works best when it manages the branch and worktree lifecycle for one task at a time.
+Git Vibe works best when it manages one task at a time, whether that task lives in its own worktree or in your current checkout.
+
+Use `worktree` when you want an isolated lane. Use `solo` when you want the same `feat/*` workflow but prefer to stay in one checkout.
 
 ## Start from an issue
 
@@ -21,7 +23,7 @@ Git Vibe works best when it manages the branch and worktree lifecycle for one ta
 git vibe issue 42
 ```
 
-Git Vibe reads the issue title, creates a deterministic branch, and opens the corresponding worktree.
+Git Vibe reads the issue title, creates a deterministic branch, and opens the corresponding vibe. In `worktree` mode that means a worktree. In `solo` mode that means switching the current checkout to the branch.
 
 ## Do the work inside the vibe
 
@@ -37,8 +39,8 @@ git vibe open 42
 
 - `diff` shows the cumulative change for the current vibe
 - `check` shows branch, compare target, PR, checks, and session context
-- `enter` moves your shell back into the vibe
-- `open` reopens the same vibe in Codex Desktop or VS Code
+- `enter` moves your shell back into the vibe or switches the current checkout back to that branch in `solo`; in normal interactive solo use it can also reopen the same checkout in your configured workspace app
+- `open` reopens the same vibe in Codex Desktop or VS Code and, in `solo`, keeps the editor on the same checkout after the branch switch
 
 ## Open the pull request
 

--- a/docs/git-vibe/getting-started.md
+++ b/docs/git-vibe/getting-started.md
@@ -116,7 +116,7 @@ In the default `worktree` mode, that creates:
 - shared runtime plumbing such as `node_modules` from the main checkout when it already exists
 - a context summary showing the path, compare target, and current change state
 
-That last part matters in real day-to-day work. If your base checkout already has the project ready to run, a fresh vibe should feel ready too. For Node projects, Git Vibe links `node_modules` into new vibes by default so commands like `npm run dev`, `npm test`, or framework CLIs can work without a manual fix.
+If your base checkout is already ready to run, Git Vibe links `node_modules` into new vibes by default so commands like `npm run dev`, `npm test`, or framework CLIs can work without reinstalling dependencies.
 
 If you are in `solo` mode, the same command creates or switches `feat/fix-login-redirect` in your current checkout instead. The editor usually stays aligned automatically because the path does not change.
 

--- a/docs/git-vibe/getting-started.md
+++ b/docs/git-vibe/getting-started.md
@@ -13,7 +13,7 @@ editLink: true
 
 # Getting started
 
-Git Vibe works best when you are moving quickly with AI-assisted development and still want each task to stay isolated.
+Git Vibe works best when you want one `feat/*` workflow that can handle both parallel lanes and simpler one-checkout work.
 
 ## Recommended tools
 
@@ -43,7 +43,7 @@ If you are working from a local checkout, you can also run:
 
 ## Install the skill too
 
-If you use Codex, install the Git Vibe skill alongside the CLI. The CLI creates the worktree workflow. The skill gives the agent the conventions and commands to follow inside it.
+If you use Codex, install the Git Vibe skill alongside the CLI. The CLI creates the workflow. The skill gives the agent the conventions and commands to follow inside it.
 
 ```sh
 npx skills add sailscastshq/git-vibe
@@ -77,6 +77,28 @@ source ~/.zshrc
 git vibe version
 ```
 
+## Pick the right mode
+
+Git Vibe defaults to `worktree`, which is still the best fit when you want one isolated lane per task.
+
+Use `worktree` when:
+
+- you are running multiple agents or experiments in parallel
+- you want each task in its own directory
+- you want the shell and editor to jump to a dedicated lane
+
+Use `solo` when:
+
+- you usually have one active branch at a time
+- you mostly want `git switch`, `npm run dev`, and quick UI iteration
+- you want the editor to stay on the same checkout while Git Vibe switches branches
+
+Set your personal default with:
+
+```sh
+git config --global vibe.mode solo
+```
+
 ## Open your first vibe
 
 From a clean `main` checkout:
@@ -87,7 +109,7 @@ git pull --ff-only origin main
 git vibe code fix-login-redirect
 ```
 
-That creates:
+In the default `worktree` mode, that creates:
 
 - a branch like `feat/fix-login-redirect`
 - a dedicated worktree under `../.vibe/<repo>/fix-login-redirect`
@@ -95,6 +117,8 @@ That creates:
 - a context summary showing the path, compare target, and current change state
 
 That last part matters in real day-to-day work. If your base checkout already has the project ready to run, a fresh vibe should feel ready too. For Node projects, Git Vibe links `node_modules` into new vibes by default so commands like `npm run dev`, `npm test`, or framework CLIs can work without a manual fix.
+
+If you are in `solo` mode, the same command creates or switches `feat/fix-login-redirect` in your current checkout instead. The editor usually stays aligned automatically because the path does not change.
 
 If your project needs more than that, configure `vibe.sharedPaths` in `vibe.toml` for paths like `.venv`, `.direnv`, or `vendor/bundle`.
 
@@ -105,7 +129,7 @@ git vibe issue 42
 ```
 
 ::: tip
-This is where the AI benefit becomes practical. Each vibe is isolated, so you can run one agent in one worktree, explore a second change in another, and keep `main` clean for review or release.
+This is where the AI benefit becomes practical. In `worktree` mode, each vibe is isolated, so you can run one agent in one worktree, explore a second change in another, and keep `main` clean for review or release.
 :::
 
 ## Attach AI context when you open a vibe
@@ -128,4 +152,4 @@ git vibe pr
 git vibe finish --sync 42
 ```
 
-That fetches the latest remote state, verifies the merge, removes the worktree, and returns you to a clean `main` checkout.
+That fetches the latest remote state, verifies the merge, and cleans up the vibe. In `worktree` mode it removes the worktree. In `solo` mode it switches the current checkout back to `main`.

--- a/docs/git-vibe/index.md
+++ b/docs/git-vibe/index.md
@@ -1,12 +1,12 @@
 ---
 layout: home
 title: Git Vibe
-titleTemplate: Parallel AI work with a stable main branch
-description: Git Vibe gives each task its own worktree so developers and AI agents can work in parallel while keeping main stable.
+titleTemplate: Worktree-first Git with an opt-in solo mode
+description: Git Vibe stays worktree-first for parallel human and AI work, while letting solo developers use the same `feat/*` workflow in a single checkout.
 hero:
   name: Git Vibe
-  text: Parallel AI work, clearly managed.
-  tagline: Give every task its own worktree so you can move quickly with AI, keep main releasable, and keep changes isolated.
+  text: Parallel lanes when you need them, one checkout when you do not.
+  tagline: Keep the worktree-first Git Vibe flow for parallel AI work, then switch to solo mode when you just want to stay in one checkout and keep moving.
   actions:
     - theme: brand
       text: Get Started
@@ -16,15 +16,15 @@ hero:
       link: https://github.com/sailscastshq/git-vibe
 features:
   - icon: 🤖
-    title: Isolated work per task
-    details: Each task gets its own `feat/*` branch and worktree, keeping experiments, fixes, and reviews separated.
+    title: Worktree-first by default
+    details: Each task can still get its own `feat/*` branch and worktree when you need isolated experiments, reviews, or AI lanes.
+  - icon: 🪶
+    title: Solo mode when simpler is better
+    details: If you usually have one active branch at a time, `vibe.mode=solo` keeps the same `feat/*` workflow in your current checkout.
   - icon: ✅
     title: Stable main branch
     details: Keep in-progress work off `main`, release directly from it, and always know what is ready to ship.
-  - icon: 🧭
-    title: Integrated workflow
-    details: Start from an issue, inspect context and diffs, open the pull request, and finish with cleanup built in.
   - icon: ⚡
-    title: Built for Codex and AI work
-    details: Open vibes in Codex or VS Code, attach agent and task context, and return to the exact workspace when you resume the task.
+    title: Integrated workflow
+    details: Start from an issue, inspect context and diffs, open the pull request, and finish with cleanup built in whether the vibe lives in a worktree or your current checkout.
 ---

--- a/docs/git-vibe/philosophy.md
+++ b/docs/git-vibe/philosophy.md
@@ -15,27 +15,35 @@ editLink: true
 
 Git Vibe is for solo developers and teams that want the speed of AI-assisted development without losing control of their Git workflow.
 
-Its purpose is straightforward: make parallel development structured, predictable, and easy to resume.
+Its purpose is straightforward: make development structured, predictable, and easy to resume whether you are running parallel lanes or staying in one checkout.
 
 ## `main` should remain releasable
 
 `main` should be suitable for review, release, and deployment.
 
-That only works when unfinished work, experiments, and exploratory AI output stay in separate worktrees.
+That only works when unfinished work, experiments, and exploratory AI output stay out of `main`.
 
-## One task, one worktree
+## Worktree by default, solo when simpler
 
 Creating another worktree is inexpensive. Mixing unrelated changes is not.
 
 When a single checkout contains multiple ideas, experiments, and AI-generated diffs, review becomes slower and releases become less reliable.
 
-Git Vibe addresses that by giving each task its own worktree.
+Git Vibe addresses that by making `worktree` the default mode.
+
+That is still the right answer when you want:
+
+- one isolated lane per task
+- parallel AI agents
+- multiple experiments running side by side
+
+But not every developer day looks like that. Sometimes the right answer is one branch, one checkout, and fast UI iteration. That is why Git Vibe also supports `solo` mode.
 
 ## AI agents need clear boundaries
 
 AI increases throughput, but it also increases the volume of changes that need to be understood and reviewed.
 
-Git Vibe treats agents as collaborators that need clear context, an isolated branch, and a dedicated workspace.
+Git Vibe treats agents as collaborators that need clear context, an isolated branch, and, when useful, a dedicated workspace.
 
 ## Less ceremony, more clarity
 
@@ -49,6 +57,8 @@ Git Vibe reduces that ambiguity:
 - no long-lived checkout carrying unrelated pending work
 
 Open a vibe, do the work, open the PR, and finish cleanly.
+
+That can mean a separate worktree in parallel mode, or a branch switch in the current checkout when `solo` is the better fit.
 
 ## Cleanup is part of the workflow
 

--- a/docs/git-vibe/philosophy.md
+++ b/docs/git-vibe/philosophy.md
@@ -13,9 +13,9 @@ editLink: true
 
 # Philosophy
 
-Git Vibe is for solo developers and teams that want the speed of AI-assisted development without losing control of their Git workflow.
+Git Vibe keeps Git state explicit when humans and AI agents work across editors, terminals, and worktrees.
 
-Its purpose is straightforward: make development structured, predictable, and easy to resume whether you are running parallel lanes or staying in one checkout.
+Its purpose is to open one isolated lane per task and make that lane easy to inspect, reopen, and finish.
 
 ## `main` should remain releasable
 
@@ -27,9 +27,7 @@ That only works when unfinished work, experiments, and exploratory AI output sta
 
 Creating another worktree is inexpensive. Mixing unrelated changes is not.
 
-When a single checkout contains multiple ideas, experiments, and AI-generated diffs, review becomes slower and releases become less reliable.
-
-Git Vibe addresses that by making `worktree` the default mode.
+Git Vibe uses `worktree` as the default mode so each task can stay on its own branch and checkout.
 
 That is still the right answer when you want:
 
@@ -37,19 +35,15 @@ That is still the right answer when you want:
 - parallel AI agents
 - multiple experiments running side by side
 
-But not every developer day looks like that. Sometimes the right answer is one branch, one checkout, and fast UI iteration. That is why Git Vibe also supports `solo` mode.
+Use `solo` when you want the same branch-based workflow in the current checkout.
 
 ## AI agents need clear boundaries
 
-AI increases throughput, but it also increases the volume of changes that need to be understood and reviewed.
+AI-assisted work increases the number of diffs that still need review. Git Vibe gives agents explicit context, an isolated branch, and, when useful, a dedicated workspace.
 
-Git Vibe treats agents as collaborators that need clear context, an isolated branch, and, when useful, a dedicated workspace.
+## Reduce ambiguity
 
-## Less ceremony, more clarity
-
-Many Git workflows add process when the real problem is ambiguity.
-
-Git Vibe reduces that ambiguity:
+Git Vibe reduces ambiguity by avoiding:
 
 - no `develop`
 - no stash-heavy switching
@@ -58,10 +52,6 @@ Git Vibe reduces that ambiguity:
 
 Open a vibe, do the work, open the PR, and finish cleanly.
 
-That can mean a separate worktree in parallel mode, or a branch switch in the current checkout when `solo` is the better fit.
-
 ## Cleanup is part of the workflow
 
-A good workflow should help you close work as well as start it.
-
-That is why Git Vibe includes finish, check, reopen, diff, and cleanup commands. The objective is not only speed. It is also confidence in the state of the repository.
+Git Vibe includes finish, check, reopen, diff, and cleanup commands so completed work is as explicit as in-progress work.

--- a/docs/guppy/index.md
+++ b/docs/guppy/index.md
@@ -2,15 +2,15 @@
 layout: home
 features:
   - title: Execute any Javascript code
-    details: guppy is the perfect companion for you to test out your ideas in JavaScript
+    details: Run JavaScript snippets in a scratchpad environment.
   - title: Execute code in the context of a Sails application
-    details: Quickly test out queries and ideas within the context of your Sails application
+    details: Run code with access to a Sails application's models, helpers, and configuration.
   - title: Test your Sails helperr and Waterline queries
-    details: guppy is the perfect sandbox for your Sails prototyping needs
+    details: Try helper calls and Waterline queries before adding them to the app.
 hero:
   name: guppy
-  text: The tinker tool for backend Javascript
-  tagline: This simple yet powerful desktop application allows you to run Javascript code and act as a scratchpad for trying out new ideas – all within the context of your application.
+  text: JavaScript scratchpad for backend development
+  tagline: Run JavaScript code on its own or in the context of a Sails application.
   actions:
     - theme: brand
       text: Get guppy

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
   name: The Sailscasts Docs
-  text: Ship Fullstack JavaScript Apps
-  tagline: Everything you need to build production-ready apps with Sails and The Boring JavaScript Stack.
+  text: Sailscasts Documentation
+  tagline: Documentation for Sails.js, The Boring JavaScript Stack, and related tools.
   actions:
     - theme: brand
       text: Watch a Course
@@ -17,14 +17,14 @@ hero:
 features:
   - icon: ⛵
     title: Sails.js
-    details: Master the MVC framework that makes Node.js development productive and enjoyable.
+    details: Guides and reference material for building Sails applications.
   - icon: 🥱
     title: The Boring Stack
-    details: Skip the JavaScript fatigue. Build with battle-tested tools that just work.
+    details: Server-centric full-stack guides built around Sails, Inertia, Tailwind CSS, and Vue, React, or Svelte.
   - icon: 🛠️
     title: Developer Tools
-    details: Packages and utilities designed to supercharge your fullstack workflow.
+    details: Hooks, CLI tools, and supporting packages for Sails applications.
   - icon: 🖖
     title: Open Source
-    details: Community-driven libraries you can trust, use, and contribute to.
+    details: Documentation for the open-source libraries published through Sailscasts.
 ---

--- a/docs/inertia-sails/asset-versioning.md
+++ b/docs/inertia-sails/asset-versioning.md
@@ -8,11 +8,11 @@ prev:
 
 # Asset Versioning
 
-Asset versioning ensures clients always receive fresh assets after deployments. When the version changes, Inertia triggers a full page reload to fetch updated assets.
+Asset versioning ensures clients receive updated assets after deployments. When the version changes, Inertia triggers a full page reload.
 
 ## Automatic Versioning
 
-inertia-sails automatically handles asset versioning with zero configuration:
+inertia-sails automatically handles asset versioning by default:
 
 ### With Shipwright
 
@@ -24,7 +24,7 @@ Your assets change → manifest.json updates → version hash changes → client
 
 ### Without Shipwright
 
-When Shipwright isn't available, inertia-sails uses the server startup timestamp as the version. This ensures fresh assets on each server restart.
+When Shipwright isn't available, inertia-sails uses the server startup timestamp as the version. This changes the version on each server restart.
 
 ## How It Works
 

--- a/docs/inertia-sails/responses.md
+++ b/docs/inertia-sails/responses.md
@@ -11,7 +11,7 @@ next:
 
 # Inertia Responses
 
-inertia-sails uses Sails custom responses to handle Inertia page rendering. This integrates seamlessly with Sails' actions2 pattern.
+inertia-sails uses Sails custom responses to return Inertia pages from actions.
 
 ## Basic Usage
 

--- a/docs/inertia-sails/what-is-inertia-sails.md
+++ b/docs/inertia-sails/what-is-inertia-sails.md
@@ -15,8 +15,6 @@ inertia-sails is the Sails adapter for Inertia.
 
 ## Motivation
 
-We all love the feeling of an SPA but the SPA/frontend JavaScript ecosytem is not without it's drawback with the vast tooling it needs.
+inertia-sails is the server-side adapter that lets Sails actions return Inertia pages.
 
-inertia-sails is an [Inertia.js](https://inertiajs.com) server-side adapter that aims to simplify building rich SPA with Sails.
-
-With inertia-sails you get all the benefits of a modern SPA without needing a Sails API and decoupling the fronend from your backend in separate repos or monorepo.
+It lets you use Sails routing and controllers to serve Inertia pages without building a separate API or splitting the app into separate frontend and backend repos.

--- a/docs/mail/getting-started.md
+++ b/docs/mail/getting-started.md
@@ -14,9 +14,9 @@ next:
 
 ## Introduction
 
-Mail or Sails Mail provides a sleek, elegant, and developer-friendly email API that turns sending emails into a walk in the park for your Sails applications.
+Mail is a Sails hook for sending email through configured transports such as SMTP, Resend, Mailtrap, or the log transport.
 
-Mail introduces transports for sending emails via SMTP, Resend, etc which allows you to quickly and elegantly get started sending emails through any local or cloud-based email service of your choice.
+It exposes a `send` helper and template support so actions and helpers can send transactional email through one API.
 
 ## Installation
 
@@ -33,7 +33,7 @@ $ npm install sails-hook-mail
 
 ## Usage
 
-Mail exposes a `send` [helper](https://sailsjs.com/documentation/concepts/helpers) that you can call in your Sails actions or where ever you have access to helpers in your Sails application.
+Mail exposes a `send` [helper](https://sailsjs.com/documentation/concepts/helpers) that you can call in Sails actions or anywhere else you have access to helpers.
 
 For example we can send an email verification email when a user signs up successfully via a `user/signup.js` action:
 
@@ -50,6 +50,6 @@ await sails.helpers.mail.send.with({
 })
 ```
 
-You can already see a couple of the arguments you can pass to the send helper provided by Mail.
+The send helper accepts additional options for templates, transports, sender configuration, and scheduling.
 
-Next, You can check out all the various supported transports Mail provide for you to send your emails and how to configure them
+Next, review the transport and configuration pages for the provider you want to use.

--- a/docs/mail/index.md
+++ b/docs/mail/index.md
@@ -6,7 +6,7 @@ head:
 layout: home
 hero:
   name: Mail
-  tagline: The simple elegant way to send emails from a Sails applications.
+  tagline: Send email from Sails applications.
   actions:
     - theme: brand
       text: Get Started
@@ -17,11 +17,11 @@ hero:
 features:
   - icon: 👨🏾‍💻
     title: Easy setup
-    details: Sails Mail provides an amazing and elegant API for sending emails.
+    details: Send mail through `sails.helpers.mail.send()`.
   - icon: 🚚
     title: Multiple transports
-    details: Supports SMTP, Mailtrap, log, and more transports, to allow you use your favorite email service without any stress.
+    details: Use SMTP, Mailtrap, log, Resend, and other configured transports.
   - icon: 🛠️
     title: Flexible configuration
-    details: Need multiple email transports or mailers in the same Sails project? Mail make that a breeze to do.
+    details: Configure one or more mailers in the same Sails project.
 ---

--- a/docs/pellicule/easing.md
+++ b/docs/pellicule/easing.md
@@ -9,7 +9,7 @@ next:
 
 # Easing
 
-Easing functions control the rate of change in animations. Instead of linear movement, easing creates natural-feeling motion.
+Easing functions control the rate of change in animations. Instead of constant-speed movement, easing produces non-linear motion.
 
 ## Usage
 
@@ -28,7 +28,7 @@ const scale = interpolate(frame.value, [0, 30], [0, 1], {
 | `Easing.linear`    | Constant speed           | Mechanical motion                |
 | `Easing.easeIn`    | Starts slow, accelerates | Objects falling, starting motion |
 | `Easing.easeOut`   | Starts fast, decelerates | Objects landing, stopping motion |
-| `Easing.easeInOut` | Slow start and end       | Natural movement, UI transitions |
+| `Easing.easeInOut` | Slow start and end       | Repositioning, UI transitions    |
 
 ## Visual Reference
 
@@ -57,7 +57,7 @@ const x = computed(() =>
   })
 )
 
-// Scale up with bounce feel
+// Scale up with deceleration
 const scale = computed(() =>
   interpolate(frame.value, [0, 25], [0.5, 1], {
     easing: Easing.easeOut
@@ -87,7 +87,7 @@ const x = interpolate(frame.value, [0, 30], [0, 200], {
 ### Smooth UI Motion
 
 ```js
-// easeInOut is great for elements that move and stop
+// easeInOut works well for elements that move and stop
 const x = interpolate(frame.value, [0, 60], [0, 400], {
   easing: Easing.easeInOut
 })
@@ -120,12 +120,12 @@ const opacity = Easing.easeInOut(seq.progress.value)
 | Looping/repeating  | `linear`           |
 | Attention-grabbing | `easeOut`          |
 
-### Why?
+### Typical choices
 
-- **easeOut** for entrances: Fast start grabs attention, smooth stop feels natural
-- **easeIn** for exits: Natural acceleration as element leaves
-- **easeInOut** for repositioning: Feels deliberate and polished
-- **linear** for loops: Consistent speed for continuous motion
+- **easeOut** for entrances: starts fast and slows into place
+- **easeIn** for exits: starts slow and accelerates away
+- **easeInOut** for repositioning: slows at the beginning and end
+- **linear** for loops: keeps a constant rate of motion
 
 ## Combining Easings
 

--- a/docs/pellicule/nuxt.md
+++ b/docs/pellicule/nuxt.md
@@ -63,7 +63,7 @@ globals: {
 # Start your Nuxt dev server
 npx nuxt dev
 
-# In another terminal — just works
+# In another terminal
 pellicule AppDemo
 ```
 

--- a/docs/pellicule/quasar.md
+++ b/docs/pellicule/quasar.md
@@ -42,7 +42,7 @@ globals: {
 # Start your Quasar dev server
 quasar dev
 
-# In another terminal — just works
+# In another terminal
 pellicule ProductShowcase
 ```
 

--- a/docs/pellicule/what-is-pellicule.md
+++ b/docs/pellicule/what-is-pellicule.md
@@ -13,7 +13,7 @@ Pellicule is a Vue-native engine for rendering videos programmatically. Instead 
 
 ## The Name
 
-**Pellicule** (pronounced _peh-lee-KOOL_) comes from the French word for photographic film or film stock — the physical material that captures images in traditional cinema. We chose this name because Pellicule captures your Vue components frame by frame, much like how film stock captures light.
+**Pellicule** (pronounced _peh-lee-KOOL_) comes from the French word for photographic film or film stock.
 
 ## How It Works
 
@@ -39,9 +39,9 @@ const opacity = computed(() => frame.value / 30)
 </template>
 ```
 
-The key insight is that your component is a **pure function of the frame number**. Given the same frame, you get the same pixels. Every time. This is what we mean by _deterministic rendering_.
+Your component is a **pure function of the frame number**. Given the same frame, it produces the same pixels. This is _deterministic rendering_.
 
-## Vue's Reactivity is Perfect for This
+## Why Vue fits this model
 
 When Pellicule updates the `frame` prop, Vue's reactivity system efficiently re-renders only what changed. There's no page reload between frames — just reactive updates. This is why Pellicule can render at 25+ frames per second.
 
@@ -69,12 +69,12 @@ The main difference is the ecosystem. Remotion is for React developers. Pellicul
 
 ### Why Vue?
 
-If you already know Vue, Pellicule feels natural:
+If you already know Vue, the programming model stays familiar:
 
 - **Single-file components** — Template, script, and styles in one file
 - **Reactive props** — Frame updates trigger efficient re-renders
 - **Vue ecosystem** — Use any Vue library in your videos
-- **No new concepts** — If you can build a Vue component, you can make a video
+- **No new rendering model** — If you can build a Vue component, you can make a video
 
 ## When to Use Pellicule
 
@@ -107,4 +107,4 @@ The entire pipeline is automated. You just write the component and run the CLI.
 
 Pellicule doesn't force you to use a specific build tool. It reads your project's existing config — whether that's `vite.config.js`, `rsbuild.config.js`, `config/shipwright.js`, `nuxt.config.ts`, or `quasar.config.js` — and uses the right adapter automatically. Standalone projects with no config work too, using the built-in Vite adapter.
 
-This means Pellicule lives inside your app, not beside it. Your video components sit next to your pages and app components, import from them freely, and render with the same aliases and plugins your app uses. See [Integrations](/pellicule/integrations) for details.
+This means Pellicule can use the same aliases, plugins, and component imports as the rest of your app. See [Integrations](/pellicule/integrations) for details.

--- a/docs/sails-ai/getting-started.md
+++ b/docs/sails-ai/getting-started.md
@@ -14,9 +14,9 @@ editLink: true
 
 # Getting started
 
-Sails AI is a multi-provider AI hook for Sails.js. It gives you a clean, ergonomic API to chat and stream with any LLM provider — Ollama, Cloudflare Workers AI, OpenAI, Anthropic, or your own.
+Sails AI is a multi-provider AI hook for Sails.js. It exposes `sails.ai.chat()` and `sails.ai.stream()` across configured LLM providers such as Ollama, Cloudflare Workers AI, OpenAI, Anthropic, or a custom adapter.
 
-The hook uses an **adapter pattern** (similar to Sails Pay): you install the core hook, pick an adapter for your provider, configure it, and call `sails.ai.chat()` or `sails.ai.stream()`. Swap providers by changing one line of config.
+The hook uses an **adapter pattern**: install the core hook, add an adapter for the provider you want, configure it, and call `sails.ai.chat()` or `sails.ai.stream()`.
 
 ## Install the hook
 
@@ -41,7 +41,7 @@ npm i @sails-ai/openai
 :::
 
 ::: tip
-`@sails-ai/local` connects to [Ollama](https://ollama.com), which runs open-source LLMs on your machine for free. Perfect for development.
+`@sails-ai/local` connects to [Ollama](https://ollama.com), which runs open-source LLMs on your machine. This is useful for local development.
 
 `@sails-ai/openai` works with any OpenAI-compatible provider — [Together AI](https://together.xyz), [Groq](https://groq.com), [Fireworks](https://fireworks.ai), [OpenRouter](https://openrouter.ai), [OpenAI](https://openai.com), and more. See the [OpenAI adapter docs](/sails-ai/openai) for the full list.
 :::

--- a/docs/sails-ai/index.md
+++ b/docs/sails-ai/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: Sails AI
   text: AI integration for Sails.js
-  tagline: Multi-provider AI hook with a clean adapter pattern. Chat, stream, and reason with any LLM provider.
+  tagline: Multi-provider AI hook with an adapter pattern for chat and streaming.
   actions:
     - theme: brand
       text: Get Started
@@ -14,11 +14,11 @@ hero:
 features:
   - icon: 🔌
     title: Adapter Pattern
-    details: Swap AI providers without changing application code. Use Ollama locally, Cloudflare in production, or build your own adapter.
+    details: Swap AI providers in configuration or add your own adapter.
   - icon: 🌊
     title: Streaming Built-in
-    details: First-class streaming support via async generators. Stream AI responses token-by-token to your users in real time.
+    details: Stream responses with async generators.
   - icon: 🎯
-    title: Ergonomic API
-    details: "From simple one-liners to full conversations: sails.ai.chat('Hello') or sails.ai.stream({ messages, system, model })."
+    title: Chat and stream API
+    details: "Use sails.ai.chat('Hello') or sails.ai.stream({ messages, system, model })."
 ---

--- a/docs/sails-ai/local.md
+++ b/docs/sails-ai/local.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Local
 
-`@sails-ai/local` connects sails-ai to [Ollama](https://ollama.com), which runs open-source LLMs directly on your machine. No API keys, no usage costs, no data leaving your computer — perfect for development and prototyping.
+`@sails-ai/local` connects sails-ai to [Ollama](https://ollama.com), which runs open-source LLMs directly on your machine. It does not require API keys, usage fees, or sending data to a remote provider.
 
 ## Why use the local adapter?
 

--- a/docs/sails-pay/getting-started.md
+++ b/docs/sails-pay/getting-started.md
@@ -14,11 +14,9 @@ editLink: true
 
 # Introduction
 
-Sails Pay simplifies payment integration for Sails.js developers, offering an intuitive interface to seamlessly incorporate payment processing into your applications. Say goodbye to tedious payment-related boilerplate code.
+Sails Pay provides a payment integration layer for Sails.js applications.
 
-Sails Pay handles the heavy lifting of payment management, from basic transactions to advanced features like coupons, subscription swapping, and more.
-
-With Sails Pay, you can focus on building great products while Sails Pay takes care of payment complexities.
+It covers provider adapters, transactions, coupons, and subscription-related flows through one Sails-oriented API.
 
 ## Getting started
 
@@ -62,9 +60,3 @@ Next, follow the instructions below to setup your preferred payment provider.
 - [Flutterwave](/sails-pay/flutterwave)
 - [Paystack](/sails-pay/paystack)
 - [Paga](/sails-pay/paga)
-
-## Star the repo :star:
-
-::: tip Star the Sails Pay repo on GitHub :star:
-If you like Sails Pay, show it some love with [a star on GitHub](https://github.com/sailscastshq/sails-pay).
-:::

--- a/docs/sails-pay/index.md
+++ b/docs/sails-pay/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
   name: Sails Pay
-  text: Payment made easy for Sails Developers
-  tagline: Simplifying payment integrations for your Sails.js applications.
+  text: Payments for Sails.js
+  tagline: Payment provider integration for Sails applications.
   actions:
     - theme: brand
       text: Get Started
@@ -17,11 +17,11 @@ hero:
 features:
   - icon: 💳
     title: Multiple Payment Providers
-    details: Seamlessly integrate with a variety of payment providers, including Lemon Squeezy, PayPal, Stripe, and more.
+    details: Integrate with providers such as Lemon Squeezy, PayPal, Stripe, and more.
   - icon: ⚙️
     title: Easy Configuration
-    details: Set up payment processing quickly with simple configuration options tailored for Sails.js developers.
+    details: Configure payment processing through Sails-oriented provider settings.
   - icon: 💻
     title: Developer-Friendly API
-    details: Access a well-documented and intuitive API, designed to streamline integration and customization.
+    details: Use a documented API for checkout, subscriptions, and transaction handling.
 ---

--- a/docs/sails-pay/lemonsqueezy.md
+++ b/docs/sails-pay/lemonsqueezy.md
@@ -17,17 +17,17 @@ editLink: true
 
 # Lemon Squeezy
 
-[Lemon Squeezy](https://www.lemonsqueezy.com) is an all-in-one platform designed specifically for selling digital products and software. Founded in 2020 and acquired by Stripe in 2024, Lemon Squeezy acts as your merchant of record—handling payments, merchant fees, fraud prevention, and sales tax compliance so you can focus on building your product.
+[Lemon Squeezy](https://www.lemonsqueezy.com) is a platform for selling digital products and software. It acts as the merchant of record, handling payments, merchant fees, fraud prevention, and sales tax compliance.
 
-## Why Lemon Squeezy?
+## Provider capabilities
 
-Lemon Squeezy stands out as the ideal choice for digital product creators and SaaS businesses:
+Relevant Lemon Squeezy capabilities include:
 
 - **Merchant of Record**: Lemon Squeezy handles all tax compliance, fraud prevention, and legal responsibilities
 - **Global Reach**: Accept payments from 135+ countries with zero additional setup
 - **No Monthly Fees**: Simple 5% + 50¢ per transaction pricing with no subscription costs
 - **16 Payment Methods**: Including PayPal, credit cards, and regional payment options out of the box
-- **Built for Digital**: Native support for software licenses, subscriptions, digital downloads, and courses
+- **Digital product support**: Software licenses, subscriptions, digital downloads, and courses
 - **AI Fraud Detection**: Real-time fraud prevention across signups, refunds, and transactions
 
 ## Getting Started with Lemon Squeezy

--- a/docs/sails-quest/how-it-works.md
+++ b/docs/sails-quest/how-it-works.md
@@ -11,13 +11,13 @@ next:
 
 # How Quest Works
 
-This page explains the technical architecture of Quest, our design decisions, and what we built upon to create a native job scheduling solution for Sails.js.
+This page explains Quest's architecture, design decisions, and the tradeoffs behind its process-based scheduler.
 
 ## The Core Challenge
 
 When building a job scheduler for Sails.js, we faced a fundamental challenge: How do you run scheduled code with full access to Sails models, helpers, and configurations?
 
-Most JavaScript job schedulers (like Bree) use worker threads for isolation and stability. However, worker threads run in a completely separate context - they can't access your Sails app's models or helpers. You'd need complex message passing between threads, which creates a terrible developer experience.
+Most JavaScript job schedulers (like Bree) use worker threads for isolation and stability. However, worker threads run in a separate context and cannot access your Sails app's models or helpers directly. Supporting that model would require message passing and repeated bootstrap logic.
 
 ## Our Solution: Process-Based Isolation
 
@@ -63,7 +63,7 @@ This minimal Sails lift:
 
 ## Scheduling Engine
 
-Quest combines three battle-tested libraries for maximum flexibility:
+Quest combines three libraries to support multiple scheduling styles:
 
 ### 1. Cron Expressions (cron-parser)
 
@@ -227,7 +227,7 @@ This pattern:
 
 ### Why Not Worker Threads?
 
-Worker threads seem perfect for jobs - they're isolated, efficient, and built into Node.js. But they have a fatal flaw for Sails apps:
+Worker threads seem like a good fit for jobs because they're isolated, efficient, and built into Node.js. But they have a fatal flaw for Sails apps:
 
 ```javascript
 // In a worker thread, this fails:
@@ -420,7 +420,7 @@ The codebase is modular - a main hook file that coordinates separate modules for
 
 ## Summary
 
-Quest is built on a simple insight: Sails already knows how to run scripts with `sails run`. By combining this with robust scheduling libraries and process isolation, we get a job scheduler that feels native to Sails while providing production-grade reliability.
+Quest uses `sails run` as the execution model for scheduled jobs. Combined with the scheduling libraries above and process isolation, this keeps jobs aligned with existing Sails script behavior.
 
 The architecture prioritizes:
 
@@ -429,4 +429,4 @@ The architecture prioritizes:
 3. **Flexibility** - Multiple scheduling formats for different needs
 4. **Simplicity** - No external dependencies or complex setup
 
-This design makes Quest a natural extension of Sails rather than a foreign addition.
+This keeps Quest aligned with Sails scripts instead of introducing a separate job runtime model.

--- a/docs/sails-quest/index.md
+++ b/docs/sails-quest/index.md
@@ -2,7 +2,7 @@
 layout: home
 hero:
   name: Sails Quest
-  text: Elegant Job Scheduling for Sails.js
+  text: Job Scheduling for Sails.js
   tagline: Schedule background jobs in your Sails applications with human-readable intervals, cron expressions, and full access to your app's context.
   actions:
     - theme: brand
@@ -17,14 +17,14 @@ hero:
 features:
   - icon: 🕐
     title: Flexible Scheduling
-    details: Use cron expressions, human-readable intervals like "5 minutes" or "1 hour", or schedule jobs for specific dates.
+    details: Use cron expressions, human-readable intervals like "5 minutes" or "1 hour", or specific run dates.
   - icon: 🚀
     title: Full Sails Context
-    details: Access all your models, helpers, and configuration in scheduled jobs - everything works just like in your actions.
+    details: Access models, helpers, and configuration in scheduled jobs.
   - icon: 🎯
-    title: Simple API
-    details: Just add a quest property to your existing Sails scripts. No complex setup or new patterns to learn.
+    title: Script-based API
+    details: Add a `quest` property to existing Sails scripts.
   - icon: 🔄
-    title: Smart Execution
-    details: Prevent job overlaps, run in minimal console environment, and handle errors gracefully with event emitters.
+    title: Execution Controls
+    details: Prevent overlaps, run in the console environment, and emit lifecycle events.
 ---

--- a/docs/sails-quest/introduction.md
+++ b/docs/sails-quest/introduction.md
@@ -11,11 +11,11 @@ next:
 
 # Introduction to Job Scheduling
 
-If you're coming from frontend JavaScript or even basic Node.js development, job scheduling might be a new concept. Let's explore what it is, why you need it, and how it transforms your application's capabilities.
+Job scheduling runs code automatically at specific times or intervals without a user request.
 
 ## What is Job Scheduling?
 
-Job scheduling is the practice of running code automatically at specific times or intervals, without user interaction. Think of it as setting multiple alarms for your code - each alarm triggers a specific task to run.
+Job scheduling is the practice of running code automatically at specific times or intervals without user interaction.
 
 In the simplest terms:
 
@@ -25,11 +25,11 @@ In the simplest terms:
 
 ## Why Do Applications Need Job Scheduling?
 
-As applications grow, you'll encounter tasks that shouldn't run immediately during a user request. Here's why:
+As applications grow, you'll encounter tasks that should not run during a user request.
 
 ### 1. Performance and User Experience
 
-Imagine a user uploading a video to your platform. Processing that video (transcoding, generating thumbnails, extracting metadata) might take minutes. You can't make the user wait - instead, you accept the upload and schedule the processing as a background job.
+For example, video processing can take minutes. Instead of making the user wait, accept the upload and schedule the processing as a background job.
 
 ```javascript
 // api/controllers/videos/upload.js

--- a/docs/sails-quest/job-management.md
+++ b/docs/sails-quest/job-management.md
@@ -88,7 +88,7 @@ module.exports = {
 await sails.quest.run('migrate-data', { dryRun: false })
 ```
 
-This is perfect for:
+Common uses include:
 
 - One-time administrative tasks
 - Scripts triggered by user actions

--- a/docs/sails-sqlite/deployment.md
+++ b/docs/sails-sqlite/deployment.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/sails-sqlite-social.png
 title: Deployment
 titleTemplate: Sails SQLite
-description: Sails SQLite is designed for production deployment with robust defaults and deployment-ready configurations.
+description: Production deployment guidance for Sails SQLite.
 prev:
   text: Performance optimization
   link: '/sails-sqlite/performance-optimization'
@@ -17,7 +17,7 @@ editLink: true
 
 # Deployment
 
-Sails SQLite is designed for production deployment with robust defaults and deployment-ready configurations.
+This page covers production configuration and deployment guidance for Sails SQLite.
 
 ## Production Configuration
 
@@ -290,7 +290,7 @@ async function migrate() {
 
     // Create new indexes
     await sails.sendNativeQuery(`
-      CREATE INDEX IF NOT EXISTS idx_users_phone 
+      CREATE INDEX IF NOT EXISTS idx_users_phone
       ON users(phone_number)
     `)
 
@@ -499,7 +499,7 @@ module.exports = {
 
       // Get database statistics
       const stats = await sails.sendNativeQuery(`
-        SELECT 
+        SELECT
           name,
           (SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=m.name) as table_count,
           (SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name=m.name) as index_count

--- a/docs/sails-stash/getting-started.md
+++ b/docs/sails-stash/getting-started.md
@@ -28,7 +28,7 @@ npm i sails-stash
 
 ## Zero Configuration
 
-As of **v0.1.0**, Sails Stash works out of the box with **no configuration required**. It uses an in-memory store by default, making it perfect for getting started quickly without needing to set up Redis or any other cache backend.
+As of **v0.1.0**, Sails Stash works out of the box with **no configuration required**. It uses an in-memory store by default, so you can start caching without setting up Redis or another cache backend.
 
 ```js
 await sails.cache.fetch(

--- a/docs/sails-stash/index.md
+++ b/docs/sails-stash/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
   name: Sails Stash
-  text: Caching made easy for Sails Developers
-  tagline: Sails Stash offers a unified API for cache backends to speed up your web app with fast data retrieval.
+  text: Caching for Sails applications
+  tagline: Unified cache API for memory, Redis, Memcached, and other backends.
   actions:
     - theme: brand
       text: Get Started
@@ -14,14 +14,14 @@ hero:
 features:
   - icon: 🚀
     title: Efficient Caching
-    details: Boost your application's performance by caching frequently accessed data, reducing database load and improving response times.
+    details: Cache frequently accessed data to reduce repeated database work.
   - icon: ⚡
     title: Zero Configuration
     details: Works out of the box with an in-memory store. No Redis required to get started!
   - icon: 🔄
     title: Versatile Store Support
-    details: Choose between memory (default), Redis, or Memcached as your caching store for any environment, allowing flexibility to fit your application's needs.
+    details: Choose between memory (default), Redis, or Memcached for different environments.
   - icon: 🛠️
     title: Simple Integration
-    details: Seamlessly integrate Sails Stash into your project with easy setup and straightforward usage, ensuring quick implementation.
+    details: Add caching through the `sails.cache` API.
 ---

--- a/docs/sails-stash/memory.md
+++ b/docs/sails-stash/memory.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/sails-stash-social.png
 title: Memory
 titleTemplate: Sails Stash
-description: Learn about the Memory store in Sails Stash - a zero-configuration, in-memory caching solution perfect for development and simple applications
+description: Learn about the Memory store in Sails Stash for development, tests, and single-instance applications.
 prev:
   text: Getting started
   link: '/sails-stash/getting-started'
@@ -17,7 +17,7 @@ editLink: true
 
 # Memory
 
-The Memory store is the default cache backend for Sails Stash. It provides a simple, zero-configuration solution for caching data in memory, making it perfect for development and getting started quickly.
+The Memory store is the default cache backend for Sails Stash. It provides a zero-configuration in-memory cache for development, tests, and simple single-instance applications.
 
 ## Features
 
@@ -47,7 +47,7 @@ The Memory store uses a JavaScript `Map` to store cached values in memory. Each 
 
 ## When to Use Memory Store
 
-The Memory store is ideal for:
+Use the Memory store for:
 
 - **Development environments**: Quick setup with no external dependencies
 - **Single-instance applications**: When you don't need distributed caching
@@ -65,7 +65,7 @@ Keep in mind these limitations of the Memory store:
 
 ## For Production
 
-While the Memory store works in production, consider using [Redis](/sails-stash/redis) for production environments that require:
+While the Memory store can work in production, use [Redis](/sails-stash/redis) when you need:
 
 - Persistent caching across restarts
 - Distributed caching across multiple servers

--- a/docs/sails-stash/sqlite.md
+++ b/docs/sails-stash/sqlite.md
@@ -54,11 +54,11 @@ module.exports.cachestores = {
 }
 ```
 
-That's it, your Sails app is now ready to use SQLite for caching 🥳.
+Your Sails app is now configured to use SQLite for caching.
 
 ## When to Use SQLite Store
 
-The SQLite store is ideal for:
+Use the SQLite store for:
 
 - **Single-server deployments**: When you don't need distributed caching across multiple servers
 - **Persistent caching**: Cache survives application restarts without running an external service

--- a/docs/slipway/bridge.md
+++ b/docs/slipway/bridge.md
@@ -17,9 +17,7 @@ editLink: true
 
 # Bridge
 
-Bridge is an **auto-generated data management interface** for your Sails applications. Named after the ship's bridge—the command center where the captain navigates and controls the vessel.
-
-Think of it as [Laravel Nova](https://nova.laravel.com/) or [AdminJS](https://adminjs.co/) built specifically for Sails.
+Bridge is an auto-generated data management interface for your Sails applications.
 
 ## What is Bridge?
 

--- a/docs/slipway/database-services.md
+++ b/docs/slipway/database-services.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Database Services
 
-Slipway makes it easy to provision and manage databases for your Sails applications. No more manual Docker commands or connection string juggling.
+Slipway provisions and manages databases for your Sails applications from the same platform.
 
 ## Supported Databases
 

--- a/docs/slipway/dock.md
+++ b/docs/slipway/dock.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Dock
 
-Dock is your **database command center** for production. Run SQL queries, compare schemas, apply migrations, and browse data—all without external tools or SSH access.
+Dock is Slipway's database management interface for production. Run SQL queries, compare schemas, apply migrations, and browse data without external tools or SSH access.
 
 ## What is Dock?
 
@@ -29,7 +29,7 @@ Dock provides a web-based interface for managing your PostgreSQL or MySQL databa
 - **Schema Diff** - Compare Waterline models with database schema
 - **One-Click Migrations** - Generate and apply schema changes
 
-No more switching to pgAdmin or DBeaver. Manage your production database from Slipway.
+Dock lets you manage the production database from Slipway.
 
 ## Requirements
 

--- a/docs/slipway/first-deploy.md
+++ b/docs/slipway/first-deploy.md
@@ -17,7 +17,7 @@ editLink: true
 
 # Your First Deploy
 
-Let's deploy your first Sails.js application with Slipway.
+This page walks through deploying your first Sails.js application with Slipway.
 
 ## Prerequisites
 

--- a/docs/slipway/helm.md
+++ b/docs/slipway/helm.md
@@ -17,9 +17,7 @@ editLink: true
 
 # Helm
 
-Helm is a **production REPL** for your Sails applications. Named after the ship's helm—where you steer and command the vessel.
-
-Think of it as [Tinkerwell](https://tinkerwell.app/) for Sails — a live console connected to your running app.
+Helm is a production REPL for your Sails applications.
 
 ## What is Helm?
 

--- a/docs/slipway/multi-app.md
+++ b/docs/slipway/multi-app.md
@@ -20,7 +20,7 @@ editLink: true
 By default, each Slipway environment runs a single Sails app. Multi-app environments let you run several Sails processes side by side from the same codebase — a web server and a background worker, or the same app serving different route prefixes.
 
 ::: info All Apps Are Sails Apps
-Slipway is purpose-built for [The Boring JavaScript Stack](https://docs.sailscasts.com/boring-stack/getting-started). Every app in a multi-app environment is a Sails application — they all share the same project source code and are built from the same codebase. The difference is _how_ each app is configured to run (web vs. worker, different Sails environments, different route paths).
+Every app in a multi-app environment is a Sails application. The apps share the same project source code; the main difference is how each app is configured to run (web vs. worker, different Sails environments, different route paths).
 
 This means all apps get full access to Slipway's platform features: [Helm](/slipway/helm) REPL, [Bridge](/slipway/bridge) admin, [Quest](/slipway/quest) job dashboard, [Dock](/slipway/dock) migrations, and more.
 :::
@@ -90,7 +90,7 @@ slipway logs            # shows default app logs
 slipway terminal        # opens shell in default app container
 ```
 
-For single-app environments, you never need to think about this — it just works.
+For single-app environments, the default app is used automatically.
 
 ## Route Paths
 

--- a/docs/slipway/philosophy-and-architecture.md
+++ b/docs/slipway/philosophy-and-architecture.md
@@ -218,7 +218,7 @@ Backup storage is configured via [global environment variables](/slipway/global-
 | ---------------------- | --------------------------------------------------------------------------------- |
 | **Sails.js**           | Slipway is built with Sails because it's for Sails — dogfooding the framework     |
 | **Vue 3 + Inertia.js** | Server-driven SPA — fast page transitions without a separate API layer            |
-| **SQLite**             | Zero-config database, single file backup, perfect for a self-hosted dashboard     |
+| **SQLite**             | Zero-config database, single file backup, suitable for a self-hosted dashboard    |
 | **Caddy**              | Automatic HTTPS, Docker-native routing via labels, minimal config                 |
 | **Docker**             | Universal container runtime, no vendor lock-in, works on any Linux VPS            |
 | **`node:22-slim`**     | Debian-based for glibc compatibility with native modules like `better-sqlite3`    |

--- a/docs/slipway/what-is-slipway.md
+++ b/docs/slipway/what-is-slipway.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: What is Slipway?
 titleTemplate: Slipway
-description: Slipway is an open-source, self-hostable deployment platform purpose-built for Sails.js and The Boring JavaScript Stack applications.
+description: Slipway is an open-source, self-hosted deployment platform for Sails.js and The Boring JavaScript Stack applications.
 prev:
   text: Overview
   link: /slipway/
@@ -17,11 +17,11 @@ editLink: true
 
 # What is Slipway?
 
-Slipway is an open-source, self-hostable deployment platform purpose-built for **Sails.js** and **The Boring JavaScript Stack** applications. Think Coolify meets Laravel Forge meets Nova meets Tinkerwell—but designed from the ground up to understand Sails applications deeply.
+Slipway is an open-source, self-hosted deployment platform for **Sails.js** and **The Boring JavaScript Stack** applications. It combines deployment, database management, admin access, REPL access, and Quest monitoring in one platform.
 
 ## The Goal
 
-**One platform to deploy, manage, monitor, and administrate all your Sails applications and their databases.**
+Slipway's goal is to deploy, manage, monitor, and administer Sails applications and their databases from one place.
 
 Slipway provides:
 
@@ -33,7 +33,7 @@ Slipway provides:
 
 ## The Slipway Suite
 
-Slipway isn't just a deployment tool—it's a suite of integrated tools that work together:
+Slipway includes these tools:
 
 | Component           | Equivalent To   | Description                      |
 | ------------------- | --------------- | -------------------------------- |
@@ -44,7 +44,7 @@ Slipway isn't just a deployment tool—it's a suite of integrated tools that wor
 
 ### Helm
 
-Named after the ship's **helm**—where you steer and command the vessel. Helm is a production REPL accessible from the Slipway dashboard that understands your Sails environment:
+Helm is a production REPL accessible from the Slipway dashboard that understands your Sails environment:
 
 ```javascript
 // Query models directly
@@ -62,7 +62,7 @@ sails.config.custom.stripeKey
 
 ### Bridge
 
-Named after the ship's **bridge**—the command center where the captain navigates and controls the vessel. Bridge auto-generates an admin panel from your Sails models:
+Bridge auto-generates an admin panel from your Sails models:
 
 - CRUD operations for all your models
 - Relationship management (hasMany, belongsTo)
@@ -125,9 +125,9 @@ Under the hood, Slipway uses:
 
 ## When to Use Slipway
 
-Slipway is great for:
+Use Slipway for:
 
-- **Sails.js applications** — Purpose-built for the Sails ecosystem
+- **Sails.js applications** — Sails-specific deployment, admin, and operations tooling
 - **The Boring JavaScript Stack** — Vue/React + Inertia + Sails
 - **Self-hosted deployments** — Run on your own VPS or bare metal
 - **Small to medium teams** — No Kubernetes complexity needed

--- a/docs/slipway/why-slipway.md
+++ b/docs/slipway/why-slipway.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: Why Slipway?
 titleTemplate: Slipway
-description: Learn why Slipway is the best choice for deploying Sails.js applications compared to generic deployment platforms.
+description: Why Slipway exists for deploying and operating Sails.js applications.
 prev:
   text: What is Slipway
   link: /slipway/what-is-slipway
@@ -19,11 +19,11 @@ editLink: true
 
 ## The Problem Today
 
-Developers building with Sails.js and The Boring JavaScript Stack have to cobble together multiple tools:
+Deploying and operating a Sails.js app often requires separate tools for deployment, administration, debugging, and monitoring:
 
 - **Coolify/Dokploy** for deployment (generic, not Sails-aware)
 - **AdminJS/Forest Admin** for admin panels (separate setup, not integrated)
-- **A REPL workaround** for production debugging (no elegant Tinkerwell equivalent)
+- **A REPL workaround** for production debugging (no dedicated Sails REPL equivalent)
 - **Separate job queue monitoring** (no Horizon equivalent)
 - **Multiple dashboards** for different concerns
 
@@ -37,18 +37,18 @@ Developers building with Sails.js and The Boring JavaScript Stack have to cobble
 | Laravel Horizon | Queue monitoring                 |
 | Laravel Pulse   | Application monitoring           |
 
-**Sails developers deserve the same integrated experience.**
+Slipway combines similar concerns in one platform for Sails applications.
 
 ## What Slipway Provides
 
-A **single, unified platform** that:
+Slipway provides one platform that:
 
 - Deploys Sails apps with one command
 - Manages databases (PostgreSQL, MySQL, Redis)
 - Provides a Sails-aware admin panel (like Nova)
 - Offers a production REPL (like Tinkerwell)
 - Monitors queues (Sails Quest integration)
-- All with a **slick, modern dashboard** inspired by Linear and Resend
+- Provides a web dashboard for the same operational tasks
 
 ## Learning from the Best
 
@@ -86,18 +86,18 @@ Slipway combines the best ideas from existing tools:
 | **Queue Dashboard**    | No      | No        | No          | Quest integration |
 | **Transparent Docker** | Hidden  | Hidden    | Yes         | Yes               |
 
-## What Makes Slipway Different
+## Slipway-specific behavior
 
-### 1. Sails-Native, Not Generic
+### 1. Sails-native behavior
 
-Slipway **understands** Sails applications:
+Slipway understands Sails applications:
 
 - Auto-detects `config/models.js`, `config/datastores.js`, `api/models/`
 - Knows about Sails lifecycle, hooks, and policies
 - Integrates with Sails Quest for job queues
-- Provides a REPL where `await User.find()` just works
+- Provides a REPL with direct model and helper access
 
-### 2. The Full Suite
+### 2. Integrated tooling
 
 Instead of piecing together separate tools:
 
@@ -106,7 +106,7 @@ Instead of piecing together separate tools:
 - REPL (custom scripts)
 - Queue monitor (custom dashboard)
 
-You get one integrated platform where everything works together.
+You get one platform for these tasks instead of separate products.
 
 ### 3. Lightweight
 
@@ -118,17 +118,12 @@ You get one integrated platform where everything works together.
 
 Compare to Coolify's ~800MB-1GB footprint.
 
-### 4. Beautiful Dashboard
-
-Inspired by Linear and Resend:
+### 4. Dashboard features
 
 - Dark mode first
 - Keyboard shortcuts everywhere
 - Command palette (Cmd+K)
-- Clean, modern design
 
-## The Bottom Line
+## Summary
 
-If you're building with Sails.js, Slipway is purpose-built for you. No more cobbling together generic tools. No more separate setups for admin panels, REPLs, and queue monitoring.
-
-**One platform. One command. Zero complexity.**
+Slipway groups deployment, admin access, REPL access, service management, and Quest monitoring into one Sails-focused platform.

--- a/docs/sounding/auth-and-actors.md
+++ b/docs/sounding/auth-and-actors.md
@@ -5,20 +5,13 @@ editLink: true
 
 # Auth and actors
 
-A lot of important product behavior is really about **who** is acting.
+Actors let request and browser helpers resolve auth state from a named role in the current world.
 
 In Sounding terms:
 
 - the **trial** states the behavior
 - the **world** provides the situation
 - the **actor** gives the role inside that situation
-
-That is why Sounding treats **actors** as a first-class concept.
-
-- what does a guest see?
-- what can a subscriber open?
-- what can a publisher publish?
-- what email does a reader receive?
 
 ## What an actor is
 
@@ -44,8 +37,6 @@ Then the trial can reference them clearly:
 - `current.users.publisher`
 - `current.users.unlockedReader`
 
-That is much better than carrying around anonymous test records.
-
 ## `request.as(actor)`
 
 When a request trial needs to act as an authenticated actor, use `request.as(actor)`.
@@ -62,9 +53,9 @@ test('subscriber can read the issue', async ({ sails, expect }) => {
 })
 ```
 
-This keeps authenticated request trials readable without forcing every test to hand-roll session state.
+This lets request trials act as an authenticated user without manual session setup.
 
-Sounding should detect the app's auth conventions for you:
+Sounding resolves common auth conventions such as:
 
 - `User` with `req.session.userId`
 - `Creator` with `req.session.creatorId`
@@ -91,13 +82,11 @@ test(
 )
 ```
 
-A few useful details:
+Useful details:
 
 - if you pass an actor name like `'subscriber'`, Sounding will look for it in `world.current.users`
 - if you pass an email address, Sounding will resolve or create that actor as needed
 - the default browser login path currently uses a magic-link flow under the hood
-
-That makes the browser story realistic without making every browser test repeat auth boilerplate.
 
 ## `login.withPassword(actorOrEmail, page, options)`
 
@@ -192,15 +181,13 @@ test('creator password login redirects to invoices', async ({
 })
 ```
 
-## A good pattern for actor-driven tests
+## A common pattern for actor-driven tests
 
-A good default is:
+A common flow is:
 
 1. load a world
 2. pick an actor from the world
 3. use that actor through `request.as()` or `login.as()`
-
-That gives the trial a nice product-shaped rhythm.
 
 ```js
 test('publisher can create an issue', async ({ sails, expect }) => {
@@ -229,15 +216,11 @@ Use an **explicit email** when the trial is really about the auth path itself an
 - `'reader@example.com'`
 - `'browser-reader@example.com'`
 
-That small choice keeps tests readable.
-
 ## The main rule
 
-Actors are not just there to save typing.
+Prefer actor names for named roles in a world. Use explicit emails when the test is about a specific identity.
 
-They exist so the test can talk in product language.
-
-A good Sounding auth test should read like:
+A Sounding auth test should read like:
 
 - _subscriber can open the issue_
 - _publisher can save the draft_

--- a/docs/sounding/browser-testing.md
+++ b/docs/sounding/browser-testing.md
@@ -5,9 +5,7 @@ editLink: true
 
 # Browser testing
 
-Sounding uses Playwright for browser trials, but the goal is not to make Playwright feel foreign inside a Sails app.
-
-The goal is to make browser trials feel like the natural top layer of the same testing story.
+Sounding uses Playwright for browser-capable trials.
 
 ## `test()` when the browser matters
 
@@ -38,23 +36,19 @@ test(
 )
 ```
 
-## Why worlds matter even more here
+## Load a world before browser setup
 
-Browser trials become fragile when they carry too much setup.
+Browser trials become harder to maintain when they carry too much setup. Use `sails.sounding.world.use()` to start from a named business situation.
 
-That is why `sails.sounding.world.use()` matters so much. It lets the trial start from a named business situation instead of twenty lines of scattered setup code.
+## Run the same flows across browser projects
 
-## Mobile should be first-class
-
-Sounding should treat mobile browser projects as first-class citizens, not as an afterthought.
-
-A good browser story should make it easy to run the same core flows across:
+Run the same core flows across:
 
 - desktop
 - mobile
 - dark mode when relevant
 
-## The ideal browser split
+## Choose the right layer
 
 Use browser trials for what only the browser can prove.
 
@@ -63,8 +57,6 @@ Leave lower-level behavior to:
 - `test()` with `sails.helpers`
 - `test()` with `get()` / `post()`
 - `test()` with `visit()`
-
-That keeps browser coverage high-value and resilient.
 
 ## What browser-capable trials add
 
@@ -78,7 +70,7 @@ When you opt into `{ browser: true }`, the trial context additionally gives you:
 It also makes helpers like `login.as(actorOrEmail, page)` useful in the same trial.
 It also makes helpers like `login.withPassword(actorOrEmail, page, { password })` useful when the real browser form is the behavior.
 
-## A practical split that keeps browser tests healthy
+## Typical browser cases
 
 Use browser-capable trials for:
 

--- a/docs/sounding/configuration.md
+++ b/docs/sounding/configuration.md
@@ -5,7 +5,7 @@ editLink: true
 
 # Configuration
 
-Sounding can be configured through `config/sounding.js`, but the file is optional. Most apps can ride the defaults and only add it when they need an override.
+Sounding can be configured through `config/sounding.js`, but the file is optional. Most apps can rely on the defaults and add it only when they need an override.
 
 That means there are two layers:
 
@@ -50,6 +50,8 @@ Add `config/sounding.js` only when you want to override Sounding's defaults:
 
 ```js
 module.exports.sounding = {
+  environments: ['test'],
+
   datastore: 'inherit',
 
   browser: {
@@ -58,10 +60,11 @@ module.exports.sounding = {
 }
 ```
 
-## Good defaults
+## Default values
 
-Sounding should ship with defaults that feel calm and predictable:
+Sounding defaults to:
 
+- `environments = ['test']`
 - `datastore.mode = 'managed'`
 - `datastore.identity = 'default'`
 - `datastore.adapter = 'sails-sqlite'`
@@ -73,7 +76,33 @@ Sounding should ship with defaults that feel calm and predictable:
 - `request.transport = 'virtual'`
 - `browser.projects = ['desktop']`
 
-These defaults make it easy to install Sounding and go, while still leaving room for deliberate overrides later.
+These are the starting defaults for a new Sounding setup.
+
+## `environments`
+
+The `environments` section tells Sounding which Sails environments are allowed to boot the hook.
+
+The default is:
+
+- `['test']`
+
+That means Sounding stays dark in other app boot paths like `development`, `console`, or `production` unless you opt in deliberately.
+
+Use this when you intentionally need Sounding outside the normal test lane:
+
+```js
+module.exports.sounding = {
+  environments: ['test', 'console']
+}
+```
+
+Or, if you truly want it in production-like boots:
+
+```js
+module.exports.sounding = {
+  environments: ['test', 'production']
+}
+```
 
 ## `world`
 
@@ -93,19 +122,15 @@ The `datastore` section tells Sounding how to work with your app's Sails datasto
 
 #### `inherit`
 
-This is the advanced option for apps that already have a serious test datastore story in `config/env/test.js` and want Sounding to respect it as-is.
+Use `inherit` when the app already defines its own test datastore in `config/env/test.js` and Sounding should use it as-is.
 
 #### `managed`
 
-This is the default. Sounding provisions a temporary datastore for the run before the app lifts, using `sails-sqlite` and storing files under `.tmp/db`.
-
-Use this for the normal zero-ceremony Sounding experience.
+`managed` is the default. Sounding provisions a temporary datastore before the app lifts, using `sails-sqlite` and storing files under `.tmp/db`.
 
 #### `external`
 
-Sounding validates and uses a separately managed test datastore, such as a dedicated Postgres instance.
-
-Use this when you need database-specific behavior without giving Sounding responsibility for provisioning it.
+Use `external` when a separate process manages the test datastore, such as a dedicated Postgres instance.
 
 ### `identity`
 
@@ -113,7 +138,7 @@ The datastore identity Sounding should target, usually `default`.
 
 ### `adapter`
 
-The adapter Sounding should provision when `mode` is `managed`. In `0.0.1`, the first-class choice is `sails-sqlite`.
+The adapter Sounding should provision when `mode` is `managed`. In `0.0.1`, the supported default is `sails-sqlite`.
 
 ### `isolation`
 
@@ -129,15 +154,17 @@ Where Sounding should place managed SQLite files. The default is `.tmp/db`, and 
 
 The `request` section tells Sounding how non-browser trials should talk to the app.
 
+If you want the full request client API on top of these settings, read [Request clients and transport](/sounding/request-clients).
+
 ### `transport`
 
-A calm default is:
+Default:
 
 - `virtual`
 
 That means request helpers like `get()` and `post()` are powered by `sails.request()`.
 
-This is the most Sails-native default for helper-adjacent endpoint trials, JSON API trials, and many Inertia-style trials.
+This is the default for helper-adjacent endpoint trials, JSON API trials, and many Inertia-style trials.
 
 When you need stricter parity with the live HTTP stack, Sounding should also support:
 
@@ -156,11 +183,9 @@ request: {
 }
 ```
 
-### Switching transport cleanly
+### Transport override order
 
-Sounding should let transport choice stay boring and explicit.
-
-The override order should be:
+Transport overrides are applied in this order:
 
 1. request helper call options such as `get('/health', { transport: 'http' })`
 2. trial options such as `test('...', { transport: 'http' }, async (...) => {})`
@@ -175,12 +200,6 @@ const response = await http.get('/health')
 
 That keeps one request API while still letting a trial opt into true HTTP parity when it matters.
 
-## Why this design matters
-
-The goal is not to make datastore choice irrelevant.
-
-The goal is to make datastore choice affect as little test code as possible.
-
 Most Sounding trials should still be written in terms of:
 
 - helpers
@@ -190,5 +209,3 @@ Most Sounding trials should still be written in terms of:
 - Playwright flows
 
 not raw adapter details.
-
-That is how Sounding stays elegant while still respecting real Sails infrastructure.

--- a/docs/sounding/factories.md
+++ b/docs/sounding/factories.md
@@ -1,0 +1,393 @@
+---
+title: Factories
+editLink: true
+---
+
+# Factories
+
+Factories are the primitive data layer in Sounding.
+
+If a **scenario** is a named business situation, a **factory** is the record shape that situation is built from.
+
+Factories answer questions like:
+
+- what does a default user look like?
+- what should change when that user is a publisher?
+- how do we make a default issue, subscription, or invoice?
+
+Factories are not the place to describe the whole product situation.
+They should stay narrow and reusable.
+
+If you want the composition layer above factories, read [Scenarios](/sounding/scenarios).
+
+## Where factories live
+
+By default, Sounding looks for factories under:
+
+```text
+tests/factories/
+```
+
+That default comes from the Sounding world config.
+If your app needs a different location, you can override `sounding.world.factories` in `config/sounding.js`.
+
+Sounding loads factory files recursively and understands:
+
+- `.js`
+- `.cjs`
+- `.mjs`
+
+## The simplest factory
+
+The most direct form is a single factory definition:
+
+```js
+import { defineFactory } from 'sounding'
+
+export default defineFactory('user', ({ sequence }) => ({
+  fullName: 'Test User',
+  email: sequence('user-email', (n) => `user-${n}@example.com`),
+  emailStatus: 'verified'
+}))
+```
+
+The factory name matters.
+
+If the name matches a Sails model identity like `user`, `issue`, or `subscription`, then `world.create('user')` will persist through that model.
+
+If it does not match a model identity, Sounding can still build the value, but `create()` will just return the built object.
+
+## What the definition receives
+
+When a factory definition is a function, Sounding calls it with a small helper object:
+
+- `sequence`
+- `fake`
+- `seed`
+- `sails`
+
+### `sequence()`
+
+`sequence()` is the default uniqueness tool.
+
+```js
+email: sequence('user-email', (n) => `user-${n}@example.com`)
+slug: sequence('issue-slug', (n) => `issue-${n}`)
+```
+
+If you omit the name, Sounding uses a default sequence.
+
+```js
+email: sequence((n) => `user-${n}@example.com`)
+```
+
+This is usually better than scattering `Date.now()` and `Math.random()` helpers across test files.
+
+### `fake`
+
+Sounding ships a deliberately small fake-data surface today:
+
+- `fake.person.fullName()`
+- `fake.internet.email()`
+- `fake.lorem.words(count)`
+- `fake.lorem.sentence(count)`
+
+Example:
+
+```js
+defineFactory('user', ({ fake, sequence }) => ({
+  fullName: fake.person.fullName(),
+  email: sequence('user-email', (n) => `user-${n}@example.com`)
+}))
+```
+
+The fake-data API is intentionally small. The main value comes from:
+
+- sane defaults
+- deterministic uniqueness
+- meaningful traits
+
+### `seed`
+
+Sounding's world engine also exposes a current `seed` value to factory and scenario definitions.
+
+You can set it manually:
+
+```js
+sails.sounding.world.seed('demo-a')
+```
+
+Then factory definitions can read that value through the `seed` helper.
+
+### `sails`
+
+The real Sails runtime is also available.
+
+That means a factory definition can read app helpers or configuration when it truly needs to, although most factories should stay simple and data-shaped.
+
+## Traits
+
+Traits add named variants to a factory.
+
+```js
+import { defineFactory } from 'sounding'
+
+export default defineFactory('user', ({ fake, sequence }) => ({
+  fullName: fake.person.fullName(),
+  email: sequence('user-email', (n) => `user-${n}@example.com`),
+  emailStatus: 'verified',
+  isPublisher: false
+}))
+  .trait('publisher', { isPublisher: true })
+  .trait('unverified', { emailStatus: 'unverified' })
+```
+
+A trait patch can be:
+
+- an object
+- a function
+
+### Object traits
+
+Object traits merge into the built value:
+
+```js
+.trait('publisher', { isPublisher: true })
+```
+
+### Function traits
+
+Function traits receive the current built value.
+
+```js
+.trait('published', (issue) => ({
+  ...issue,
+  status: 'published',
+  publishedAt: String(Date.now())
+}))
+```
+
+Function traits replace the current value with whatever they return.
+So if you do not merge the base record, you can accidentally wipe out required fields.
+
+Dangerous:
+
+```js
+.trait('published', () => ({
+  status: 'published'
+}))
+```
+
+Safer:
+
+```js
+.trait('published', (issue) => ({
+  ...issue,
+  status: 'published'
+}))
+```
+
+## Building vs creating
+
+Factories support two different jobs:
+
+- `build` for a value that is not persisted
+- `create` for a record that should be persisted when a matching model exists
+
+## Inside a scenario
+
+Inside a scenario, `build()` and `create()` return a thenable builder with a small fluent API:
+
+- `.trait(name)`
+- `.traits(names)`
+- `.with(overrides)`
+- `.value()`
+
+That means this works:
+
+```js
+const publisher = await create('user').trait('publisher')
+const freeIssue = await create('issue', {
+  author: publisher.id
+})
+  .trait('published')
+  .trait('free')
+```
+
+And this also works:
+
+```js
+const preview = await build('user')
+  .trait('publisher')
+  .with({ email: 'publisher@example.com' })
+```
+
+## On the top-level world engine
+
+The top-level world engine has the same concepts, but not the same fluent shape.
+
+Use:
+
+```js
+const preview = world.build(
+  'user',
+  {},
+  {
+    traits: ['publisher']
+  }
+)
+
+const publisher = await world.create(
+  'user',
+  {},
+  {
+    traits: ['publisher']
+  }
+)
+```
+
+Not:
+
+```js
+await world.create('user').trait('publisher')
+```
+
+That chaining style is for the scenario-local `build()` and `create()` helpers, not the top-level `world.build()` and `world.create()` methods.
+
+## Building or creating many records
+
+The world engine also provides:
+
+- `world.buildMany(name, count, overrides, options)`
+- `world.createMany(name, count, overrides, options)`
+
+Example:
+
+```js
+const previews = await world.buildMany('user', 3)
+const subscribers = await world.createMany(
+  'user',
+  2,
+  {},
+  {
+    traits: ['subscriber']
+  }
+)
+```
+
+## Real example
+
+Here is a practical factory set:
+
+```js
+// tests/factories/user.js
+const { defineFactory } = require('sounding')
+
+module.exports = defineFactory('user', ({ fake, sequence }) => ({
+  fullName: fake.person.fullName(),
+  email: sequence('user-email', (n) => `user-${n}@example.com`),
+  password: 'secret123',
+  tosAcceptedByIp: '127.0.0.1',
+  emailStatus: 'verified',
+  isPublisher: false
+}))
+  .trait('publisher', { isPublisher: true })
+  .trait('unverified', { emailStatus: 'unverified' })
+
+// tests/factories/issue.js
+module.exports = defineFactory('issue', ({ sequence }) => ({
+  slug: sequence('issue-slug', (n) => `issue-${n}`),
+  title: sequence('issue-title', (n) => `Issue ${n}`),
+  category: 'deep-dive',
+  excerpt: 'Preview text',
+  content: '<p>Full issue content</p>',
+  status: 'draft',
+  readingTime: 3,
+  isFree: false
+}))
+  .trait('published', (issue) => ({
+    ...issue,
+    status: 'published',
+    publishedAt: String(Date.now())
+  }))
+  .trait('free', { isFree: true, freeUntil: null })
+```
+
+Then a scenario can stay focused on the situation:
+
+```js
+const { defineScenario } = require('sounding')
+
+module.exports = defineScenario('issue-access', async ({ create }) => {
+  const publisher = await create('user').trait('publisher')
+  const subscriber = await create('user')
+  const freeIssue = await create('issue', { author: publisher.id })
+    .trait('published')
+    .trait('free')
+  const gatedIssue = await create('issue', { author: publisher.id }).trait(
+    'published'
+  )
+
+  return {
+    users: { publisher, subscriber },
+    issues: { freeIssue, gatedIssue }
+  }
+})
+```
+
+## File export shapes Sounding understands
+
+Sounding's world loader accepts a few factory export shapes.
+
+### Single definition export
+
+```js
+module.exports = defineFactory('user', ({ sequence }) => ({
+  email: sequence((n) => `user-${n}@example.com`)
+}))
+```
+
+### Function export using the loader API
+
+```js
+module.exports = ({ factory }) =>
+  factory('user', ({ sequence }) => ({
+    email: sequence((n) => `user-${n}@example.com`)
+  }))
+```
+
+### Multiple definitions in one file
+
+```js
+module.exports = {
+  factories: [
+    defineFactory('user', ({ sequence }) => ({
+      email: sequence((n) => `user-${n}@example.com`)
+    })),
+    defineFactory('issue', ({ sequence }) => ({
+      slug: sequence((n) => `issue-${n}`)
+    }))
+  ]
+}
+```
+
+## Practical guidance
+
+A good factory:
+
+- models one record shape well
+- uses `sequence()` for deterministic uniqueness
+- uses traits for meaningful variants
+- stays small enough to inspect
+
+A bad factory:
+
+- tries to describe the whole business situation
+- hard-codes too many unrelated relationships
+- duplicates scenario-level meaning
+- becomes a dumping ground for random setup
+
+The simplest rule is:
+
+If setup is repeating across files, add a factory.
+If the setup is describing a business situation, add or reuse a scenario.

--- a/docs/sounding/getting-started.md
+++ b/docs/sounding/getting-started.md
@@ -5,7 +5,7 @@ editLink: true
 
 # Getting started
 
-Sounding is designed to feel natural in a Sails app from the first install.
+Install Sounding, keep your Sails test environment in `config/env/test.js`, and add `config/sounding.js` only when you need overrides.
 
 ## 1. Install Sounding
 
@@ -16,7 +16,7 @@ npm install -D sounding @playwright/test sails-sqlite
 ### Install the Sounding skill for AI agents
 
 If you use Codex, Claude Code, Cursor, or another coding agent, install the Sounding skill too.
-That gives the agent first-class guidance for worlds, actors, transports, mailbox assertions,
+That gives the agent guidance for worlds, actors, transports, mailbox assertions,
 browser trials, and Sounding's auth helpers.
 
 ```bash
@@ -29,7 +29,7 @@ Sounding does not replace Sails test config.
 
 Your app still defines its test environment in `config/env/test.js`, and Sounding builds on top of that.
 
-A strong default is to let Sounding manage the datastore and keep `config/env/test.js` focused on app behavior.
+One common setup is to let Sounding manage the datastore and keep `config/env/test.js` focused on app behavior.
 
 ```js
 // config/env/test.js
@@ -56,12 +56,14 @@ If your app already has a good test datastore strategy, Sounding can still respe
 
 ```js
 module.exports.sounding = {
+  environments: ['test'],
   datastore: 'inherit'
 }
 ```
 
 Most apps can skip this file entirely. Sounding already defaults to:
 
+- `environments = ['test']`
 - `datastore.mode = 'managed'`
 - `datastore.identity = 'default'`
 - `datastore.adapter = 'sails-sqlite'`
@@ -71,7 +73,15 @@ Most apps can skip this file entirely. Sounding already defaults to:
 - `request.transport = 'virtual'`
 - browser projects start with `desktop`
 
-Only add `config/sounding.js` when your app needs a real override, such as `datastore: 'inherit'`, `datastore: 'external'`, or custom browser behavior.
+Only add `config/sounding.js` when your app needs a real override, such as `datastore: 'inherit'`, `datastore: 'external'`, custom browser behavior, or widening Sounding beyond the default test-only environment.
+
+If you intentionally need Sounding in another boot path, widen the allowlist explicitly:
+
+```js
+module.exports.sounding = {
+  environments: ['test', 'console']
+}
+```
 
 ## 4. Write your first trial
 
@@ -128,9 +138,7 @@ test(
 
 ## 6.1 Define your first world
 
-Before a suite gets interesting, give it a named business situation to stand on.
-
-A good first world is usually one of:
+Define a named world for repeatable setup. Common starting points are:
 
 - a signed-out guest
 - a subscriber with active access
@@ -171,7 +179,7 @@ test('subscriber can read the issue', async ({ sails, expect }) => {
 })
 ```
 
-This is the point of worlds: the test stops reading like setup and starts reading like behavior.
+Use worlds when several trials need the same business state.
 
 ## 7. Run the suite
 
@@ -188,5 +196,3 @@ Once the basic runtime is in place, most apps will want to add:
 - a few named actors like `guest`, `subscriber`, and `publisher`
 - at least one endpoint, Inertia, and browser trial for a mission-critical flow
 - a mobile browser project once the core journeys are stable
-
-Sounding works best when your tests read like your product.

--- a/docs/sounding/how-it-works.md
+++ b/docs/sounding/how-it-works.md
@@ -5,23 +5,21 @@ editLink: true
 
 # How Sounding works
 
-Before we talk about the runtime, it helps to define Sounding's core word:
+A **trial** is one named behavior check in a real Sails runtime.
 
-A **trial** is one named behavior check proving something true about your app in a real Sails runtime.
-
-Sounding keeps the familiar `test()` API, but it uses **trial** as the conceptual word because the framework is built around product behaviors, worlds, actors, and the conditions a system must safely pass before you ship.
+Sounding keeps the standard `test()` API. The docs use **trial** as the term for one test case.
 
 If you want the full concept model, read [Trials](/sounding/trials).
 
-Sounding is built around a simple idea:
-
-**Boot a real Sails app, create a deterministic world for the current trial, then give the test the right tools for the layer it is exercising.**
+Sounding works by booting a real Sails app, creating deterministic setup for the current trial, and exposing the helpers that match the layer under test.
 
 ## The runtime in five steps
 
 ### 1. Sounding boots your app
 
 When a trial starts, Sounding boots your Sails app in test mode and exposes its public testing runtime on `sails.sounding`.
+
+The hook is intentionally conservative about when it activates. By default, Sounding only boots when `sounding.environments` includes the current Sails environment, and the default list is `['test']`.
 
 That runtime is where the rest of the system hangs together:
 
@@ -33,22 +31,19 @@ That runtime is where the rest of the system hangs together:
 
 ### 2. Sounding resolves a datastore strategy
 
-Sounding should respect normal Sails test configuration before it does anything clever.
+Sounding supports three datastore modes:
 
-By default, Sounding manages a temporary `sails-sqlite` datastore for the run or the worker and stores those files under `.tmp/db`.
+- `managed` provisions a temporary `sails-sqlite` datastore under `.tmp/db`
+- `inherit` uses the app's existing test datastore config
+- `external` validates and uses a separately managed test datastore
 
-That gives us a clean, Sails-native story:
-
-- managed by default for zero-ceremony installation
-- inherit when the app already has a solid test setup it needs to preserve
-- external when a team wants to bring its own dedicated test datastore
-- keep tests written against helpers, Waterline, requests, and browser flows either way
+Tests keep the same helper, request, and browser APIs regardless of the selected mode.
 
 ### 3. Sounding loads a world
 
-This is where Sounding should feel different from a generic test runner.
+Sounding loads a named world from `tests/factories` and `tests/scenarios`.
 
-It does not just create rows. It loads a named business situation from `tests/factories` and `tests/scenarios`.
+If you want those layers in detail, read [Factories](/sounding/factories), [Scenarios](/sounding/scenarios), and [Worlds](/sounding/worlds).
 
 That means:
 
@@ -64,22 +59,20 @@ A world includes:
 - the relationships between them
 - the current business situation the trial cares about
 
-A good world gives the trial readable handles like `current.users.subscriber` and `current.issues.gatedIssue`, not vague keys like `user1` or `record2`. It should feel like a product situation, not a fixture dump.
+Use readable handles like `current.users.subscriber` and `current.issues.gatedIssue`, not vague keys like `user1` or `record2`.
 
 ### 4. Sounding furnishes the right test surface
 
-Every trial starts from the same calm context.
+Each trial receives the real Sails runtime plus the helpers that match the layer under test.
 
-One important part of that surface is transport.
-
-Sounding should keep one request story in user land while choosing the right transport underneath:
+One part of that surface is transport:
 
 - virtual requests through `sails.request()` when we want fast, app-aware trials
 - real HTTP requests when parity with the live HTTP stack matters more
 
-That gives us one stable API without pretending every kind of request behaves the same way.
+If you want the full request and visit surface, read [Request clients and transport](/sounding/request-clients).
 
-The transport choice should resolve calmly in this order:
+Transport selection resolves in this order:
 
 1. a per-call override like `get('/health', { transport: 'http' })`
 2. a per-trial override like `test('...', { transport: 'http' }, ...)`
@@ -94,22 +87,20 @@ From there, the furnished context stays simple:
 - `sails.sounding` exposes worlds, mailbox capture, and request orchestration
 - top-level aliases like `get()`, `post()`, and `visit()` exist for the most common flows
 - `visit()` understands Inertia-specific request headers like partial reloads without introducing a second testing API
-- browser-capable trials can additionally destructure `page` when the browser really matters
+- browser-capable trials can additionally destructure `page`
 
 ### 5. Sounding reports what mattered
 
-When a trial fails, the output should help you understand the failure quickly:
+When a trial fails, the output should identify:
 
 - which world was loaded
 - which actor was in play
 - which request or browser step failed
 - which part of app state was relevant
 
-## Why the hook matters
+## As a hook, Sounding can access
 
-Because Sounding is a Sails hook, it can speak the native language of a Sails app without asking you to bolt on a second mental model.
-
-It can understand and expose:
+As a Sails hook, Sounding can understand and expose:
 
 - helpers
 - actions
@@ -121,16 +112,12 @@ It can understand and expose:
 - mail
 - jobs and realtime over time
 
-That is the difference between tests that merely run and a testing story that actually feels at home in Sails.
-
 ## What a trial context means
 
 A **trial** is the behavior being proved.
 A **trial context** is the single object Sounding passes into `test()` so a behavior can be proved inside a real app runtime.
 
-It is the environment the current trial lives inside.
-
-That context should feel calm and familiar:
+It is the environment the current trial runs inside:
 
 - `sails` is the real app runtime
 - `sails.helpers`, `sails.models`, `sails.config`, and `sails.hooks` stay canonical
@@ -138,17 +125,14 @@ That context should feel calm and familiar:
 - top-level aliases like `get()`, `post()`, and `visit()` exist only as ergonomic shortcuts
 - `expect` is always available for assertions
 
-So when we say “trial context,” we do **not** mean a second fake app abstraction.
-We mean: **the real Sails runtime, plus a small set of testing capabilities shaped around it.**
+When the docs say “trial context,” they mean the real Sails runtime plus a small set of testing helpers.
 
-## The design patterns behind Sounding
+## Core conventions
 
-Sounding should stay grounded in a few simple patterns:
+Sounding is built around a few simple conventions:
 
 - `sails` is the real runtime object in every trial
 - `sails.sounding` is where Sounding-specific capabilities live
 - top-level aliases like `get()` and `post()` are conveniences, not a separate system
 - worlds describe business situations, not random fixtures
-- calm defaults come first; heavier tools should only appear when a trial really needs them
-
-That is how Sounding stays elegant instead of turning into a bag of special cases.
+- heavier tools should only appear when a trial really needs them

--- a/docs/sounding/index.md
+++ b/docs/sounding/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
   name: Sounding
-  text: Elegant testing for Sails.js
-  tagline: Test helpers, endpoints, JSON APIs, Inertia pages, mail, and browser flows with one Sails-native runtime.
+  text: Testing for Sails.js
+  tagline: Test helpers, endpoints, JSON APIs, Inertia pages, mail, and browser flows in one Sails-native runtime.
   image:
     src: /sounding-logo.png
     alt: Sounding
@@ -16,15 +16,15 @@ hero:
       link: https://github.com/sailscastshq/sounding
 features:
   - icon: ⚓
-    title: Hook-first by design
-    details: Reach for sails.sounding everywhere. Add config/sounding.js only when your app needs a real override.
+    title: Sails hook runtime
+    details: Access Sounding through sails.sounding and add config/sounding.js only when you need overrides.
   - icon: 🌊
-    title: Worlds, not fixture soup
-    details: Define factories and scenarios under tests/ and load a world that reads like your business domain instead of a pile of setup code.
+    title: Factories, scenarios, and worlds
+    details: Define factories and scenarios under tests/ and load named worlds for repeatable trial setup.
   - icon: 🧪
-    title: One home for every trial
-    details: Use test() everywhere, then destructure sails, get, post, visit, page, and expect from one calm trial context.
+    title: Unified trial context
+    details: Use test() for helpers, requests, Inertia responses, mail, and browser-capable trials.
   - icon: 🛟
-    title: Good defaults, not magic
-    details: Manage a temporary sails-sqlite datastore under .tmp/db by default, and opt into inherit only when your app genuinely needs it.
+    title: Default test setup
+    details: Managed sails-sqlite, mail capture, virtual requests, and a desktop browser project are enabled by default.
 ---

--- a/docs/sounding/mail-testing.md
+++ b/docs/sounding/mail-testing.md
@@ -5,11 +5,9 @@ editLink: true
 
 # Mail testing
 
-Sounding makes outgoing mail easy to test without forcing developers to parse logs or invent their own fake inbox.
+Sounding captures outgoing mail during a trial by wrapping `sails.helpers.mail.send`, rendering a preview when a template is used, and storing the normalized result in `sails.sounding.mailbox`.
 
-Because Sails already has a strong mail story, Sounding leans into it. When a trial boots, Sounding wraps `sails.helpers.mail.send`, captures the real outgoing inputs flowing through `sails-hook-mail`, renders a preview when a template is used, and stores the normalized result in `sails.sounding.mailbox`.
-
-That means the mail story stays simple:
+That means:
 
 - your app still uses `sails.helpers.mail.send`
 - Sounding captures what was actually sent during the trial
@@ -51,9 +49,9 @@ And each captured message is normalized enough to assert on comfortably:
 - `status` for sent vs failed deliveries
 - `error` details when delivery fails
 
-## Why this matters
+## Common mail cases
 
-A lot of important product behavior lives in mail:
+Mail assertions are useful for:
 
 - magic links
 - password resets
@@ -61,16 +59,10 @@ A lot of important product behavior lives in mail:
 - billing notifications
 - team access flows
 
-If mail is painful to test, teams either skip it or test it too late.
+## Mail and auth helpers
 
-Sounding should make mail trials feel as natural as endpoint trials.
-
-## Mail and auth work well together
-
-A lot of the nicest early Sounding mail tests involve auth flows:
+Mail tests often use auth helpers such as:
 
 - `auth.requestMagicLink()`
 - `auth.issueMagicLink()`
 - `login.as(actorOrEmail, page)` for the browser-capable follow-through
-
-That combination is what makes passwordless and invitation flows feel first-class instead of bolted on.

--- a/docs/sounding/organizing-your-suite.md
+++ b/docs/sounding/organizing-your-suite.md
@@ -5,13 +5,9 @@ editLink: true
 
 # Organizing your suite
 
-A testing framework should not force an awkward file structure on your app.
+Organize the suite so the relationship between **trials**, **features**, and **layers** is easy to see.
 
-Sounding works best when your suite makes the relationship between **trials**, **features**, and **layers** easy to see.
-
-Your test tree should look like the product and the testing layers, not like the framework itself.
-
-That is why the recommended structure is intentionally boring.
+The test tree should follow the product and the testing layers, not the framework name.
 
 ## A strong default structure
 
@@ -40,13 +36,7 @@ This gives you three useful separations:
 
 ## Why not `tests/sounding/`
 
-Sounding should power the suite, not distort the suite.
-
-A folder like `tests/sounding/` makes the framework more visible than the product.
-
-That is usually a smell.
-
-The framework should disappear into the way the tests read.
+A folder like `tests/sounding/` makes the framework more visible than the product. Prefer grouping by layer and feature instead.
 
 ## Unit tests
 
@@ -83,7 +73,7 @@ tests/e2e/pages/
     editor.test.js
 ```
 
-This layout works well because related behaviors stay together while the fast non-browser lane stays separate from true browser journeys.
+This layout keeps related behaviors together while separating non-browser checks from browser journeys.
 
 ## Split by behavior, not by tool
 
@@ -91,7 +81,7 @@ A good file should answer this question clearly:
 
 **What family of trials lives here?**
 
-That is why names like `reader-access.test.js` and `magic-link-browser.test.js` are stronger than vague names like `issues.test.js` when the feature has multiple distinct behaviors.
+Names like `reader-access.test.js` and `magic-link-browser.test.js` are clearer than vague names like `issues.test.js` when the feature has multiple distinct behaviors.
 
 Inside a feature folder, split files by **behavior** and **runtime value**, not by arbitrary naming.
 
@@ -102,11 +92,13 @@ For example:
 - `contracts.test.js` for request or Inertia-level issue contracts
 - `reader-access.test.js` for browser-capable reading flows
 
-That keeps the suite fast, legible, and easy to maintain.
+This keeps the suite fast, legible, and easy to maintain.
 
 ## Factories belong under `tests/factories`
 
 Factories should live under `tests/factories` because they are test vocabulary, not app runtime code.
+
+If you want the full factory API and loading behavior, read [Factories](/sounding/factories).
 
 A practical layout might look like:
 
@@ -117,7 +109,7 @@ tests/factories/
   subscription.js
 ```
 
-Each factory should model one record shape well and stay boring.
+Each factory should model one record shape well.
 
 ## Scenarios belong under `tests/scenarios`
 
@@ -128,9 +120,16 @@ tests/scenarios/
   issue-access.js
   publisher-editor.js
   magic-link-signin.js
+tests/world-helpers/
+    create-user-with-team.js
 ```
 
 A good scenario name should tell you the situation before you open the file.
+
+If a helper exists only to keep a scenario readable, keep it near the scenarios.
+Use a named folder such as `tests/world-helpers/` instead of a vague `tests/support/` folder.
+
+If you want the full scenario API and loading behavior, read [Scenarios](/sounding/scenarios).
 
 ## A useful rule of thumb
 
@@ -142,9 +141,11 @@ If a trial just needs one more field value, prefer:
 - a small override
 - a helper inside the scenario
 
+If that helper grows into product-state setup, keep it in a named nearby folder like `tests/world-helpers/`, not inside the auto-loaded `tests/scenarios/` tree.
+
 Do not create a new scenario for every tiny variation.
 
-## Keep the feature folders calm
+## Keep feature folders focused
 
 A few practical rules help a lot:
 
@@ -154,9 +155,9 @@ A few practical rules help a lot:
 - group by feature before grouping by runtime detail
 - do not let one giant file become the whole feature
 
-## A real-app shape that works well
+## Example layout
 
-This is the kind of layout Sounding is designed to support in a real app:
+This is a layout that works well in a real app:
 
 ```text
 tests/
@@ -187,15 +188,15 @@ tests/
       blog.test.js
       contact.test.js
       story.test.js
+  world-helpers/
+    create-user-with-team.js
   scenarios/
     issue-access.js
     publisher-editor.js
 ```
 
-That structure is simple, scalable, and easy to onboard someone into.
+This structure is simple and scalable.
 
-## The main idea
+## Summary
 
-A Sounding suite should look like a well-organized product codebase that happens to use Sounding.
-
-Not like a product codebase that has been bent around the framework.
+A Sounding suite should look like a well-organized product codebase that uses Sounding.

--- a/docs/sounding/request-clients.md
+++ b/docs/sounding/request-clients.md
@@ -1,0 +1,249 @@
+---
+title: Request Clients and Transport
+editLink: true
+---
+
+# Request clients and transport
+
+Sounding provides two closely related clients:
+
+- `request` for endpoint and session-aware request behavior
+- `visit` for Inertia-aware page contracts on top of that same request engine
+
+Underneath those clients, Sounding can run over two transports:
+
+- `virtual`
+- `http`
+
+## The request client
+
+The request client is the fuller non-browser request surface in Sounding.
+
+Every trial gets it as:
+
+```js
+test('guest is redirected from dashboard', async ({ request, expect }) => {
+  const response = await request.get('/dashboard')
+
+  expect(response).toRedirectTo('/login')
+})
+```
+
+The top-level aliases like `get()` and `post()` are convenience methods bound from the same client.
+
+## Request client methods
+
+The request client exposes:
+
+- `request(method, target, options?)`
+- `get(target, options?)`
+- `head(target, options?)`
+- `post(target, payload, options?)`
+- `put(target, payload, options?)`
+- `patch(target, payload, options?)`
+- `delete(target, payload, options?)`
+- `withHeaders(headers)`
+- `withSession(session)`
+- `using(transport)`
+- `as(actor)`
+
+## `withHeaders()`
+
+`withHeaders()` returns a new scoped client with default headers applied.
+
+```js
+const api = request.withHeaders({
+  accept: 'application/json'
+})
+```
+
+This does not mutate the original client.
+
+## `withSession()`
+
+`withSession()` returns a new scoped client with default session values applied.
+
+```js
+const verified = request.withSession({
+  creatorEmail: 'creator@example.com'
+})
+```
+
+This is especially useful in virtual request trials where session state is part of the behavior under test.
+
+Like `withHeaders()`, it returns a new scoped client instead of mutating the original one.
+
+## `using()`
+
+`using()` returns a new scoped client pinned to a transport.
+
+```js
+const http = request.using('http')
+const response = await http.get('/health')
+```
+
+This is how a single trial can keep most requests fast and virtual while opting one branch into real HTTP parity.
+
+## `as()`
+
+`as(actor)` scopes the client through a world actor.
+
+```js
+const response = await request.as(current.users.publisher).get('/dashboard')
+```
+
+Sounding looks for actor data in this order:
+
+- `actor.headers` or `actor.sounding.headers`
+- `actor.session` or `actor.sounding.session`
+- otherwise it derives a session from the actor identity
+
+When it derives a session automatically, it uses:
+
+- the configured auth session key with `actor.id`
+- `teamId` from `actor.team` or `actor.teamId` when present
+
+This lets `request.as(actor)` follow the app's auth conventions without manual session setup.
+
+## The visit client
+
+`visit()` is the Inertia-aware layer built on top of the same request engine.
+
+Use it when the contract is an Inertia page:
+
+```js
+test('pricing page returns the expected Inertia component', async ({
+  visit,
+  expect
+}) => {
+  const page = await visit('/pricing')
+
+  expect(page).toBeInertiaPage('billing/pricing')
+})
+```
+
+The visit client exposes:
+
+- `visit(target, options?)`
+- `visit.get(target, options?)`
+- `visit.head(target, options?)`
+- `visit.post(target, payload, options?)`
+- `visit.put(target, payload, options?)`
+- `visit.patch(target, payload, options?)`
+- `visit.delete(target, payload, options?)`
+- `visit.del(target, payload, options?)`
+- `visit.using(transport)`
+
+`visit.transport` also reflects the current transport.
+
+## What `visit()` adds
+
+`visit()` automatically adds the default Inertia headers:
+
+- `x-inertia: true`
+- `x-requested-with: XMLHttpRequest`
+- `accept: text/html, application/xhtml+xml`
+
+It also understands these Inertia-specific options:
+
+- `component`
+- `only`
+- `except`
+- `reset`
+- `errorBag`
+- `version`
+
+Example:
+
+```js
+const page = await visit('/dashboard', {
+  component: 'dashboard/index',
+  only: ['notifications'],
+  reset: ['sidebar'],
+  errorBag: 'profile'
+})
+```
+
+That becomes the same partial-reload headers an Inertia client would send.
+
+Important:
+
+- `component` is required when using `only`
+- `component` is required when using `except`
+
+## The two transports
+
+### `virtual`
+
+`virtual` is Sounding's default request transport.
+
+It routes directly through the Sails app instead of going over the network.
+
+Use it for:
+
+- fast endpoint trials
+- helper-adjacent request behavior
+- session-aware auth flows
+- most Inertia contract tests
+
+Under the hood, Sounding routes these requests through the Sails router and passes along:
+
+- headers
+- a session object
+- flash support
+
+Use `http` when the test needs full network-stack parity.
+
+### `http`
+
+`http` sends real network requests with `fetch()`.
+
+Use it when the test needs parity with the live HTTP stack, such as:
+
+- cookie or CSRF behavior
+- proxy-sensitive behavior
+- true base URL behavior
+- cases where the exact HTTP layer is the thing being proved
+
+Sounding resolves a base URL in this order:
+
+- `request.baseUrl`
+- `browser.baseUrl`
+- the lifted Sails server address
+- `sails.config.port`
+
+You can also pass an absolute URL or `baseUrl` per call.
+
+## Choosing a transport
+
+Transport selection happens in this order:
+
+1. per-call override such as `get('/health', { transport: 'http' })`
+2. a scoped client from `request.using('http')` or `visit.using('http')`
+3. a trial-level option like `{ transport: 'http' }`
+4. Sounding's configured default
+
+If no explicit override is present, an absolute URL or `baseUrl` will also move the request onto HTTP.
+
+Most suites should keep `virtual` as the default and opt into `http` only when the trial truly needs that stricter path.
+
+## Payloads and query behavior
+
+Payload handling works like this:
+
+- `GET`, `HEAD`, and `DELETE` treat plain-object payloads like query params on virtual transport
+- object and array payloads are JSON-encoded for HTTP when needed
+- string and binary-like payloads pass through as-is
+
+That means most endpoint trials can stay very close to ordinary request code.
+
+## When to use what
+
+Reach for:
+
+- `get()` or `post()` when the trial is short and obvious
+- `request` when you need headers, session state, actors, or transport control
+- `visit()` when the response is an Inertia page contract
+- browser trials when the DOM, navigation, or client runtime is the real behavior
+
+The `request` and `visit` clients share the same transport model, headers, and scoping rules.

--- a/docs/sounding/scenarios.md
+++ b/docs/sounding/scenarios.md
@@ -1,0 +1,310 @@
+---
+title: Scenarios
+editLink: true
+---
+
+# Scenarios
+
+If a **factory** describes one record shape, a **scenario** composes those records into a named business situation.
+
+Scenario names usually describe the setup they provide:
+
+- `issue-access`
+- `publisher-editor`
+- `billing-upgrade`
+- `team-invite`
+
+The output of a scenario is the **world** your trial will read from.
+
+If you want the broader concept model around worlds and actors, read [Worlds](/sounding/worlds).
+
+## Where scenarios live
+
+By default, Sounding looks for scenarios under:
+
+```text
+tests/scenarios/
+```
+
+That default comes from `sounding.world.scenarios`.
+If your app needs a different location, you can override it in `config/sounding.js`.
+
+Sounding loads scenario files recursively and understands:
+
+- `.js`
+- `.cjs`
+- `.mjs`
+
+## The simplest scenario
+
+```js
+import { defineScenario } from 'sounding'
+
+export default defineScenario('issue-access', async ({ create }) => {
+  const publisher = await create('user').trait('publisher')
+  const subscriber = await create('user').trait('subscriber')
+  const gatedIssue = await create('issue', {
+    author: publisher.id
+  }).trait('published')
+
+  return {
+    users: { publisher, subscriber },
+    issues: { gatedIssue }
+  }
+})
+```
+
+That return value is the resolved world.
+
+A good scenario return shape should give the trial readable handles like:
+
+- `current.users.publisher`
+- `current.users.subscriber`
+- `current.issues.gatedIssue`
+
+Avoid vague keys like:
+
+- `user1`
+- `record2`
+- `data`
+
+## What the definition receives
+
+When a scenario definition is a function, Sounding calls it with a small helper object:
+
+- `build`
+- `create`
+- `defineFactory`
+- `defineScenario`
+- `sails`
+- `sequence`
+- `seed`
+- `context`
+
+### `build()`
+
+`build(name, overrides)` resolves a factory value without persisting it.
+
+### `create()`
+
+`create(name, overrides)` resolves a factory and persists it when a matching Sails model identity exists.
+
+If there is no matching model, Sounding returns the built object.
+
+### `defineFactory()` and `defineScenario()`
+
+These advanced helpers let a scenario file register additional world definitions when it truly needs to.
+
+Most apps should prefer static top-level definitions and only reach for this when the file is intentionally composing related world definitions together.
+
+### `sails`
+
+The real Sails runtime.
+
+This is useful when a scenario needs to call a real helper, inspect config, or intentionally create part of its state through application behavior instead of plain model creation.
+
+### `sequence`
+
+The same deterministic sequence helper factories use.
+
+This is handy when a scenario needs one more unique value without falling back to `Date.now()` or `Math.random()`.
+
+### `seed`
+
+The current world seed.
+
+If you set one through `sails.sounding.world.seed(value)`, Sounding exposes it here for deterministic scenario behavior.
+
+### `context`
+
+The optional input passed to `world.use(name, context)`.
+
+That lets a trial parameterize the scenario without inventing a second scenario for a small but meaningful variation.
+
+```js
+const current = await world.use('team-invite', {
+  inviterRole: 'owner'
+})
+```
+
+Then the scenario can read:
+
+```js
+export default defineScenario('team-invite', async ({ context, create }) => {
+  const inviter = await create('user').trait(context.inviterRole)
+
+  return { users: { inviter } }
+})
+```
+
+## Scenario-local builders
+
+Inside a scenario, `build()` and `create()` return thenable builders with a small fluent API:
+
+- `.trait(name)`
+- `.traits(names)`
+- `.with(overrides)`
+- `.value()`
+
+That means all of these work:
+
+```js
+const publisher = await create('user').trait('publisher')
+
+const unlockedReader = await create('user')
+  .traits(['subscriber', 'active'])
+  .with({ email: 'reader@example.com' })
+
+const preview = await build('issue')
+  .trait('published')
+  .with({ title: 'Preview only' })
+```
+
+This fluent builder exists on the scenario-local helpers.
+It does **not** exist on top-level `world.create()` or `world.build()`.
+
+## Loading a scenario in a trial
+
+Trials usually load a scenario through the world engine:
+
+```js
+import { test } from 'sounding'
+
+test('subscriber can read a members-only issue', async ({ world, expect }) => {
+  const current = await world.use('issue-access')
+
+  expect(current.users.subscriber).toBeDefined()
+  expect(current.issues.gatedIssue).toBeDefined()
+})
+```
+
+After `use()`, the resolved world is also available on:
+
+```js
+world.current
+```
+
+This is mainly useful when a helper needs to inspect the current resolved world after the initial load.
+
+## Scenario helpers
+
+Sometimes a scenario needs more than direct factory creation.
+
+For example:
+
+- a real signup helper that creates a user, team, and membership together
+- a billing bootstrap helper that calls application code on purpose
+- a small helper that keeps a scenario readable without becoming a reusable factory
+
+In those cases:
+
+- factories own primitive record shapes
+- scenarios own business situations
+- scenario-local helpers keep a scenario readable when the setup is more than one record
+
+When a helper only exists to support scenario composition, keep it in a clearly named world-helper area near the scenarios.
+
+One useful layout is:
+
+```text
+tests/
+  world-helpers/
+    create-user-with-team.js
+  scenarios/
+  publisher-editor.js
+  issue-access.js
+```
+
+Keep these helpers outside `tests/scenarios/` itself.
+Sounding recursively loads JavaScript files under the configured scenario directory, so plain helper modules should live nearby, not inside the auto-loaded tree.
+
+## Supported export shapes
+
+Sounding's world loader understands a few shapes today.
+
+### A direct definition
+
+```js
+import { defineScenario } from 'sounding'
+
+export default defineScenario('issue-access', async ({ create }) => {
+  // ...
+})
+```
+
+### A function export
+
+If a file exports a function, Sounding calls it with a loader API containing:
+
+- `sails`
+- `world`
+- `defineFactory`
+- `defineScenario`
+- `factory`
+- `scenario`
+- `registerFactory`
+- `registerScenario`
+
+That means this is also valid:
+
+```js
+module.exports = ({ scenario }) =>
+  scenario('issue-access', async ({ create }) => {
+    // ...
+  })
+```
+
+### An array
+
+```js
+module.exports = [
+  defineScenario('issue-access', async () => ({})),
+  defineScenario('publisher-editor', async () => ({}))
+]
+```
+
+### An object group
+
+```js
+module.exports = {
+  scenarios: [
+    defineScenario('issue-access', async () => ({})),
+    defineScenario('publisher-editor', async () => ({}))
+  ]
+}
+```
+
+Object groups can also include `factories`.
+
+## What makes a good scenario
+
+A strong scenario:
+
+- is named after a business situation
+- returns readable handles
+- uses traits and overrides before inventing one-off setup
+- stays small enough to trust
+- works across multiple related trials
+
+A weak scenario:
+
+- tries to model the whole app
+- returns generic names
+- duplicates factory work
+- creates data the trial never uses
+- exists only because one trial needed one more field value
+
+## When to create a new scenario
+
+Create a new scenario when the trial needs a new named business situation.
+
+Prefer a trait, override, or small scenario helper when:
+
+- the actors are the same
+- the relationships are basically the same
+- only one or two fields change
+- the difference does not need a new scenario name
+
+Factories answer "what is one of these records like?"
+
+Scenarios answer "what situation is this trial living inside?"

--- a/docs/sounding/testing-helpers.md
+++ b/docs/sounding/testing-helpers.md
@@ -31,11 +31,7 @@ test('signupWithTeam creates a user and team', async ({ sails, expect }) => {
 })
 ```
 
-## Why helper trials matter
-
-A lot of critical Sails behavior lives in helpers.
-
-If helper trials feel great, teams can cover important business logic quickly without reaching for browser tests too early.
+Many Sails apps keep important business logic in helpers, so this layer usually covers behavior more cheaply than a request or browser trial.
 
 ## What helper trials should expose
 
@@ -45,9 +41,9 @@ Helper trials should give you:
 - `sails.sounding.helpers('user.signupWithTeam', inputs)` as the dynamic fallback when the helper identity is not known ahead of time
 - `expect` for clean assertions
 - access to the current app runtime when needed
-- world helpers for setup when the helper depends on existing records
+- world helpers for setup when the helper depends on existing records, usually kept in a nearby folder like `tests/world-helpers/`
 
-That keeps the happy path simple while still allowing realistic setup.
+If the helper needs world setup, read [Scenarios](/sounding/scenarios) and [Worlds](/sounding/worlds).
 
 ## Canonical first, dynamic second
 

--- a/docs/sounding/testing-inertia.md
+++ b/docs/sounding/testing-inertia.md
@@ -5,15 +5,17 @@ editLink: true
 
 # Testing Inertia pages
 
-Inertia responses deserve their own testing lane.
+Use `visit()` when you want to test the server-side contract of an Inertia response.
 
-They are not just JSON, and they are not just browser pages. They are a Sails response model with their own shape, props, redirects, validation, and partial reload behavior.
+Inertia responses have their own component, props, redirect, validation, and partial reload behavior.
 
 When a repo uses a separate functional layer, these trials usually live under `tests/functional/pages/`.
 
+If you want the full `visit()` surface and its relationship to request transport, read [Request clients and transport](/sounding/request-clients).
+
 ## `test()` for Inertia responses
 
-Use `test()` when you want to test the server-side contract of an Inertia response without jumping straight to a browser flow.
+Use `test()` when you want to test the server-side contract of an Inertia response without starting a browser.
 
 ```js
 import { test } from 'sounding'
@@ -52,9 +54,7 @@ test('sign up returns validation errors for invalid input', async ({
 
 ## Partial reloads
 
-A good Inertia testing story should also cover partial reload behavior when a page only requests a subset of props.
-
-That keeps the framework honest about how modern Sails + Inertia apps really behave.
+Use partial reload assertions when a page only requests a subset of props.
 
 ```js
 import { test } from 'sounding'
@@ -81,5 +81,3 @@ Under the hood, Sounding should translate that into the same Inertia headers the
 - `toHaveSharedProp()`
 - `toHaveValidationError()`
 - `toRedirectTo()`
-
-This is one of Sounding's most important jobs: make Inertia testing feel like a first-class citizen instead of a half-step between HTTP and E2E.

--- a/docs/sounding/testing-json-apis.md
+++ b/docs/sounding/testing-json-apis.md
@@ -5,9 +5,7 @@ editLink: true
 
 # Testing JSON APIs and endpoints
 
-Sounding should be just as good for API-only Sails apps as it is for full browser flows.
-
-That is why endpoint testing is a first-class part of the framework.
+Use Sounding's request helpers for endpoint and JSON API behavior.
 
 When a repo separates browser E2E from faster app checks, these trials usually live under `tests/functional/api/`.
 
@@ -34,7 +32,7 @@ test('guest gets 401 on a private JSON endpoint', async ({ get, expect }) => {
 
 Most endpoint trials should use Sounding's virtual request transport by default. That means `get()` and `post()` are usually powered by `sails.request()`.
 
-When parity with the real HTTP stack matters more, opt in deliberately:
+When the trial needs the real HTTP stack, opt into it explicitly:
 
 ```js
 test(
@@ -100,7 +98,7 @@ test('creator password login redirects to invoices', async ({
 })
 ```
 
-Sounding should also keep `request.as(actor)` aligned with the app's auth conventions, including
+`request.as(actor)` also follows the app's auth conventions, including
 `User` / `userId` and `Creator` / `creatorId`.
 
 ## The two request surfaces
@@ -110,18 +108,18 @@ Sounding gives you the same request engine in two shapes:
 - top-level aliases like `get()` and `post()` for the common path
 - the fuller `sails.sounding.request` client when you want to scope headers, sessions, actors, or transports
 
-A good rule is:
+Use this rule:
 
 - start with `get()` / `post()` when the trial is simple
 - reach for `sails.sounding.request` when you need more control
 
+If you want the full request client API, visit transport behavior, and scoping helpers like `withSession()` and `as(actor)`, read [Request clients and transport](/sounding/request-clients).
+
 ## Useful endpoint matchers
 
-Sounding's request story currently leans on a small set of matchers that map cleanly to product behavior:
+Common matchers include:
 
 - `toHaveStatus()`
 - `toRedirectTo()`
 - `toHaveJsonPath()`
 - `toHaveHeader()`
-
-That keeps endpoint trials precise without making them feel low-level.

--- a/docs/sounding/trial-context.md
+++ b/docs/sounding/trial-context.md
@@ -6,7 +6,7 @@ editLink: true
 # Trial context
 
 A **trial** is one named behavior check.
-The **trial context** is the environment Sounding passes into that trial.
+The **trial context** is the object Sounding passes into that trial.
 
 Every Sounding trial starts the same way:
 
@@ -24,30 +24,25 @@ That object passed into the callback is the **trial context**.
 
 If you are looking for the higher-level definition of a trial itself, read [Trials](/sounding/trials).
 
-The trial context is Sounding's most important design decision.
-
-It gives each trial:
+The trial context gives each trial:
 
 - the real Sails runtime
 - the most useful testing surfaces for the current trial
 - a few ergonomic aliases for common work
 
-The goal is not to hide Sails.
-It is to make the right things easy without inventing a second fake app model.
+It does not replace the Sails runtime. `sails` remains the canonical entry point.
 
 ## The canonical center is `sails`
 
 At the center of every trial is `sails`.
 
-That means the normal Sails surfaces still matter most:
+The normal Sails surfaces still matter most:
 
 - `sails.helpers`
 - `sails.models`
 - `sails.config`
 - `sails.hooks`
 - `sails.sounding`
-
-If you already know Sails, the testing story should feel familiar.
 
 ## What is available in the context
 
@@ -84,6 +79,8 @@ It covers:
 
 The scoped request client for the current trial.
 
+If you want the full request client and transport surface, read [Request clients and transport](/sounding/request-clients).
+
 Use it when you want the fuller request surface:
 
 ```js
@@ -94,7 +91,7 @@ const response = await request.as(current.users.subscriber).get('/dashboard')
 
 Convenience aliases bound from `request`.
 
-These are ideal when the trial is simple and readable with a short call:
+Use them when the trial is short and readable with a short call:
 
 ```js
 const response = await get('/dashboard')
@@ -103,6 +100,8 @@ const response = await get('/dashboard')
 ### `visit`
 
 The Inertia-aware request surface.
+
+This is still built on Sounding's request engine, not a separate browser system.
 
 Use it when the real contract is an Inertia page, not just a status code.
 
@@ -115,7 +114,7 @@ expect(page).toBeInertiaPage('billing/pricing')
 
 Sounding's auth helpers.
 
-This is the lower-level auth surface for:
+Use this lower-level auth surface for:
 
 - resolving users
 - issuing magic links
@@ -169,7 +168,7 @@ test(
 )
 ```
 
-This is deliberate. The browser should only show up when the browser actually matters.
+These keys are only available when the trial opts into browser support.
 
 ### `t`
 
@@ -179,7 +178,7 @@ This keeps Sounding grounded in the native Node test runner instead of hiding it
 
 ## Trial options
 
-Sounding keeps trial options intentionally small.
+Sounding-specific trial options are intentionally small.
 
 ### `{ browser: true }`
 
@@ -225,5 +224,3 @@ So if you are not sure which surface to reach for, use this rule:
 
 - use `sails.helpers`, `sails.models`, and `sails.sounding` when you want the most explicit form
 - use `get()`, `post()`, `visit()`, `login`, `world`, and `mailbox` when they make the trial easier to read
-
-That balance is what keeps Sounding elegant instead of magical.

--- a/docs/sounding/trials.md
+++ b/docs/sounding/trials.md
@@ -16,15 +16,7 @@ Examples:
 - a publisher can save a draft
 - requesting a magic link sends a usable email
 
-That idea should feel familiar if you have used tools like Jest or Pest: a file contains a suite of related checks, and each named check proves one thing.
-
-Sounding keeps that familiar shape, but gives it a more intentional name.
-
-Why **trial**?
-
-Because Sounding is part of a maritime ecosystem.
-Before a ship commits to the voyage, it is tested against reality.
-A trial is where you learn whether the app can safely proceed.
+Sounding uses the standard `test()` API. The docs use **trial** as the conceptual term for one test case.
 
 In practice, a trial is still written with `test()`:
 
@@ -37,9 +29,6 @@ test('guest is redirected from dashboard', async ({ get, expect }) => {
   expect(response).toRedirectTo('/login')
 })
 ```
-
-So Sounding does **not** invent a strange new function name.
-It uses the familiar `test()` API, while the docs use **trial** to describe what that test is doing inside the Sounding model.
 
 ## What makes a good trial
 
@@ -63,7 +52,7 @@ Weak trial names:
 - `works correctly`
 - `can call helper`
 
-The title should read like a product truth.
+Prefer names that describe observable behavior.
 
 ## A trial is not the same thing as a world
 
@@ -83,8 +72,7 @@ For example, `issue-access` might support all of these:
 - reader with an unlock can finish the story
 - requesting a magic link from the issue page sends the right email
 
-The world stays the same.
-The trials change because the behaviors being proved are different.
+The world stays the same. The trials change because the behaviors being proved are different.
 
 ## A trial should choose the right layer
 
@@ -140,8 +128,7 @@ test(
 )
 ```
 
-The behavior decides the layer.
-Not the other way around.
+Choose the lowest layer that proves the behavior.
 
 ## A trial context is the environment of the trial
 
@@ -169,12 +156,10 @@ Sounding keeps the larger structure simple:
 - a **file** groups related trials
 - a **suite** is the whole test tree for the app
 
-That is intentionally close to the mental model developers already know from Jest, Pest, and the native Node test runner.
+This matches the structure developers already know from Jest, Pest, and the native Node test runner.
 
-What Sounding adds is a better Sails-native runtime under that familiar shape.
+What Sounding adds is a Sails-aware runtime under that familiar shape.
 
 ## The main rule
 
-A Sounding trial should read like a product truth being proved inside a real Sails app.
-
-That is the bar.
+Name trials after the behavior they prove.

--- a/docs/sounding/what-is-sounding.md
+++ b/docs/sounding/what-is-sounding.md
@@ -7,7 +7,7 @@ editLink: true
 
 Sounding is a Sails-native testing framework for Sails applications and The Boring JavaScript Stack.
 
-It brings the full testing story under one roof:
+It covers:
 
 - helper and business-logic tests
 - endpoint and JSON API tests
@@ -15,67 +15,49 @@ It brings the full testing story under one roof:
 - browser and end-to-end flows
 - mail assertions
 
-Instead of stitching together a runner, a browser harness, ad hoc seeding code, and test-only app hooks, Sounding gives your app one coherent testing runtime.
+Sounding provides one runtime for these test types so they can share the same app boot, request helpers, world setup, and assertion surface.
 
 ## Where the name comes from
 
 In maritime navigation, **sounding** means measuring the depth of water beneath a ship before it moves forward.
 
-Historically, sailors used a sounding line with a weighted lead to test the seabed and make sure it was safe to proceed.
-
-That metaphor is unusually good for testing:
-
-- before you ship, you test the waters
-- you check what is underneath the surface
-- you make sure the ground beneath the code is safe
-- a failing trial is a warning that the water is shallower than it looked
-
-That is why the name fits this ecosystem so naturally.
-
-Alongside names like Slipway, Quest, Lookout, Wish, and Clearance, Sounding feels like the thing you do before committing the ship to the voyage.
-
-In software terms, that is exactly what a test suite should be.
+The name matches the rest of the ecosystem and the role of checking an application before release.
 
 ## Why Sounding exists
 
-The current Sails testing story has all the right pieces, but they still feel too separate:
+The current Sails testing pieces work well on their own:
 
 - `node:test` is excellent for lightweight tests
 - Playwright is excellent for browser flows
 - `inertia-sails/test` gives us useful response assertions
 - `getSails()` patterns work, but they still ask every app to invent its own ceremony
 
-What is missing is the elegant middle layer: a Sails-aware runtime that makes realistic tests easy to write and easy to trust.
+Sounding adds a Sails-aware runtime that ties these pieces together under one hook and one `test()` API.
 
 ## What Sounding means by a trial
 
-Sounding uses the familiar `test()` API, but it talks about each test as a **trial**.
-
-A trial is one named product truth you are proving inside a real Sails app:
+Sounding uses the standard `test()` API. The docs use **trial** to mean one named behavior check inside a real Sails app, such as:
 
 - _guest is redirected from dashboard_
 - _subscriber can read a members-only issue_
 - _requesting a magic link sends a usable email_
 
-That language matters because it keeps the framework focused on behavior, not plumbing.
 If you want the full concept model, read [Trials](/sounding/trials).
 
 ## What makes Sounding Sails-native
 
-Sounding is designed as a **Sails hook first** and a **CLI second**.
+Sounding is implemented as a Sails hook and exposed on `sails.sounding`.
 
-That means the canonical surfaces are:
+The canonical surfaces are:
 
 - optional `config/sounding.js` when you need overrides
 - `sails.sounding`
 
-Not `config/test.js`, and not `sails.test`.
-
-That choice matters because Sounding should feel like every other serious Sails subsystem in your app. You configure it once, lower the app once, and let the hook give you a clean public runtime.
+By default, the hook only activates in the environments listed under `sounding.environments`, which starts as `['test']`.
 
 ## What Sounding covers
 
-Sounding should feel natural wherever Sails developers actually spend time testing.
+Sounding covers the places Sails developers commonly test.
 
 ### Helpers and business logic
 
@@ -114,17 +96,11 @@ Use `test()` with `page` when a flow is truly about the browser:
 
 Use `test()` and `sails.sounding.mailbox` to assert on outgoing transactional email like magic links, invites, password resets, and billing notifications.
 
-## What Sounding does not want you to do
+## Common problems it helps avoid
 
-Sounding should reduce ceremony, not push you into awkward compromises.
-
-It should help you avoid:
+Sounding helps avoid:
 
 - adding product-code test routes just to seed data
 - booting shadow app instances that fight over the same datastore
 - scattering fixtures across app code and test code
 - treating browser, API, and Inertia tests as unrelated worlds
-
-## Sounding in one sentence
-
-Sounding is the test home for everything Sails already does well.

--- a/docs/sounding/worlds.md
+++ b/docs/sounding/worlds.md
@@ -7,18 +7,16 @@ editLink: true
 
 If a **trial** is the behavior being proved, a **world** is the business situation that trial lives inside.
 
-If `test()` is the outer shape of Sounding, **worlds** are the inner shape.
+A world is the named, deterministic state returned by a scenario.
 
-A world is the named, deterministic business state that a trial lives inside.
-
-That means a world is not just a bag of fixtures and it is not just raw seed data. A world is a product situation:
+It contains the actors, records, and relationships a trial needs. For example:
 
 - a guest trying to open a gated issue
 - a subscriber with active access
 - a publisher editing a draft
 - a reader requesting a magic link
 
-That distinction matters. Sounding should help you test **product situations**, not just database rows.
+Use worlds to represent business situations instead of anonymous seed data.
 
 ## The four building blocks
 
@@ -56,7 +54,7 @@ Examples:
 - `unlockedReader`
 - `teamOwner`
 
-Actors matter because most product behavior is role-sensitive.
+Actors matter because many behaviors are role-sensitive.
 
 ### World
 
@@ -78,22 +76,22 @@ So the hierarchy looks like this:
 
 ## Why worlds matter
 
-Without worlds, tests usually drift toward one of two bad outcomes:
+Without worlds, tests usually drift toward one of two patterns:
 
 - giant setup blocks that hide the point of the trial
-- tiny fake fixtures that are too thin to trust
+- tiny fixtures that omit important relationships
 
-Worlds give Sounding a better middle path:
+Worlds help by keeping setup:
 
 - realistic enough to trust
 - named clearly enough to understand
-- reusable without feeling abstract
-
-The test stays focused on behavior because the world already carries the setup burden.
+- reusable across related trials
 
 ## Factories are the primitive layer
 
-A good factory should describe one thing well and stay boring.
+A factory describes one record shape.
+
+If you want the full factory surface, read [Factories](/sounding/factories).
 
 ```js
 import { defineFactory } from 'sounding'
@@ -107,20 +105,20 @@ export default defineFactory('user', ({ fake, sequence }) => ({
   .trait('subscriber', { subscriptionStatus: 'active' })
 ```
 
-The important thing here is not fake data generation by itself. It is the **traits**.
+The key part is the **traits**.
 
-Traits let the test vocabulary start sounding like the product:
+Traits add named variants such as:
 
 - `publisher`
 - `subscriber`
 - `expired`
 - `foundingSupporter`
 
-That is how the data layer starts to feel intentional.
-
-## Scenarios are where meaning appears
+## Scenarios compose a business situation
 
 A scenario is where separate records become a named business situation.
+
+If you want the full scenario surface, loading behavior, and file export shapes, read [Scenarios](/sounding/scenarios).
 
 ```js
 import { defineScenario } from 'sounding'
@@ -144,9 +142,7 @@ export default defineScenario('issue-access', async ({ create }) => {
 })
 ```
 
-The return value is the world.
-
-It should be something a test can read without opening the scenario first.
+The return value is the world. It should be something a test can read without opening the scenario first.
 
 ## What makes a good scenario name
 
@@ -171,9 +167,7 @@ The rule is simple:
 
 If the name does not tell you what business situation exists, it is probably not a good scenario name.
 
-## A world should read like the product
-
-Once you load a world, the test should feel like it is operating inside the product, not inside setup code.
+## A world should expose readable handles
 
 ```js
 import { test } from 'sounding'
@@ -189,12 +183,10 @@ test('subscriber can read a members-only issue', async ({ sails, expect }) => {
 })
 ```
 
-That reads well because the world gives the trial meaningful handles:
+The world gives the trial meaningful handles such as:
 
 - `current.users.subscriber`
 - `current.issues.gatedIssue`
-
-Those names do a lot of work.
 
 ## Good worlds vs bad worlds
 
@@ -214,7 +206,7 @@ A bad world:
 - creates too much data just because it can
 - is only understandable if you read 100 lines of setup first
 
-If a scenario starts feeling like a miniature production snapshot, it is too big.
+If a scenario starts looking like a production snapshot, it is too big.
 
 ## Use the same world across multiple trial types
 
@@ -262,7 +254,7 @@ test('reader gets a magic link email', async ({ sails, auth, expect }) => {
 })
 ```
 
-That is the payoff: one world, many useful trial surfaces.
+The same world can support multiple trial types.
 
 ## When to create a new scenario
 
@@ -283,6 +275,8 @@ In those cases, prefer:
 - a small override
 - a small helper inside the scenario
 
+If that helper only exists to support scenario composition, keep it near the scenarios in a named helper area such as `tests/world-helpers/`, not inside the auto-loaded `tests/scenarios/` tree.
+
 ## The relationship between trials, worlds, and actors
 
 A useful way to hold these ideas together is:
@@ -292,7 +286,7 @@ A useful way to hold these ideas together is:
 - the **actor** provides the role operating inside that situation
 - the **trial context** provides the runtime and tools
 
-That is the grammar Sounding is trying to make elegant.
+This is the relationship between the main Sounding concepts.
 
 ## A simple naming pattern that works well
 
@@ -310,13 +304,8 @@ Examples:
 - `billing-upgrade`
 - `team-invite`
 
-It keeps the suite calm and predictable.
+This keeps naming consistent across the suite.
 
-## The main idea to hold onto
+## Summary
 
-If you remember only one thing, let it be this:
-
-**A world is not there to make tests shorter. It is there to make them more truthful.**
-
-The goal is not clever setup reuse.
-The goal is a test that reads like a real product situation and still stays easy to trust.
+Use worlds to represent reusable business situations, not just shorter setup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sailscasts-docs",
-  "version": "1.20.6",
+  "version": "1.20.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sailscasts-docs",
-      "version": "1.20.6",
+      "version": "1.20.7",
       "devDependencies": {
         "@commitlint/cli": "^20.1.0",
         "@commitlint/config-conventional": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sailscasts-docs",
-  "version": "1.20.6",
+  "version": "1.20.7",
   "private": true,
   "description": "The official docs hub for Sailscasts",
   "scripts": {


### PR DESCRIPTION
## Summary
- add the Durable UI landing page, philosophy pages, and progress primitive docs
- organize the sidebar by philosophy, introduction, and progress category pages
- align the docs copy with the course and open-source project listing

Closes #69