### PR TITLE
docs: document Sounding browser failure artifacts

### DIFF
--- a/docs/sounding/browser-testing.md
+++ b/docs/sounding/browser-testing.md
@@ -35,6 +35,156 @@ test(
 )
 ```
 
+## Failure artifacts
+
+Browser failures are the hardest failures to understand from a stack trace alone, so Sounding captures the most useful evidence automatically.
+
+When a `{ browser: true }` trial fails, Sounding keeps:
+
+- the current page URL
+- a `current-url.txt` file
+- a full-page `screenshot.png`
+
+The files live under:
+
+```txt
+.tmp/sounding/artifacts/<trial-name>/<browser-project>/
+```
+
+For example, this trial:
+
+```js
+test(
+  'subscriber can finish a members-only issue',
+  { browser: true },
+  async ({ page }) => {
+    await page.goto('/issues/the-nerve-to-build')
+
+    // ...
+  }
+)
+```
+
+would write failure evidence to:
+
+```txt
+.tmp/sounding/artifacts/subscriber-can-finish-a-members-only-issue/desktop/
+```
+
+Sounding also appends the current URL and artifact paths to the thrown error:
+
+```txt
+Sounding browser artifacts:
+- URL: http://127.0.0.1:3333/issues/the-nerve-to-build
+- current URL file: .tmp/sounding/artifacts/subscriber-can-finish-a-members-only-issue/desktop/current-url.txt
+- screenshot: .tmp/sounding/artifacts/subscriber-can-finish-a-members-only-issue/desktop/screenshot.png
+```
+
+That keeps the assertion failure as the main message while still pointing you at the browser evidence.
+
+## Capture traces and videos
+
+Screenshots and URLs are cheap enough to keep on by default. Traces and videos are heavier, so Sounding makes them opt-in.
+
+Turn them on for one trial when a browser flow is flaky or timing-sensitive:
+
+```js
+test(
+  'checkout keeps the cart after refresh',
+  {
+    browser: {
+      artifacts: {
+        trace: true,
+        video: true
+      }
+    }
+  },
+  async ({ page, expect }) => {
+    await page.goto('/checkout')
+    await page.reload()
+
+    await expect(page.getByText('Your cart')).toBeVisible()
+  }
+)
+```
+
+The failure directory will then include:
+
+```txt
+current-url.txt
+screenshot.png
+trace.zip
+video.webm
+```
+
+Use trace when you need to inspect network requests, DOM snapshots, console output, or the timing between browser actions.
+Use video when motion, redirects, focus changes, or transient UI states are the thing you need to see.
+
+## Artifact modes
+
+Artifact settings accept booleans for the common path:
+
+- `true` keeps the artifact when the trial fails
+- `false` disables that artifact
+
+They also accept explicit modes:
+
+- `off` disables the artifact
+- `on-failure` keeps the artifact only for failed trials
+- `on` keeps the artifact for successful trials too
+
+Most apps should use booleans in day-to-day tests:
+
+```js
+test(
+  'publisher can update an issue cover',
+  {
+    browser: {
+      artifacts: {
+        trace: true
+      }
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/publisher/issues/42/edit')
+  }
+)
+```
+
+Use `on` when you are deliberately collecting evidence from a passing browser flow:
+
+```js
+test(
+  'launch demo recording stays stable',
+  {
+    browser: {
+      artifacts: {
+        video: 'on'
+      }
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/demo')
+  }
+)
+```
+
+## Disable artifacts for a trial
+
+If a smoke trial is intentionally tiny and you do not want files, turn artifacts off for that trial:
+
+```js
+test(
+  'health page responds',
+  { browser: { artifacts: false } },
+  async ({ page }) => {
+    await page.goto('/health')
+  }
+)
+```
+
+This is mainly useful for very large suites or trials that intentionally fail while exercising error boundaries.
+
 ## Load a world before browser setup
 
 Browser trials become harder to maintain when they carry too much setup. Use the trial's `world` option to start from a named business situation before the browser flow begins.

--- a/docs/sounding/configuration.md
+++ b/docs/sounding/configuration.md
@@ -78,6 +78,11 @@ Sounding defaults to:
 - `sockets.transports = ['websocket']`
 - `sockets.path = '/socket.io'`
 - `browser.projects = ['desktop']`
+- `browser.artifacts.outputDir = '.tmp/sounding/artifacts'`
+- `browser.artifacts.screenshot = true`
+- `browser.artifacts.currentUrl = true`
+- `browser.artifacts.trace = false`
+- `browser.artifacts.video = false`
 
 These are the starting defaults for a new Sounding setup.
 
@@ -249,6 +254,153 @@ Most Sounding trials should still be written in terms of:
 - Playwright flows
 
 not raw adapter details.
+
+## `browser`
+
+The `browser` section controls Playwright-backed browser trials.
+
+The default project is `desktop`, and browser support is enabled by default:
+
+```js
+module.exports.sounding = {
+  browser: {
+    enabled: true,
+    type: 'chromium',
+    projects: ['desktop'],
+    defaultProject: 'desktop'
+  }
+}
+```
+
+Most apps can leave this alone and opt into browser behavior trial by trial:
+
+```js
+test(
+  'subscriber can read a gated issue',
+  { browser: true },
+  async ({ page }) => {
+    await page.goto('/issues/the-nerve-to-build')
+  }
+)
+```
+
+### `artifacts`
+
+The `browser.artifacts` section controls what Sounding keeps when browser trials fail.
+
+Defaults:
+
+```js
+module.exports.sounding = {
+  browser: {
+    artifacts: {
+      outputDir: '.tmp/sounding/artifacts',
+      screenshot: true,
+      currentUrl: true,
+      trace: false,
+      video: false
+    }
+  }
+}
+```
+
+By default, failed browser trials keep the current URL and a full-page screenshot.
+The files are written under:
+
+```txt
+.tmp/sounding/artifacts/<trial-name>/<browser-project>/
+```
+
+For example:
+
+```txt
+.tmp/sounding/artifacts/subscriber-can-read-a-gated-issue/desktop/current-url.txt
+.tmp/sounding/artifacts/subscriber-can-read-a-gated-issue/desktop/screenshot.png
+```
+
+### Artifact settings
+
+Each artifact setting accepts a boolean:
+
+- `true` keeps the artifact when the trial fails
+- `false` disables the artifact
+
+For trace and video, that gives a concise opt-in:
+
+```js
+module.exports.sounding = {
+  browser: {
+    artifacts: {
+      trace: true,
+      video: true
+    }
+  }
+}
+```
+
+Artifact settings also accept explicit modes:
+
+- `off`
+- `on-failure`
+- `on`
+
+Use `on` when you want evidence from successful browser trials too:
+
+```js
+module.exports.sounding = {
+  browser: {
+    artifacts: {
+      trace: 'on'
+    }
+  }
+}
+```
+
+### Per-trial artifact overrides
+
+A trial can override artifact settings without changing the app-wide defaults:
+
+```js
+test(
+  'checkout keeps the cart after refresh',
+  {
+    browser: {
+      artifacts: {
+        trace: true,
+        video: true
+      }
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/checkout')
+  }
+)
+```
+
+Use `artifacts: false` as a trial-level off switch:
+
+```js
+test(
+  'fast browser smoke test',
+  { browser: { artifacts: false } },
+  async ({ page }) => {
+    await page.goto('/health')
+  }
+)
+```
+
+### Artifact cleanup
+
+Sounding writes browser artifacts to `.tmp/sounding/artifacts` by default, which keeps them out of source control in typical Sails apps.
+
+Clean them whenever you want a fresh debug directory:
+
+```sh
+rm -rf .tmp/sounding/artifacts
+```
+
+If your CI uploads artifacts, upload `.tmp/sounding/artifacts` after failed test runs.
+If your CI workspace is persistent, add a cleanup step before or after the test command.
 
 ## Diagnostics
 

--- a/docs/sounding/how-it-works.md
+++ b/docs/sounding/how-it-works.md
@@ -104,6 +104,29 @@ When a trial fails, the output should identify:
 - which request or browser step failed
 - which part of app state was relevant
 
+For browser-capable trials, Sounding captures failure artifacts before teardown closes the Playwright context.
+That timing matters because the page still knows its current URL, can still take a screenshot, and can still flush trace or video output.
+
+By default, failed browser trials keep:
+
+- the current URL
+- `current-url.txt`
+- `screenshot.png`
+
+When enabled, they can also keep:
+
+- `trace.zip`
+- `video.webm`
+
+Those files live under:
+
+```txt
+.tmp/sounding/artifacts/<trial-name>/<browser-project>/
+```
+
+The original error remains the main failure, and Sounding appends the artifact paths beneath it.
+That means an assertion still reads like an assertion failure, but the terminal output also points to the browser evidence.
+
 ## As a hook, Sounding can access
 
 As a Sails hook, Sounding can understand and expose:


### PR DESCRIPTION
Closes sailscastshq/sounding#39

## Summary
- document default browser failure artifacts for Sounding
- explain trace and video opt-ins, artifact modes, per-trial overrides, and cleanup
- describe why artifacts are captured before browser teardown

## Verification
- npm run lint
- npm run build
- git diff --check