### PR TITLE
docs: document Sounding failure diagnostics

### DIFF
--- a/docs/sounding/auth-and-actors.md
+++ b/docs/sounding/auth-and-actors.md
@@ -88,6 +88,8 @@ Useful details:
 - if you pass an email address, Sounding will resolve or create that actor as needed
 - the default browser login path currently uses a magic-link flow under the hood
 
+If an actor alias cannot be resolved, Sounding lists the actor names available in the current world. That makes typo-level failures point back to product language instead of leaving you to inspect the scenario by hand.
+
 ## `login.withPassword(actorOrEmail, page, options)`
 
 For apps that use real password login forms, Sounding should let the browser follow that flow instead of faking session state.
@@ -134,6 +136,8 @@ Use this when you need a real actor record and want Sounding to resolve either:
 - a world actor name
 - a user or creator object
 - an email address
+
+When a world actor name is missing, the error includes the available aliases from common actor collections such as `users` and `creators`.
 
 ### `auth.issueMagicLink()`
 

--- a/docs/sounding/configuration.md
+++ b/docs/sounding/configuration.md
@@ -250,6 +250,18 @@ Most Sounding trials should still be written in terms of:
 
 not raw adapter details.
 
+## Diagnostics
+
+Sounding keeps failure diagnostics concise by default. Response assertion failures show the request, response status, key headers, and a short body excerpt.
+
+When a failing response needs more inspection, set:
+
+```sh
+SOUNDING_DIAGNOSTICS=verbose npm test
+```
+
+That expands response excerpts in assertion failures without changing `config/sounding.js`.
+
 ## `sockets`
 
 The `sockets` section configures Sounding's Sails websocket helpers.

--- a/docs/sounding/request-clients.md
+++ b/docs/sounding/request-clients.md
@@ -49,6 +49,36 @@ The request client exposes:
 - `using(transport)`
 - `as(actor)`
 
+## Failure diagnostics
+
+When a response assertion fails, Sounding includes the request and response context that usually explains what happened.
+
+```js
+const response = await request.get('/health')
+
+expect(response).toHaveStatus(200)
+```
+
+If the app returned `500`, the failure includes a compact diagnostic block:
+
+```txt
+Expected response status 200, received 500.
+
+Sounding response diagnostics:
+- Request: GET /health (virtual)
+- Response: 500 Server Error
+- Headers: content-type: application/json, x-request-id: req_123
+- Body: {"message":"Database unavailable","detail":"Connection pool exhausted"}
+```
+
+The same response diagnostics are used by request, visit, Inertia, validation, and socket request assertions when the response shape is available.
+
+By default, Sounding keeps the body excerpt concise. When you need the full response body while debugging a failure, run the trial with:
+
+```sh
+SOUNDING_DIAGNOSTICS=verbose npm test
+```
+
 ## `withHeaders()`
 
 `withHeaders()` returns a new scoped client with default headers applied.

--- a/docs/sounding/trial-context.md
+++ b/docs/sounding/trial-context.md
@@ -75,6 +75,8 @@ It covers:
 - Inertia assertions like `toBeInertiaPage()` and `toHaveProp()`
 - Playwright assertions when the trial is browser-capable
 
+Failed response assertions include the Sails-shaped context Sounding has available: request method, target, transport, response status, headers, and a body excerpt. For the full response body while debugging, run with `SOUNDING_DIAGNOSTICS=verbose`.
+
 ### `request`
 
 The scoped request client for the current trial.

--- a/docs/sounding/worlds.md
+++ b/docs/sounding/worlds.md
@@ -167,6 +167,13 @@ The rule is simple:
 
 If the name does not tell you what business situation exists, it is probably not a good scenario name.
 
+When a factory, trait, or scenario name is wrong, Sounding lists the available names in the failure. This keeps world failures close to the suite vocabulary:
+
+```txt
+Unknown Sounding scenario: missing-dashboard.
+Available scenarios: issue-access, publisher-editor
+```
+
 ## A world should expose readable handles
 
 ```js


### PR DESCRIPTION
## Summary
- document failed response assertion diagnostics
- document SOUNDING_DIAGNOSTICS=verbose
- note available actor, factory, trait, and scenario names in resolution failures

## Verification
- npm run lint
- npm run build

Resolves sailscastshq/sounding#33