### PR TITLE
docs: update Sounding Inertia assertions

### DIFF
--- a/docs/sounding/testing-inertia.md
+++ b/docs/sounding/testing-inertia.md
@@ -27,8 +27,8 @@ test('pricing page returns the correct component and props', async ({
   const page = await visit('/pricing')
 
   expect(page).toBeInertiaPage('billing/pricing')
-  expect(page).toHaveProp('plans')
-  expect(page).toHaveProp('auth.user', null)
+  expect(page).toHaveInertiaProp('plans')
+  expect(page).toHaveInertiaProp('auth.user', null)
 })
 ```
 
@@ -46,7 +46,7 @@ test(
     const page = await visit.as('owner')('/dashboard')
 
     expect(page).toBeInertiaPage('dashboard/index')
-    expect(page).toHaveProp('invoices')
+    expect(page).toHaveInertiaProp('invoices')
   }
 )
 ```
@@ -68,8 +68,7 @@ test('sign up returns validation errors for invalid input', async ({
   })
 
   expect(page).toBeInertiaPage('auth/signup')
-  expect(page).toHaveValidationError('fullName')
-  expect(page).toHaveValidationError('emailAddress')
+  expect(page).toHaveInertiaErrors(['fullName', 'emailAddress'])
 })
 ```
 
@@ -88,7 +87,12 @@ test('dashboard can request only notifications', async ({ visit, expect }) => {
   })
 
   expect(page).toBeInertiaPage('dashboard/index')
-  expect(page).toHaveProp('notifications')
+  expect(page).toHaveInertiaPartialReload({
+    component: 'dashboard/index',
+    only: ['notifications'],
+    reset: ['sidebar']
+  })
+  expect(page).toHaveOnlyInertiaProps(['notifications'])
 })
 ```
 
@@ -97,8 +101,15 @@ Under the hood, Sounding should translate that into the same Inertia headers the
 ## Useful Inertia matchers
 
 - `toBeInertiaPage()`
-- `toHaveProp()`
-- `toMatchProp()`
-- `toHaveSharedProp()`
-- `toHaveValidationError()`
+- `toHaveInertiaProp()`
+- `toHaveInertiaProps()`
+- `toHaveInertiaPropCount()`
+- `toHaveOnlyInertiaProps()`
+- `toMatchInertiaProp()`
+- `toHaveSharedInertiaProp()`
+- `toHaveSharedInertiaProps()`
+- `toHaveInertiaError()`
+- `toHaveInertiaErrors()`
+- `toHaveNoInertiaErrors()`
+- `toHaveInertiaPartialReload()`
 - `toRedirectTo()`

--- a/docs/sounding/trial-context.md
+++ b/docs/sounding/trial-context.md
@@ -72,7 +72,7 @@ It covers:
 
 - generic assertions like `toBe()` and `toEqual()`
 - request assertions like `toHaveStatus()` and `toRedirectTo()`
-- Inertia assertions like `toBeInertiaPage()` and `toHaveProp()`
+- Inertia assertions like `toBeInertiaPage()` and `toHaveInertiaProp()`
 - Playwright assertions when the trial is browser-capable
 
 Failed response assertions include the Sails-shaped context Sounding has available: request method, target, transport, response status, headers, and a body excerpt. For the full response body while debugging, run with `SOUNDING_DIAGNOSTICS=verbose`.

--- a/docs/sounding/trials.md
+++ b/docs/sounding/trials.md
@@ -141,7 +141,7 @@ test('pricing returns the right page props', async ({ visit, expect }) => {
   const page = await visit('/pricing')
 
   expect(page).toBeInertiaPage('billing/pricing')
-  expect(page).toHaveProp('plans')
+  expect(page).toHaveInertiaProp('plans')
 })
 ```
 

--- a/docs/sounding/worlds.md
+++ b/docs/sounding/worlds.md
@@ -226,7 +226,7 @@ test('guest sees the paywall state', async ({ sails, visit, expect }) => {
   const current = await sails.sounding.world.use('issue-access')
   const page = await visit(`/i/${current.issues.gatedIssue.slug}`)
 
-  expect(page).toHaveProp('hasSubscription', false)
+  expect(page).toHaveInertiaProp('hasSubscription', false)
 })
 ```
 


### PR DESCRIPTION
## Summary
- Update Sounding Inertia docs to use the explicit matcher API.
- Remove references to the old generic Inertia matcher names.
- Document partial reload assertions with `toHaveInertiaPartialReload()` and `toHaveOnlyInertiaProps()`.

## Checks
- npm run lint
- npm run build
- git diff --check

Closes sailscastshq/sounding#32