### PR TITLE
docs: document virtual response session snapshots

### DIFF
--- a/docs/sounding/request-clients.md
+++ b/docs/sounding/request-clients.md
@@ -75,6 +75,36 @@ This is especially useful in virtual request trials where session state is part 
 
 Like `withHeaders()`, it returns a new scoped client instead of mutating the original one.
 
+## Inspecting virtual session state
+
+Virtual request responses expose the final `req.session` snapshot as `response.session`.
+
+```js
+const response = await request.post('/login', {
+  email: 'ada@example.com',
+  password: 'secret123'
+})
+
+expect(response.session.userId).toBe(user.id)
+expect(response.session.returnTo).toBe('/dashboard')
+```
+
+This is useful for request-level auth flows where the important behavior is stored in session before the next redirect or page visit.
+
+`response.session` is a snapshot taken after the route handler finishes. Later requests on the same client can keep mutating the shared virtual session, but earlier response snapshots do not change.
+
+For example:
+
+```js
+const login = await request.post('/login', credentials)
+const logout = await request.post('/logout')
+
+expect(login.session.userId).toBe(user.id)
+expect(logout.session.userId).toBeUndefined()
+```
+
+Real HTTP responses leave `response.session` undefined because server-side session state is hidden behind cookies and the app's session store.
+
 ## `using()`
 
 `using()` returns a new scoped client pinned to a transport.

--- a/docs/sounding/testing-json-apis.md
+++ b/docs/sounding/testing-json-apis.md
@@ -101,6 +101,25 @@ test('creator password login redirects to invoices', async ({
 `request.as(actor)` also follows the app's auth conventions, including
 `User` / `userId` and `Creator` / `creatorId`.
 
+Virtual request responses also expose the final `req.session` snapshot. That lets fast request trials prove intermediate auth state without moving the flow into a browser test:
+
+```js
+test('creator password login stores the return URL', async ({
+  auth,
+  expect
+}) => {
+  const result = await auth.request.withPassword('creator@example.com', {
+    password: 'secret123',
+    returnUrl: '/invoices'
+  })
+
+  expect(result.response).toRedirectTo('/invoices')
+  expect(result.response.session.returnUrl).toBe('/invoices')
+})
+```
+
+`response.session` is available for Sounding's virtual transport. If a trial opts into real HTTP, session state remains server-side and `response.session` is undefined.
+
 ## The two request surfaces
 
 Sounding gives you the same request engine in two shapes:


### PR DESCRIPTION
Related: sailscastshq/sounding#16

## Summary
- Document `response.session` for Sounding virtual request responses.
- Clarify that HTTP responses leave session state undefined.
- Add an auth-flow example for request-level session assertions.

## Verification
- npm run lint
- npm run build