### PR TITLE
docs: document Sounding datastore config cleanup

### DIFF
--- a/docs/sounding/configuration.md
+++ b/docs/sounding/configuration.md
@@ -116,6 +116,43 @@ The `world` section tells Sounding where to find factories and scenarios and how
 
 The `datastore` section tells Sounding how to work with your app's Sails datastore configuration.
 
+Use either the shorthand form:
+
+```js
+module.exports.sounding = {
+  datastore: 'inherit'
+}
+```
+
+or the canonical object form:
+
+```js
+module.exports.sounding = {
+  datastore: {
+    mode: 'managed',
+    identity: 'default',
+    adapter: 'sails-sqlite',
+    root: '.tmp/db',
+    isolation: 'worker'
+  }
+}
+```
+
+Legacy nested managed config is no longer supported:
+
+```js
+// No longer supported.
+module.exports.sounding = {
+  datastore: {
+    managed: {
+      directory: '.tmp/db'
+    }
+  }
+}
+```
+
+Use `mode: 'managed'` and `root` instead of `managed.directory`.
+
 ### `mode`
 
 `mode` controls the relationship between Sounding and your app's test datastore.


### PR DESCRIPTION
Refs sailscastshq/sounding#56

Summary:
- Documents the canonical Sounding datastore shorthand and object forms.
- Calls out that legacy `datastore.managed.directory` config is no longer supported.
- Shows the migration to `mode: "managed"` plus `root`.

Verification:
- git diff --check