### PR TITLE
Document trial world options

### DIFF
--- a/docs/sounding/auth-and-actors.md
+++ b/docs/sounding/auth-and-actors.md
@@ -39,28 +39,32 @@ Then the trial can reference them clearly:
 
 ## `request.as(actor)`
 
-When a request trial needs to act as an authenticated actor, use `request.as(actor)`.
+When a request trial needs to act as an authenticated actor, load a world on the test declaration and use `request.as(actor)`.
 
 ```js
-test('subscriber can read the issue', async ({ sails, expect }) => {
-  const current = await sails.sounding.world.use('issue-access')
+test(
+  'subscriber can read the issue',
+  { world: 'issue-access' },
+  async ({ world, request, expect }) => {
+    const response = await request
+      .as('subscriber')
+      .get(`/i/${world.current.issues.gatedIssue.slug}`)
 
-  const response = await sails.sounding.request
-    .as(current.users.subscriber)
-    .get(`/i/${current.issues.gatedIssue.slug}`)
-
-  expect(response).toHaveStatus(200)
-})
+    expect(response).toHaveStatus(200)
+  }
+)
 ```
 
-You can also pass the actor alias directly after loading the world:
+That keeps the scenario name in the trial declaration and lets the request body read like product behavior.
+
+You can also pass the resolved actor object directly:
 
 ```js
 test('subscriber can read the issue', async ({ world, request, expect }) => {
   const current = await world.use('issue-access')
 
   const response = await request
-    .as('subscriber')
+    .as(current.users.subscriber)
     .get(`/i/${current.issues.gatedIssue.slug}`)
 
   expect(response).toHaveStatus(200)

--- a/docs/sounding/browser-testing.md
+++ b/docs/sounding/browser-testing.md
@@ -24,9 +24,8 @@ import { test } from 'sounding'
 
 test(
   'subscriber can finish a members-only issue',
-  { browser: true },
-  async ({ sails, page, login, expect }) => {
-    await sails.sounding.world.use('issue-access')
+  { browser: true, world: 'issue-access' },
+  async ({ page, login, expect }) => {
     await login.as('subscriber', page)
 
     await page.goto('/issues/the-nerve-to-build')
@@ -38,7 +37,7 @@ test(
 
 ## Load a world before browser setup
 
-Browser trials become harder to maintain when they carry too much setup. Use `sails.sounding.world.use()` to start from a named business situation.
+Browser trials become harder to maintain when they carry too much setup. Use the trial's `world` option to start from a named business situation before the browser flow begins.
 
 ## Run the same flows across browser projects
 

--- a/docs/sounding/getting-started.md
+++ b/docs/sounding/getting-started.md
@@ -124,9 +124,8 @@ import { test } from 'sounding'
 
 test(
   'subscriber can read a members-only issue',
-  { browser: true },
-  async ({ sails, page, login, expect }) => {
-    await sails.sounding.world.use('issue-access')
+  { browser: true, world: 'issue-access' },
+  async ({ page, login, expect }) => {
     await login.as('subscriber', page)
 
     await page.goto('/issues/the-nerve-to-build')
@@ -168,15 +167,17 @@ export default defineScenario('issue-access', async ({ create }) => {
 Then the trial can read from the product situation directly:
 
 ```js
-test('subscriber can read the issue', async ({ sails, expect }) => {
-  const current = await sails.sounding.world.use('issue-access')
+test(
+  'subscriber can read the issue',
+  { world: 'issue-access' },
+  async ({ world, request, expect }) => {
+    const response = await request
+      .as('subscriber')
+      .get(`/i/${world.current.issues.gatedIssue.slug}`)
 
-  const response = await sails.sounding.request
-    .as(current.users.subscriber)
-    .get(`/i/${current.issues.gatedIssue.slug}`)
-
-  expect(response).toHaveStatus(200)
-})
+    expect(response).toHaveStatus(200)
+  }
+)
 ```
 
 Use worlds when several trials need the same business state.

--- a/docs/sounding/how-it-works.md
+++ b/docs/sounding/how-it-works.md
@@ -41,7 +41,13 @@ Tests keep the same helper, request, and browser APIs regardless of the selected
 
 ### 3. Sounding loads a world
 
-Sounding loads a named world from `tests/factories` and `tests/scenarios`.
+Sounding loads a named world from `tests/factories` and `tests/scenarios` when a trial declares one:
+
+```js
+test('subscriber can read the issue', { world: 'issue-access' }, async () => {
+  // world.current is ready here
+})
+```
 
 If you want those layers in detail, read [Factories](/sounding/factories), [Scenarios](/sounding/scenarios), and [Worlds](/sounding/worlds).
 

--- a/docs/sounding/request-clients.md
+++ b/docs/sounding/request-clients.md
@@ -154,12 +154,19 @@ This is how a single trial can keep most requests fast and virtual while opting 
 const response = await request.as(current.users.publisher).get('/dashboard')
 ```
 
-When a named world has been loaded, you can pass the actor alias directly:
+When a named world has been loaded, you can pass the actor alias directly.
+The most concise form is to load the world from the test declaration:
 
 ```js
-await world.use('publisher-dashboard')
+test(
+  'publisher can see the dashboard',
+  { world: 'publisher-dashboard' },
+  async ({ request, expect }) => {
+    const response = await request.as('publisher').get('/dashboard')
 
-const response = await request.as('publisher').get('/dashboard')
+    expect(response).toHaveStatus(200)
+  }
+)
 ```
 
 You can also pass an email address when the app's configured auth model can resolve it:
@@ -220,11 +227,15 @@ The visit client exposes:
 `visit.as(actor)` mirrors `request.as(actor)`, so Inertia contract trials can use world actor aliases too:
 
 ```js
-await world.use('billing-dashboard')
+test(
+  'owner can see billing',
+  { world: 'billing-dashboard' },
+  async ({ visit, expect }) => {
+    const page = await visit.as('owner')('/billing')
 
-const page = await visit.as('owner')('/billing')
-
-expect(page).toBeInertiaPage('billing/show')
+    expect(page).toBeInertiaPage('billing/show')
+  }
+)
 ```
 
 ## What `visit()` adds

--- a/docs/sounding/scenarios.md
+++ b/docs/sounding/scenarios.md
@@ -165,11 +165,41 @@ It does **not** exist on top-level `world.create()` or `world.build()`.
 
 ## Loading a scenario in a trial
 
-Trials usually load a scenario through the world engine:
+When a trial has one obvious business situation, put the world on the test declaration:
 
 ```js
 import { test } from 'sounding'
 
+test(
+  'subscriber can read a members-only issue',
+  { world: 'issue-access' },
+  async ({ world, request, expect }) => {
+    const response = await request
+      .as('subscriber')
+      .get(`/i/${world.current.issues.gatedIssue.slug}`)
+
+    expect(response).toHaveStatus(200)
+  }
+)
+```
+
+Sounding loads that scenario before the handler runs, so aliases such as `request.as('subscriber')`, `visit.as('owner')`, and `sockets.as('player')` can read from `world.current`.
+
+If a scenario needs a small input, pass `context`:
+
+```js
+test(
+  'subscriber can read a regional issue',
+  { world: { name: 'issue-access', context: { region: 'lagos' } } },
+  async ({ world, expect }) => {
+    expect(world.current.region).toBe('lagos')
+  }
+)
+```
+
+Manual loading is still available when a trial needs dynamic setup or more than one world:
+
+```js
 test('subscriber can read a members-only issue', async ({ world, expect }) => {
   const current = await world.use('issue-access')
 

--- a/docs/sounding/testing-inertia.md
+++ b/docs/sounding/testing-inertia.md
@@ -39,18 +39,16 @@ Use `visit.as(actor)` when an Inertia page contract depends on the current actor
 ```js
 import { test } from 'sounding'
 
-test('creator dashboard returns invoice props', async ({
-  world,
-  visit,
-  expect
-}) => {
-  await world.use('creator-dashboard')
+test(
+  'creator dashboard returns invoice props',
+  { world: 'creator-dashboard' },
+  async ({ visit, expect }) => {
+    const page = await visit.as('owner')('/dashboard')
 
-  const page = await visit.as('owner')('/dashboard')
-
-  expect(page).toBeInertiaPage('dashboard/index')
-  expect(page).toHaveProp('invoices')
-})
+    expect(page).toBeInertiaPage('dashboard/index')
+    expect(page).toHaveProp('invoices')
+  }
+)
 ```
 
 `visit.as()` uses the same actor resolution as `request.as()`, including aliases from the current world and email strings that match the configured auth model.

--- a/docs/sounding/testing-json-apis.md
+++ b/docs/sounding/testing-json-apis.md
@@ -67,18 +67,18 @@ test('mix virtual speed with one real-http check', async ({
 ```js
 import { test } from 'sounding'
 
-test('publisher can create an issue', async ({ sails, expect }) => {
-  const current = await sails.sounding.world.use('publisher-team')
-
-  const response = await sails.sounding.request
-    .as(current.users.publisher)
-    .post('/api/issues', {
+test(
+  'publisher can create an issue',
+  { world: 'publisher-team' },
+  async ({ request, expect }) => {
+    const response = await request.as('publisher').post('/api/issues', {
       title: 'New issue'
     })
 
-  expect(response).toHaveStatus(201)
-  expect(response).toHaveJsonPath('title', 'New issue')
-})
+    expect(response).toHaveStatus(201)
+    expect(response).toHaveJsonPath('title', 'New issue')
+  }
+)
 ```
 
 When the app's real password login action matters, use the first-party request auth helper instead of inventing session setup by hand:

--- a/docs/sounding/trial-context.md
+++ b/docs/sounding/trial-context.md
@@ -149,7 +149,21 @@ await login.as('subscriber', page)
 
 A convenience alias for `sails.sounding.world`.
 
-Use it to load named business situations:
+Prefer the trial option when the test has one clear business situation:
+
+```js
+test(
+  'subscriber can read the issue',
+  { world: 'issue-access' },
+  async ({ request }) => {
+    const response = await request.as('subscriber').get('/issues/first')
+  }
+)
+```
+
+Inside the handler, the resolved world is available at `world.current`.
+
+Use manual loading when the setup needs to be dynamic:
 
 ```js
 const current = await world.use('issue-access')

--- a/docs/sounding/websocket-testing.md
+++ b/docs/sounding/websocket-testing.md
@@ -180,10 +180,9 @@ Use `sockets.as(actor).connect()` when the socket should start as an actor from 
 ```js
 test(
   'the active player can ask for their private match state',
-  { socket: true },
-  async ({ world, sockets, expect }) => {
-    const current = await world.use('match-in-progress')
-    const player = await sockets.as(current.users.playerOne).connect()
+  { socket: true, world: 'match-in-progress' },
+  async ({ sockets, expect }) => {
+    const player = await sockets.as('playerOne').connect()
 
     const response = await player.get('/api/matches/current/private-state')
 
@@ -195,7 +194,6 @@ test(
 If you pass a string, Sounding looks in the current world using your auth collection.
 
 ```js
-const current = await world.use('match-in-progress')
 const player = await sockets.as('playerOne').connect()
 ```
 


### PR DESCRIPTION
Resolves sailscastshq/sounding#27

## Summary
- document the world trial option as the default single-scenario path
- update request, visit, browser, JSON API, and websocket examples to use declaration-level worlds
- keep manual world.use() documented for dynamic or multi-world setup

## Validation
- npm run lint
- npm run build