### PR TITLE
docs: document sounding pretty reporter

### DIFF
--- a/docs/sounding/configuration.md
+++ b/docs/sounding/configuration.md
@@ -501,13 +501,30 @@ If your CI workspace is persistent, add a cleanup step before or after the test 
 
 Sounding keeps failure diagnostics concise by default. Response assertion failures show the request, response status, key headers, and a short body excerpt.
 
-When a failing response needs more inspection, set:
+When a failing response needs more inspection through the Sounding CLI, run:
+
+```sh
+npx sounding test --verbose
+```
+
+That expands response excerpts and shows full stacks without changing
+`config/sounding.js`.
+
+If you are calling Node or npm directly, set:
 
 ```sh
 SOUNDING_DIAGNOSTICS=verbose npm test
 ```
 
-That expands response excerpts in assertion failures without changing `config/sounding.js`.
+When formatted output hides something important, use raw error output:
+
+```sh
+npx sounding test --raw-error
+SOUNDING_RAW=1 npm test
+```
+
+Raw mode prints the original Node test error, its `cause`, Sounding metadata, and
+the primary frame payload after the readable failure.
 
 ## `sockets`
 

--- a/docs/sounding/getting-started.md
+++ b/docs/sounding/getting-started.md
@@ -201,7 +201,7 @@ PASS  tests/arch.test.js
 
 PASS  Tests: 2 passed, 2 total
 
-Duration: 94ms
+      Duration: 94ms
 ```
 
 When a trial fails, Sounding keeps the first application frame in view and
@@ -231,7 +231,7 @@ FAIL  tests/billing.test.js
 
 FAIL  Tests: 1 failed, 1 total
 
-Duration: 70ms
+      Duration: 70ms
 ```
 
 Use `--verbose` when you want full stacks and expanded diagnostics:

--- a/docs/sounding/getting-started.md
+++ b/docs/sounding/getting-started.md
@@ -200,6 +200,7 @@ PASS  tests/arch.test.js
   ✓ JSON paths read like product facts    0ms
 
 PASS  Tests: 2 passed, 2 total
+
 Duration: 94ms
 ```
 
@@ -229,6 +230,7 @@ FAIL  tests/billing.test.js
   -> 25    expect(response).toHaveStatus(200)
 
 FAIL  Tests: 1 failed, 1 total
+
 Duration: 70ms
 ```
 

--- a/docs/sounding/getting-started.md
+++ b/docs/sounding/getting-started.md
@@ -185,7 +185,65 @@ Use worlds when several trials need the same business state.
 ## 7. Run the suite
 
 ```bash
-npm run test
+npx sounding test
+```
+
+Most generated apps wire `npm test` to the same command.
+
+By default, `sounding test` uses Sounding's readable reporter. Small passing
+runs list the trial names and end with a compact summary:
+
+```txt
+PASS  tests/arch.test.js
+
+  ✓ request helpers stay response-shaped  1ms
+  ✓ JSON paths read like product facts    0ms
+
+PASS  Tests: 2 passed, 2 total
+Duration: 94ms
+```
+
+When a trial fails, Sounding keeps the first application frame in view and
+groups the context that usually explains the behavior:
+
+```txt
+FAIL  tests/billing.test.js
+
+  × creator sees billing summary
+
+  Expected response status 200, received 500.
+
+  Request
+    GET /api/billing/summary (http) -> http://localhost:1337/api/billing/summary
+    headers: accept: application/json
+
+  Response
+    500 Server Error
+    headers: content-type: application/json
+
+  Body
+    {"message":"boom"}
+
+  at tests/billing.test.js:25
+
+  -> 25    expect(response).toHaveStatus(200)
+
+FAIL  Tests: 1 failed, 1 total
+Duration: 70ms
+```
+
+Use `--verbose` when you want full stacks and expanded diagnostics:
+
+```bash
+npx sounding test --verbose
+```
+
+Use `--raw-error` when formatted output hides something you need. Raw mode keeps
+the readable failure first, then prints the original Node test error, its
+`cause`, Sounding metadata, and the primary frame payload:
+
+```bash
+npx sounding test --raw-error
 ```
 
 ## What to add next

--- a/docs/sounding/how-it-works.md
+++ b/docs/sounding/how-it-works.md
@@ -124,8 +124,16 @@ Those files live under:
 .tmp/sounding/artifacts/<trial-name>/<browser-project>/
 ```
 
-The original error remains the main failure, and Sounding appends the artifact paths beneath it.
-That means an assertion still reads like an assertion failure, but the terminal output also points to the browser evidence.
+The reporter parses Node test events into a structured Sounding failure before
+rendering terminal output. That lets Sounding spotlight the first application
+frame, group metadata like World, Request, Response, Body, and Browser, and keep
+browser evidence beside the assertion that failed.
+
+The formatted output is the default path because it is optimized for debugging
+the behavior. When you need the unformatted Node error object, run
+`sounding test --raw-error` or set `SOUNDING_RAW=1`. Raw mode prints the original
+Node wrapper error, its `cause`, Sounding metadata, and the selected primary
+frame after the readable failure.
 
 ## As a hook, Sounding can access
 

--- a/docs/sounding/how-it-works.md
+++ b/docs/sounding/how-it-works.md
@@ -124,10 +124,11 @@ Those files live under:
 .tmp/sounding/artifacts/<trial-name>/<browser-project>/
 ```
 
-The reporter parses Node test events into a structured Sounding failure before
-rendering terminal output. That lets Sounding spotlight the first application
-frame, group metadata like World, Request, Response, Body, and Browser, and keep
-browser evidence beside the assertion that failed.
+The reporter parses Node test events into a structured `SoundingTrial` before
+rendering terminal output. Passed trials stay lightweight, while failed trials
+carry a richer `SoundingFailure` payload with the message, cause chain, primary
+frame, code frame, raw error data, and grouped metadata like World, Request,
+Response, Body, and Browser.
 
 The formatted output is the default path because it is optimized for debugging
 the behavior. When you need the unformatted Node error object, run

--- a/docs/sounding/request-clients.md
+++ b/docs/sounding/request-clients.md
@@ -59,21 +59,41 @@ const response = await request.get('/health')
 expect(response).toHaveStatus(200)
 ```
 
-If the app returned `500`, the failure includes a compact diagnostic block:
+If the app returned `500`, the default reporter groups the useful context:
 
 ```txt
-Expected response status 200, received 500.
+FAIL  tests/billing.test.js
 
-Sounding response diagnostics:
-- Request: GET /health (virtual)
-- Response: 500 Server Error
-- Headers: content-type: application/json, x-request-id: req_123
-- Body: {"message":"Database unavailable","detail":"Connection pool exhausted"}
+  × creator sees billing summary
+
+  Expected response status 200, received 500.
+
+  Request
+    GET /health (virtual)
+
+  Response
+    500 Server Error
+    headers: content-type: application/json, x-request-id: req_123
+
+  Body
+    {"message":"Database unavailable","detail":"Connection pool exhausted"}
+
+  at tests/health.test.js:6
+
+  -> 6     expect(response).toHaveStatus(200)
 ```
 
-The same response diagnostics are used by request, visit, Inertia, validation, and socket request assertions when the response shape is available.
+The same response diagnostics are used by request, visit, Inertia, validation,
+and socket request assertions when the response shape is available.
 
-By default, Sounding keeps the body excerpt concise. When you need the full response body while debugging a failure, run the trial with:
+By default, Sounding keeps the body excerpt concise. When you need full response
+excerpts and full stacks while debugging, run the trial with:
+
+```sh
+npx sounding test --verbose
+```
+
+If you are calling Node or npm directly, set the diagnostic environment variable:
 
 ```sh
 SOUNDING_DIAGNOSTICS=verbose npm test


### PR DESCRIPTION
## Summary
- document the default `sounding test` reporter in Getting Started
- show pass and fail output examples with grouped failure metadata
- describe `--verbose`, `--raw-error`, and `SOUNDING_RAW=1` debugging modes
- update request diagnostics, how-it-works, and configuration docs for the reporter model

## Validation
- `npm run lint`
- `npm run build`

Closes #89

Related implementation PR: sailscastshq/sounding#89.