### PR TITLE
Update Pellicule output and macro docs

### DIFF
--- a/docs/pellicule/agent-skills.md
+++ b/docs/pellicule/agent-skills.md
@@ -40,7 +40,7 @@ After installing, simply ask your AI assistant to create a video:
 The AI will:
 
 1. Write a Vue component with proper Pellicule animations
-2. Render it to MP4 using `npx pellicule`
+2. Render it with `npx pellicule`
 
 ## Source
 

--- a/docs/pellicule/cli.md
+++ b/docs/pellicule/cli.md
@@ -9,7 +9,7 @@ next:
 
 # CLI Reference
 
-The Pellicule CLI is the primary way to render videos. It takes a Vue component and outputs an MP4 file.
+The Pellicule CLI is the primary way to render videos. It takes a Vue component and outputs a video file (`mp4` by default).
 
 ## Basic Usage
 
@@ -31,6 +31,8 @@ Pellicule also checks your project's default video directory based on the detect
 | Option         | Short | Default        | Description                                      |
 | -------------- | ----- | -------------- | ------------------------------------------------ |
 | `--output`     | `-o`  | `./output.mp4` | Output file path                                 |
+| `--preset`     |       | `mp4`          | Output preset (`mp4` or `webm`)                  |
+| `--quality`    |       | `standard`     | Output quality (`draft`, `standard`, or `high`)  |
 | `--duration`   | `-d`  | `90`           | Duration in frames                               |
 | `--fps`        | `-f`  | `30`           | Frames per second                                |
 | `--width`      | `-w`  | `1920`         | Video width in pixels                            |
@@ -67,7 +69,7 @@ Instead of passing integration flags on every command, set them once in your `pa
 | `outDir`    | string | Directory for rendered video output (relative path)   |
 | `bundler`   | string | Force `vite` or `rsbuild`                             |
 
-When `outDir` is set and no `-o` flag is passed, the output filename is derived from the component name. For example, `pellicule InvoiceDemo` with `outDir` set to `./renders` writes to `./renders/InvoiceDemo.mp4`.
+When `outDir` is set and no `-o` flag is passed, the output filename is derived from the component name. For example, `pellicule InvoiceDemo` with `outDir` set to `./renders` writes to `./renders/InvoiceDemo.mp4` by default, or `./renders/InvoiceDemo.webm` when you use `--preset webm`.
 
 Resolution order: **CLI flags > package.json > auto-detected > defaults**.
 
@@ -97,14 +99,33 @@ pellicule InvoiceDemo --videos-dir ./my/videos
 npx pellicule Video
 ```
 
-Renders `Video.vue` to `output.mp4` at 1920×1080, 30fps, for 90 frames (3 seconds).
+Renders `Video.vue` to `output.mp4` by default at 1920×1080, 30fps, for 90 frames (3 seconds).
 
 ### Custom Output Path
 
 ```bash
 npx pellicule Video -o intro.mp4
-npx pellicule Video --output ./renders/my-video.mp4
+npx pellicule Video -o intro        # resolves to intro.mp4 by default
+npx pellicule Video --output ./renders/my-video.webm --preset webm
 ```
+
+### Output Presets and Quality
+
+```bash
+# Default MP4 output (H.264 + AAC)
+npx pellicule Video
+
+# WebM output (VP9 + Opus)
+npx pellicule Video --preset webm
+
+# Higher-quality MP4
+npx pellicule Video --quality high
+
+# Faster draft encode
+npx pellicule Video --quality draft
+```
+
+Pellicule keeps the zero-config path simple: if you do nothing, you still get a web-friendly MP4. Use `--preset` when you need a different delivery target, and `--quality` when you want to trade encode speed for file size and fidelity.
 
 ### Duration
 
@@ -201,7 +222,7 @@ npx pellicule Video -a background.mp3
 npx pellicule Video -o intro.mp4 --audio music.wav
 ```
 
-Supported formats include MP3, WAV, AAC, and any format FFmpeg supports. The audio is re-encoded to AAC for universal MP4 compatibility.
+Supported formats include MP3, WAV, AAC, and any format FFmpeg supports. The audio is re-encoded to match the selected preset (`aac` for `mp4`, `libopus` for `webm`).
 
 #### Audio Behavior
 
@@ -226,7 +247,7 @@ The path is resolved relative to the component file. CLI flags override componen
 
 ### Combined Example
 
-A 10-second 4K video at 60fps for YouTube:
+A 10-second 4K MP4 at 60fps for YouTube:
 
 ```bash
 npx pellicule Video \
@@ -246,6 +267,8 @@ While rendering, Pellicule shows a progress bar:
 
   Input      Video.vue
   Output     output.mp4
+  Preset     mp4
+  Quality    standard
   Resolution 1920x1080
   Duration   90 frames @ 30fps (3.0s)
   Audio      background.mp3

--- a/docs/pellicule/define-video-config.md
+++ b/docs/pellicule/define-video-config.md
@@ -33,6 +33,24 @@ npx pellicule Video.vue
 
 That's it! Pellicule reads the duration from your component.
 
+## Optional Import for Editor Support
+
+The macro works without an import, and that is still the default recommendation.
+
+If your editor, linter, or TypeScript-based tooling wants an explicit symbol, you can optionally import it from `pellicule`:
+
+```vue
+<script setup>
+import { defineVideoConfig } from 'pellicule'
+
+defineVideoConfig({
+  durationInSeconds: 5
+})
+</script>
+```
+
+Pellicule strips the macro during compilation either way, so the import is only there to make external editor tooling happier.
+
 ## Why a Macro?
 
 `defineVideoConfig` works like Vue's `defineProps` — it's recognized by the compiler and doesn't exist at runtime. This gives you:

--- a/docs/pellicule/dev-preview.md
+++ b/docs/pellicule/dev-preview.md
@@ -125,4 +125,4 @@ The recommended workflow with `pellicule dev` is:
 2. **Edit your component** — modify animations, styles, timing
 3. **Save** — HMR instantly refreshes the preview
 4. **Scrub and play** — use the controls to check different parts of the video
-5. **Render** — when you're happy, run `npx pellicule` to produce the final MP4
+5. **Render** — when you're happy, run `npx pellicule` to produce the final video (`mp4` by default)

--- a/docs/pellicule/getting-started.md
+++ b/docs/pellicule/getting-started.md
@@ -44,7 +44,7 @@ That's it! Pellicule will:
 
 1. Start a dev server with your component
 2. Render 90 frames (3 seconds at 30fps)
-3. Encode them into `output.mp4`
+3. Encode them into `output.mp4` by default
 
 ## What's in Video.vue?
 
@@ -100,6 +100,12 @@ Key points:
 ```bash
 # Custom output filename
 npx pellicule -o intro.mp4
+
+# WebM output
+npx pellicule --preset webm
+
+# Higher-quality MP4
+npx pellicule --quality high
 
 # 5 seconds at 30fps (150 frames)
 npx pellicule -d 150

--- a/docs/pellicule/how-it-works.md
+++ b/docs/pellicule/how-it-works.md
@@ -73,7 +73,7 @@ Each frame is captured sequentially. The `useFrame()` composable reads from `win
 
 ### 4. FFmpeg Encoding
 
-All captured frames are piped directly to FFmpeg, which encodes them into the final MP4:
+All captured frames are piped directly to FFmpeg, which encodes them into the final output file. By default that is an MP4, but Pellicule can also target WebM via presets:
 
 ```bash
 ffmpeg -framerate 30 -f image2pipe -i - -c:v libx264 -pix_fmt yuv420p output.mp4
@@ -165,11 +165,12 @@ Pellicule accepts `.vue` single-file components:
 ```bash
 npx pellicule Video.vue
 npx pellicule src/intro.vue -o intro.mp4
+npx pellicule src/intro.vue --preset webm -o intro.webm
 ```
 
 ### Output
 
-Currently supports MP4 with H.264 encoding. The output is web-optimized and plays in all modern browsers and video players.
+Pellicule currently supports two built-in output presets: `mp4` (H.264 + AAC) and `webm` (VP9 + Opus). The default remains `mp4` for broad compatibility.
 
 ## Dependencies
 

--- a/docs/pellicule/index.md
+++ b/docs/pellicule/index.md
@@ -2,7 +2,7 @@
 layout: home
 title: Pellicule
 titleTemplate: Deterministic video rendering with Vue
-description: Pellicule is a Vue-native engine for generating videos programmatically. Render Vue components frame-by-frame into production-ready MP4 files.
+description: Pellicule is a Vue-native engine for generating videos programmatically. Render Vue components frame-by-frame into production-ready video files.
 head:
   - - meta
     - property: 'og:image'

--- a/docs/pellicule/nuxt.md
+++ b/docs/pellicule/nuxt.md
@@ -57,6 +57,20 @@ globals: {
 }
 ```
 
+If your editor or linter prefers an explicit symbol, you can also import the macro directly:
+
+```vue
+<script setup>
+import { defineVideoConfig } from 'pellicule'
+
+defineVideoConfig({
+  durationInSeconds: 5
+})
+</script>
+```
+
+That import is optional. Pellicule strips the macro during compilation either way.
+
 ### 3. Start Your Dev Server and Render
 
 ```bash
@@ -214,4 +228,4 @@ When you run `pellicule AppDemo`:
 3. The `/pellicule` page (injected by the module) loads `AppDemo.vue` from your `app/videos/` directory
 4. The page sets up Pellicule's frame injection (`useFrame`, `useVideoConfig`) and signals readiness
 5. Playwright screenshots each frame, advancing the frame counter between shots
-6. Frames are encoded to MP4 with FFmpeg
+6. Frames are encoded with FFmpeg into the selected output format (`mp4` by default)

--- a/docs/pellicule/quasar.md
+++ b/docs/pellicule/quasar.md
@@ -36,6 +36,20 @@ globals: {
 }
 ```
 
+If your editor or linter prefers an explicit symbol, you can also import the macro directly:
+
+```vue
+<script setup>
+import { defineVideoConfig } from 'pellicule'
+
+defineVideoConfig({
+  durationInSeconds: 4
+})
+</script>
+```
+
+That import is optional. Pellicule strips the macro during compilation either way.
+
 ### 4. Start Your Dev Server and Render
 
 ```bash
@@ -161,7 +175,7 @@ When you run `pellicule ProductShowcase`:
 2. It constructs the URL `http://localhost:9000/pellicule?component=ProductShowcase&fps=30&duration=120&width=1920&height=1080`
 3. The `/pellicule` page (served by the Vite plugin) creates a Vue app with Quasar installed, dynamically imports your video component, and sets up Pellicule's frame injection
 4. Playwright screenshots each frame, advancing the frame counter between shots
-5. Frames are encoded to MP4 with FFmpeg
+5. Frames are encoded with FFmpeg into the selected output format (`mp4` by default)
 
 ## Webpack Mode
 

--- a/docs/pellicule/what-is-pellicule.md
+++ b/docs/pellicule/what-is-pellicule.md
@@ -21,7 +21,7 @@ Pellicule uses a fundamentally different approach to video creation:
 
 1. **You write a Vue component** — Your video is just a `.vue` file with a `frame` prop
 2. **Pellicule renders each frame** — It sets `frame` to 0, captures a screenshot, sets it to 1, captures again, and so on
-3. **FFmpeg encodes the video** — All those frames become an MP4 file
+3. **FFmpeg encodes the video** — All those frames become a video file (`mp4` by default)
 
 ```vue
 <script setup>


### PR DESCRIPTION
## What this changes
- document Pellicule output presets and quality controls in the CLI docs
- update Getting Started and How It Works for the new `mp4`/`webm` output model
- clarify that Pellicule still defaults to MP4 while supporting WebM output
- include the optional `import { defineVideoConfig } from "pellicule"` guidance in the relevant Pellicule pages
- adjust related Pellicule pages so they no longer imply MP4 is the only output path

## Verification
- `npm run build`

Related to sailscastshq/pellicule#30