### PR TITLE
Document Sounding actor aliases

### DIFF
--- a/docs/sounding/auth-and-actors.md
+++ b/docs/sounding/auth-and-actors.md
@@ -53,6 +53,20 @@ test('subscriber can read the issue', async ({ sails, expect }) => {
 })
 ```
 
+You can also pass the actor alias directly after loading the world:
+
+```js
+test('subscriber can read the issue', async ({ world, request, expect }) => {
+  const current = await world.use('issue-access')
+
+  const response = await request
+    .as('subscriber')
+    .get(`/i/${current.issues.gatedIssue.slug}`)
+
+  expect(response).toHaveStatus(200)
+})
+```
+
 This lets request trials act as an authenticated user without manual session setup.
 
 Sounding resolves common auth conventions such as:
@@ -60,6 +74,14 @@ Sounding resolves common auth conventions such as:
 - `User` with `req.session.userId`
 - `Creator` with `req.session.creatorId`
 - explicit overrides in `config/sounding.js` when an app uses custom naming
+
+`request.as()` also accepts an email address when the configured auth model can resolve an existing actor:
+
+```js
+const response = await request.as('reader@example.com').get('/me')
+```
+
+For Inertia contract tests, `visit.as('subscriber')` applies the same actor resolution before making the visit.
 
 ## `login.as(actorOrEmail, page)`
 
@@ -191,7 +213,7 @@ A common flow is:
 
 1. load a world
 2. pick an actor from the world
-3. use that actor through `request.as()` or `login.as()`
+3. use that actor through `request.as()`, `visit.as()`, or `login.as()`
 
 ```js
 test('publisher can create an issue', async ({ sails, expect }) => {

--- a/docs/sounding/request-clients.md
+++ b/docs/sounding/request-clients.md
@@ -148,14 +148,30 @@ This is how a single trial can keep most requests fast and virtual while opting 
 
 ## `as()`
 
-`as(actor)` scopes the client through a world actor.
+`as(actor)` scopes the client through an actor.
 
 ```js
 const response = await request.as(current.users.publisher).get('/dashboard')
 ```
 
+When a named world has been loaded, you can pass the actor alias directly:
+
+```js
+await world.use('publisher-dashboard')
+
+const response = await request.as('publisher').get('/dashboard')
+```
+
+You can also pass an email address when the app's configured auth model can resolve it:
+
+```js
+const response = await request.as('reader@example.com').get('/me')
+```
+
 Sounding looks for actor data in this order:
 
+- an actor alias in the current world, such as `world.current.users.publisher`
+- an existing auth model record when the actor is an email string
 - `actor.headers` or `actor.sounding.headers`
 - `actor.session` or `actor.sounding.session`
 - otherwise it derives a session from the actor identity
@@ -166,6 +182,8 @@ When it derives a session automatically, it uses:
 - `teamId` from `actor.team` or `actor.teamId` when present
 
 This lets `request.as(actor)` follow the app's auth conventions without manual session setup.
+
+If an alias cannot be resolved, Sounding lists the available actor names from the current world.
 
 ## The visit client
 
@@ -195,8 +213,19 @@ The visit client exposes:
 - `visit.delete(target, payload, options?)`
 - `visit.del(target, payload, options?)`
 - `visit.using(transport)`
+- `visit.as(actor)`
 
 `visit.transport` also reflects the current transport.
+
+`visit.as(actor)` mirrors `request.as(actor)`, so Inertia contract trials can use world actor aliases too:
+
+```js
+await world.use('billing-dashboard')
+
+const page = await visit.as('owner')('/billing')
+
+expect(page).toBeInertiaPage('billing/show')
+```
 
 ## What `visit()` adds
 

--- a/docs/sounding/testing-inertia.md
+++ b/docs/sounding/testing-inertia.md
@@ -32,6 +32,29 @@ test('pricing page returns the correct component and props', async ({
 })
 ```
 
+## Authenticated visits
+
+Use `visit.as(actor)` when an Inertia page contract depends on the current actor.
+
+```js
+import { test } from 'sounding'
+
+test('creator dashboard returns invoice props', async ({
+  world,
+  visit,
+  expect
+}) => {
+  await world.use('creator-dashboard')
+
+  const page = await visit.as('owner')('/dashboard')
+
+  expect(page).toBeInertiaPage('dashboard/index')
+  expect(page).toHaveProp('invoices')
+})
+```
+
+`visit.as()` uses the same actor resolution as `request.as()`, including aliases from the current world and email strings that match the configured auth model.
+
 ## Validation and redirects
 
 ```js


### PR DESCRIPTION
Resolves sailscastshq/sounding#28

## Summary
- document direct world actor aliases for request.as()
- document email-string actor resolution
- add visit.as() examples for authenticated Inertia contract tests

## Validation
- npm run lint
- npm run build