### PR TITLE
Document Pellicule audio workflow and preview sync

### DIFF
--- a/docs/pellicule/cli.md
+++ b/docs/pellicule/cli.md
@@ -28,24 +28,25 @@ Pellicule also checks your project's default video directory based on the detect
 
 ## Options
 
-| Option         | Short | Default        | Description                                      |
-| -------------- | ----- | -------------- | ------------------------------------------------ |
-| `--output`     | `-o`  | `./output.mp4` | Output file path                                 |
-| `--preset`     |       | `mp4`          | Output preset (`mp4` or `webm`)                  |
-| `--quality`    |       | `standard`     | Output quality (`draft`, `standard`, or `high`)  |
-| `--duration`   | `-d`  | `90`           | Duration in frames                               |
-| `--fps`        | `-f`  | `30`           | Frames per second                                |
-| `--width`      | `-w`  | `1920`         | Video width in pixels                            |
-| `--height`     | `-h`  | `1080`         | Video height in pixels                           |
-| `--range`      | `-r`  |                | Frame range to render (start:end)                |
-| `--audio`      | `-a`  |                | Audio file to include (mp3, wav, etc.)           |
-| `--server-url` |       |                | Use a running dev server instead of starting one |
-| `--bundler`    |       |                | Force a specific bundler (`vite` or `rsbuild`)   |
-| `--config`     |       |                | Path to a specific config file                   |
-| `--videos-dir` |       |                | Override the default video directory             |
-| `--out-dir`    |       |                | Directory for rendered video output              |
-| `--help`       |       |                | Show help message                                |
-| `--version`    |       |                | Show version number                              |
+| Option                  | Short | Default        | Description                                      |
+| ----------------------- | ----- | -------------- | ------------------------------------------------ |
+| `--output`              | `-o`  | `./output.mp4` | Output file path                                 |
+| `--preset`              |       | `mp4`          | Output preset (`mp4` or `webm`)                  |
+| `--quality`             |       | `standard`     | Output quality (`draft`, `standard`, or `high`)  |
+| `--duration`            | `-d`  | `90`           | Duration in frames                               |
+| `--duration-from-audio` | `-A`  |                | Use the audio file length as total duration      |
+| `--fps`                 | `-f`  | `30`           | Frames per second                                |
+| `--width`               | `-w`  | `1920`         | Video width in pixels                            |
+| `--height`              | `-h`  | `1080`         | Video height in pixels                           |
+| `--range`               | `-r`  |                | Frame range to render (start:end)                |
+| `--audio`               | `-a`  |                | Audio file to include (mp3, wav, etc.)           |
+| `--server-url`          |       |                | Use a running dev server instead of starting one |
+| `--bundler`             |       |                | Force a specific bundler (`vite` or `rsbuild`)   |
+| `--config`              |       |                | Path to a specific config file                   |
+| `--videos-dir`          |       |                | Override the default video directory             |
+| `--out-dir`             |       |                | Directory for rendered video output              |
+| `--help`                |       |                | Show help message                                |
+| `--version`             |       |                | Show version number                              |
 
 ### Project Config (package.json)
 
@@ -154,6 +155,15 @@ npx pellicule Video -d 600 -f 60
 | 30s     | 900   | 1800  |
 | 60s     | 1800  | 3600  |
 
+If you already have a soundtrack, Pellicule can do this math for you:
+
+```bash
+# Probe the audio file and derive the total frame count from it
+npx pellicule Video -a narration.wav -A
+```
+
+Pellicule converts the probed audio duration into frames using the active fps. For example, a 4.25 second track at 30fps becomes 128 frames.
+
 ### Resolution
 
 ```bash
@@ -218,6 +228,9 @@ Add background music or sound effects to your video with the `--audio` flag:
 # Add background music
 npx pellicule Video -a background.mp3
 
+# Let the soundtrack define total duration
+npx pellicule Video -a background.mp3 -A
+
 # With other options
 npx pellicule Video -o intro.mp4 --audio music.wav
 ```
@@ -226,7 +239,9 @@ Supported formats include MP3, WAV, AAC, and any format FFmpeg supports. The aud
 
 #### Audio Behavior
 
-- **Video duration is the source of truth** — audio does not affect video length
+- **By default, video duration is the source of truth** — audio does not affect video length
+- Add `-A` or `--duration-from-audio` to probe the audio file and derive the total duration from it
+- `-d` and `-A` are mutually exclusive — pick one duration source
 - If audio is **shorter** than video: audio ends, video continues (silent for remainder)
 - If audio is **longer** than video: audio is truncated to match video duration
 

--- a/docs/pellicule/define-video-config.md
+++ b/docs/pellicule/define-video-config.md
@@ -133,7 +133,7 @@ defineVideoConfig({
 The audio path is resolved relative to the component file. Supported formats include MP3, WAV, AAC, and any format FFmpeg supports.
 
 ::: tip
-Audio does not affect video duration. If audio is shorter, it ends early. If longer, it's truncated to match the video length.
+By default, audio does not affect video duration. If you want the soundtrack to define total length, render with `-A` / `--duration-from-audio`. Audio that is still shorter than the final video ends early; audio that is longer is truncated to match the resolved duration.
 :::
 
 ## How It Works
@@ -214,4 +214,15 @@ defineVideoConfig({
 </script>
 ```
 
-Use `durationInSeconds` instead of computing frames manually.
+Use `durationInSeconds` instead of computing frames manually inside the macro payload.
+
+For timing logic in your component code, use Pellicule's timing helpers instead:
+
+```vue
+<script setup>
+import { secondsToFrames, useVideoConfig } from 'pellicule'
+
+const { fps } = useVideoConfig()
+const lyricStart = secondsToFrames(3.5, fps)
+</script>
+```

--- a/docs/pellicule/dev-preview.md
+++ b/docs/pellicule/dev-preview.md
@@ -31,19 +31,34 @@ npx pellicule dev MyVideo
 npx pellicule dev MyVideo -w 1280 -h 720
 ```
 
-All standard [CLI options](/pellicule/cli) work with `pellicule dev` — resolution, fps, duration, bundler, server-url, etc.
+All standard [CLI options](/pellicule/cli) work with `pellicule dev` — resolution, fps, duration, audio, `-A`, bundler, server-url, etc.
 
 ## Preview Controls
 
 The preview overlay appears at the bottom of the browser window with playback controls:
 
-| Control               | Action                       |
-| --------------------- | ---------------------------- |
-| Play / Pause button   | Start or stop auto-playback  |
-| Previous frame button | Step back one frame          |
-| Next frame button     | Step forward one frame       |
-| Timeline scrubber     | Seek to any frame            |
-| Frame counter         | Shows current frame and time |
+| Control               | Action                                 |
+| --------------------- | -------------------------------------- |
+| Play / Pause button   | Start or stop auto-playback            |
+| Previous frame button | Step back one frame                    |
+| Next frame button     | Step forward one frame                 |
+| Timeline scrubber     | Seek to any frame                      |
+| Frame counter         | Shows current frame and time           |
+| Audio sync badge      | Appears when preview audio is attached |
+
+## Audio-Aware Preview
+
+If your video has an audio track, `pellicule dev` keeps the soundtrack in sync with the overlay controls:
+
+```bash
+# Use the component's audio path
+npx pellicule dev Karaoke
+
+# Or pass audio explicitly and let it define the total duration
+npx pellicule dev Karaoke --audio ./song.wav -A
+```
+
+When audio is present, play, pause, frame stepping, and scrubbing all keep the hidden preview audio element aligned with the current frame. This makes lyric, caption, and soundtrack timing much easier to tune before you render.
 
 ### Keyboard Shortcuts
 

--- a/docs/pellicule/getting-started.md
+++ b/docs/pellicule/getting-started.md
@@ -118,6 +118,9 @@ npx pellicule -f 60
 
 # Partial render for faster iteration
 npx pellicule -d 150 -r 0:30
+
+# Sync the total duration to a soundtrack
+npx pellicule --audio ./song.wav -A
 ```
 
 ## Adding to an Existing Project
@@ -137,6 +140,8 @@ npx pellicule Video.vue
 Pellicule auto-detects your project type and reads your existing config. No extra configuration needed — if you have a `vite.config.js`, `config/shipwright.js`, or `nuxt.config.ts`, Pellicule picks it up automatically. Your aliases and plugins just work.
 
 See [Integrations](/pellicule/integrations) for framework-specific guides.
+
+If you're working against music, voiceover, or subtitles, reach for `npx pellicule dev` early. The preview overlay now keeps audio, playback, stepping, and scrubbing in sync so you can tune timing before rendering the final video.
 
 ## Next Steps
 


### PR DESCRIPTION
Refs sailscastshq/pellicule#31

## What changed
- document `-A, --duration-from-audio` in the CLI reference
- explain audio-aware preview behavior in `pellicule dev`
- clarify how `defineVideoConfig({ audio })` works with audio-derived duration
- add timing-helper guidance in getting started and macro docs

## Verification
- `npm run build`