### PR TITLE
docs: document Sounding expect-first browser testing

### DIFF
--- a/docs/sounding/browser-testing.md
+++ b/docs/sounding/browser-testing.md
@@ -7,6 +7,9 @@ editLink: true
 
 Sounding uses Playwright for browser-capable trials.
 
+Browser trials expose a Sounding page wrapper. Use `page` or `visit()` for
+actions, and keep assertions under `expect(page)`.
+
 ## `test()` when the browser matters
 
 Use browser trials when the real browser matters:
@@ -25,15 +28,177 @@ import { test } from 'sounding'
 test(
   'subscriber can finish a members-only issue',
   { browser: true, world: 'issue-access' },
-  async ({ page, login, expect }) => {
-    await login.as('subscriber', page)
+  async ({ visit, expect }) => {
+    const page = await visit.as('subscriber')('/issues/the-nerve-to-build')
 
-    await page.goto('/issues/the-nerve-to-build')
-
-    await expect(page.getByText('The rest of the story')).toBeVisible()
+    await expect(page).toSee('The rest of the story')
+    expect(page).toHaveNoSmoke()
   }
 )
 ```
+
+## Expect-first browser assertions
+
+Sounding browser trials keep the action/assertion split clear:
+
+```js
+await page
+  .click('@send-link')
+  .type('email', 'creator@example.com')
+  .press('Send link')
+
+await expect(page).toSee('Check your email')
+await expect(page).not.toSee('Invalid email')
+expect(page).toHavePath('/check-email')
+```
+
+Use these matchers for browser pages:
+
+| API                                       | Purpose                                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------------- |
+| `expect(page).toSee(text)`                | Assert page text exists in the document text.                              |
+| `expect(page).not.toSee(text)`            | Assert page text is absent.                                                |
+| `expect(page).toHaveUrl(url)`             | Assert the full URL, or path when the expected value starts with `/`.      |
+| `expect(page).toHavePath(path)`           | Assert path, query, and hash.                                              |
+| `expect(page).toHaveTitle(title)`         | Assert document title.                                                     |
+| `expect(page).toHaveNoJavascriptErrors()` | Fail on browser runtime errors.                                            |
+| `expect(page).toHaveNoConsoleLogs()`      | Fail on any console message, including `log`, `warn`, `info`, and `error`. |
+| `expect(page).toHaveNoConsoleErrors()`    | Fail only on `console.error`.                                              |
+| `expect(page).toHaveNoSmoke()`            | Fail on JavaScript errors or console errors.                               |
+
+`toHaveNoConsoleLogs()` is intentionally strict. Use it when a flow should leave
+the browser console completely silent. Use `toHaveNoSmoke()` for the normal
+smoke-safety check.
+
+## Browser test handles
+
+Use `@name` for stable browser test handles. This is a Sounding convention:
+the `@` prefix does not mean CSS, id, or JavaScript decorator. It means
+"find this element by its test handle."
+
+Sounding maps `@send-link` to elements with `data-test="send-link"` or
+`data-testid="send-link"`:
+
+```html
+<button data-test="send-link">Email me a link</button>
+```
+
+```js
+await page.click('@send-link')
+```
+
+Prefer test handles when visible copy may change, when UI repeats the same copy,
+or when an element does not have a natural accessible label. Plain text and
+normal CSS selectors still work:
+
+```js
+await page.click('Email me a link')
+await page.click('#send-link')
+await page.fill('input[name="email"]', 'creator@example.com')
+```
+
+## Fluent browser journeys
+
+The Sounding page wrapper provides common browser journey actions:
+
+```js
+await visit('/settings')
+  .as('owner')
+  .inDarkMode()
+  .withGeolocation(6.5244, 3.3792)
+  .click('@avatar')
+  .attach('@avatar-file', 'tests/fixtures/avatar.png')
+  .typeSlowly('@display-name', 'Kelvin')
+  .clear('@tagline')
+  .append('@tagline', 'Building in public')
+  .key('Enter')
+
+await page.withinFrame('@billing-frame', async (frame) => {
+  await frame.fill('@card-number', '4242424242424242')
+  await frame.click('@save-card')
+})
+```
+
+Supported page actions:
+
+| API                                                     | Purpose                                                                   |
+| ------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `page.click(target)`                                    | Click visible text, a test handle, or selector.                           |
+| `page.type(target, value)` / `page.fill(target, value)` | Fill an input by label, test handle, or selector.                         |
+| `page.typeSlowly(target, value)`                        | Type with a small delay for search boxes, masks, and key-driven UI.       |
+| `page.append(target, value)`                            | Add text to the current input value.                                      |
+| `page.clear(target)`                                    | Empty an input.                                                           |
+| `page.press(target, key)`                               | Press a key while focused on a target.                                    |
+| `page.select(target, value)`                            | Select an option.                                                         |
+| `page.check(target)` / `page.uncheck(target)`           | Toggle checkboxes and radios.                                             |
+| `page.hover(target)`                                    | Hover over a target.                                                      |
+| `page.attach(target, files)`                            | Attach one or more files to an upload input.                              |
+| `page.drag(source, target)`                             | Drag one target onto another.                                             |
+| `page.scroll(target)`                                   | Scroll an element into view, or scroll the page with numeric coordinates. |
+| `page.wait(target)`                                     | Wait for a timeout, selector, test handle, or load state.                 |
+| `page.resize(width, height)`                            | Resize the page viewport.                                                 |
+| `page.key(key)` / `page.keys(keys)`                     | Press keyboard shortcuts.                                                 |
+| `page.back()` / `page.forward()` / `page.reload()`      | Navigate browser history or reload.                                       |
+| `page.debug()`                                          | Pause in Playwright when the runtime supports it.                         |
+| `page.withinFrame(target, callback)`                    | Scope actions to an iframe.                                               |
+
+## Setup helpers
+
+Setup helpers run before navigation when chained from `visit('/path')`:
+
+```js
+const page = await visit('/dashboard')
+  .withHost('app.test')
+  .inDarkMode()
+  .withLocale('en-GB')
+  .withTimezone('Africa/Lagos')
+  .withUserAgent('SoundingBot/1.0')
+  .withGeolocation({ latitude: 6.5244, longitude: 3.3792 })
+```
+
+`withHost()` resolves relative visit targets against a specific host:
+
+```js
+await visit('/dashboard').withHost('app.test')
+// http://app.test/dashboard
+
+await visit('/dashboard').withHost('https://creator.example.com')
+// https://creator.example.com/dashboard
+```
+
+Use it for tenant domains, custom host routing, signed-link hosts, or apps that
+branch on the request `Host` header.
+
+Supported setup helpers:
+
+| API                                             | Purpose                                                                |
+| ----------------------------------------------- | ---------------------------------------------------------------------- |
+| `visit('/path').as(actor)`                      | Log in as a world actor before navigation.                             |
+| `visit('/path').on(project)` / `onMobile()`     | Open a named browser project before navigation.                        |
+| `visit('/path').withHost(host)`                 | Resolve relative paths against a specific host.                        |
+| `visit('/path').inDarkMode()` / `inLightMode()` | Emulate color scheme before navigation.                                |
+| `visit('/path').withLocale(locale)`             | Override browser locale signals where possible.                        |
+| `visit('/path').withTimezone(timezone)`         | Store timezone intent for browser metadata and future context support. |
+| `visit('/path').withUserAgent(userAgent)`       | Set the page user-agent header where possible.                         |
+| `visit('/path').withGeolocation(lat, lon)`      | Grant geolocation permission and set coordinates where possible.       |
+
+## Read and capture helpers
+
+Use page helpers when a trial needs browser state or visual evidence:
+
+```js
+page.url()
+await page.text()
+await page.text('@status')
+await page.html()
+await page.content()
+await page.script(() => document.title)
+await page.screenshot('.tmp/page.png')
+await page.screenshotElement('@receipt', '.tmp/receipt.png')
+```
+
+Raw Playwright access remains available through `page.raw` or
+`page.playwrightPage` when a browser flow needs a lower-level escape hatch.
 
 ## Failure artifacts
 
@@ -103,7 +268,8 @@ test(
     await page.goto('/checkout')
     await page.reload()
 
-    await expect(page.getByText('Your cart')).toBeVisible()
+    await expect(page).toSee('Your cart')
+    expect(page).toHaveNoSmoke()
   }
 )
 ```
@@ -177,8 +343,10 @@ If a smoke trial is intentionally tiny and you do not want files, turn artifacts
 test(
   'health page responds',
   { browser: { artifacts: false } },
-  async ({ page }) => {
-    await page.goto('/health')
+  async ({ visit, expect }) => {
+    const page = await visit('/health')
+
+    await expect(page).toSee('OK')
   }
 )
 ```
@@ -204,8 +372,10 @@ The default project is `desktop`, so most browser trials can stay terse:
 test(
   'subscriber can read a gated issue',
   { browser: true },
-  async ({ page }) => {
-    await page.goto('/issues/the-nerve-to-build')
+  async ({ visit, expect }) => {
+    const page = await visit('/issues/the-nerve-to-build')
+
+    await expect(page).toSee('The rest of the story')
   }
 )
 ```
@@ -216,8 +386,11 @@ When a trial needs a specific project, use the string shorthand:
 test(
   'mobile navigation opens the account menu',
   { browser: 'mobile' },
-  async ({ page }) => {
-    await page.goto('/dashboard')
+  async ({ visit, expect }) => {
+    const page = await visit('/dashboard').inDarkMode()
+
+    await page.click('@account-menu')
+    await expect(page).toSee('Settings')
   }
 )
 ```
@@ -235,11 +408,35 @@ test(
       }
     }
   },
-  async ({ page }) => {
-    await page.goto('/checkout')
+  async ({ visit, expect }) => {
+    const page = await visit('/checkout')
+
+    await expect(page).toSee('Checkout')
   }
 )
 ```
+
+Use `visit().on()` when one visit inside a browser trial needs a different
+project before navigation:
+
+```js
+test(
+  'publisher dashboard adapts across projects',
+  { browser: true },
+  async ({ visit, expect }) => {
+    const mobilePage = await visit('/dashboard').onMobile()
+    await expect(mobilePage).toSee('Menu')
+
+    const safariPage = await visit('/dashboard').on('safari')
+    await expect(safariPage).toSee('Dashboard')
+  }
+)
+```
+
+For a whole trial, prefer `{ browser: 'mobile' }`. For one specific visit,
+`visit('/path').onMobile()` closes the current browser session, opens the named
+project, then applies actor login, color scheme, locale, host, and other setup
+before it navigates.
 
 Define the projects in `config/sounding.js`:
 


### PR DESCRIPTION
## Summary

- Updates the Sounding browser testing docs to use the new expect-first page wrapper flow.
- Documents `@name` browser test handles, `withHost()`, visit-level project switching, setup helpers, fluent page actions, read/capture helpers, and browser expectations.
- Updates artifact and browser project examples away from raw Playwright assertions.

## Validation

- `npm run lint`
- `npm run build`

Closes #93.