### PR TITLE
docs: document Sounding browser projects

### DIFF
--- a/docs/sounding/browser-testing.md
+++ b/docs/sounding/browser-testing.md
@@ -191,11 +191,75 @@ Browser trials become harder to maintain when they carry too much setup. Use the
 
 ## Run the same flows across browser projects
 
-Run the same core flows across:
+Run the same core flows across named browser projects:
 
 - desktop
 - mobile
+- WebKit or Firefox when the browser engine matters
 - dark mode when relevant
+
+The default project is `desktop`, so most browser trials can stay terse:
+
+```js
+test(
+  'subscriber can read a gated issue',
+  { browser: true },
+  async ({ page }) => {
+    await page.goto('/issues/the-nerve-to-build')
+  }
+)
+```
+
+When a trial needs a specific project, use the string shorthand:
+
+```js
+test(
+  'mobile navigation opens the account menu',
+  { browser: 'mobile' },
+  async ({ page }) => {
+    await page.goto('/dashboard')
+  }
+)
+```
+
+Or use the object form when the trial also needs artifacts or direct browser overrides:
+
+```js
+test(
+  'checkout works in WebKit',
+  {
+    browser: {
+      project: 'safari',
+      artifacts: {
+        trace: true
+      }
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/checkout')
+  }
+)
+```
+
+Define the projects in `config/sounding.js`:
+
+```js
+module.exports.sounding = {
+  browser: {
+    projects: {
+      desktop: {},
+      mobile: {
+        device: 'iPhone 13'
+      },
+      safari: {
+        type: 'webkit'
+      }
+    }
+  }
+}
+```
+
+If a trial references a project that is not configured, Sounding fails before opening the browser and lists the available project names.
 
 ## Choose the right layer
 

--- a/docs/sounding/configuration.md
+++ b/docs/sounding/configuration.md
@@ -284,6 +284,101 @@ test(
 )
 ```
 
+Select a configured project with a string:
+
+```js
+test('mobile navigation works', { browser: 'mobile' }, async ({ page }) => {
+  await page.goto('/dashboard')
+})
+```
+
+Or use the object form when you also need trial-level browser options:
+
+```js
+test(
+  'checkout works in WebKit',
+  {
+    browser: {
+      project: 'safari'
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/checkout')
+  }
+)
+```
+
+### `projects`
+
+The simplest project list is still an array of names:
+
+```js
+module.exports.sounding = {
+  browser: {
+    projects: ['desktop', 'mobile'],
+    defaultProject: 'desktop'
+  }
+}
+```
+
+Use named project objects when a project needs its own Playwright device, browser type, viewport, context options, or launch options:
+
+```js
+module.exports.sounding = {
+  browser: {
+    projects: {
+      desktop: {},
+      mobile: {
+        device: 'iPhone 13'
+      },
+      safari: {
+        type: 'webkit',
+        viewport: {
+          width: 1280,
+          height: 720
+        },
+        contextOptions: {
+          colorScheme: 'dark'
+        },
+        launchOptions: {
+          slowMo: 25
+        }
+      }
+    },
+    defaultProject: 'desktop'
+  }
+}
+```
+
+Supported project fields:
+
+- `type` - Playwright browser type: `chromium`, `firefox`, or `webkit`
+- `device` - Playwright device name, such as `iPhone 13`
+- `viewport` - `{ width, height }`
+- `contextOptions` - options passed to `browser.newContext()`
+- `launchOptions` - options merged into the browser launch call
+
+The project-specific options are merged before per-trial overrides, so a trial can still fine-tune one run:
+
+```js
+test(
+  'publisher can edit on mobile dark mode',
+  {
+    browser: {
+      project: 'mobile',
+      contextOptions: {
+        colorScheme: 'dark'
+      }
+    }
+  },
+  async ({ page }) => {
+    await page.goto('/publisher/issues/42/edit')
+  }
+)
+```
+
+If a trial names a project that is not configured, Sounding fails with the requested project and the list of available projects.
+
 ### `artifacts`
 
 The `browser.artifacts` section controls what Sounding keeps when browser trials fail.


### PR DESCRIPTION
Closes sailscastshq/sounding#40

## Summary
- Document the new Sounding browser project configuration shape.
- Show the `browser: "mobile"` shorthand and explicit `{ browser: { project } }` selection.
- Cover device, viewport, context option, launch option, and artifact project path behavior.

## Verification
- `npm run lint`
- `npm run build`
- `git diff --check`