### PR TITLE
docs: add Sounding plugin and stress guides

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -133,7 +133,8 @@ function soundingGuide() {
         { text: 'Scenarios', link: '/sounding/scenarios' },
         { text: 'Worlds', link: '/sounding/worlds' },
         { text: 'Auth and actors', link: '/sounding/auth-and-actors' },
-        { text: 'Suite structure', link: '/sounding/organizing-your-suite' }
+        { text: 'Suite structure', link: '/sounding/organizing-your-suite' },
+        { text: 'Plugins', link: '/sounding/plugins' }
       ]
     },
     {
@@ -146,7 +147,8 @@ function soundingGuide() {
         { text: 'Websockets', link: '/sounding/websocket-testing' },
         { text: 'Browser', link: '/sounding/browser-testing' },
         { text: 'Visual regression', link: '/sounding/visual-regression' },
-        { text: 'Mail', link: '/sounding/mail-testing' }
+        { text: 'Mail', link: '/sounding/mail-testing' },
+        { text: 'Stress testing', link: '/sounding/stress-testing' }
       ]
     },
     {

--- a/docs/sounding/getting-started.md
+++ b/docs/sounding/getting-started.md
@@ -83,6 +83,25 @@ module.exports.sounding = {
 }
 ```
 
+## Optional: install plugin features
+
+Sounding keeps heavier capabilities in plugins. Install the plugin package, then
+use the API it adds.
+
+This is separate from the core configuration above. There is no `plugins` array
+and no `config/sounding.js` registration step for plugin discovery. The dev
+dependency is the registration.
+
+For example, stress testing is powered by `sounding-plugin-stress`:
+
+```bash
+npm install -D sounding-plugin-stress
+npx sounding stress /api/health --duration=10 --concurrency=25
+```
+
+Read [Plugins](/sounding/plugins) for the plugin model and
+[Stress testing](/sounding/stress-testing) for the full stress API.
+
 ## 4. Write your first trial
 
 If you are new to Sounding's callback shape, read [Trials](/sounding/trials) and [Trial context](/sounding/trial-context) alongside this guide. They explain what a trial is, what arrives inside `test()`, and when things like `page` and `login` appear.

--- a/docs/sounding/plugins.md
+++ b/docs/sounding/plugins.md
@@ -1,0 +1,276 @@
+---
+title: Plugins
+editLink: true
+---
+
+# Plugins
+
+Sounding keeps core small and lets heavier capabilities live in installable
+plugins.
+
+That means a normal Sails app can keep using the core testing runtime, while
+features such as stress testing, mutation testing, or future specialized
+reporters can bring their own dependencies only when an app asks for them.
+
+## Install-only setup
+
+Install a Sounding plugin as a dev dependency:
+
+```bash
+npm install -D sounding-plugin-stress
+```
+
+Then use the API it adds:
+
+```bash
+npx sounding stress /api/health --duration=10 --concurrency=25
+```
+
+There is no `plugins` array and no `config/sounding.js` registration step. The
+dev dependency is the registration: Sounding discovers plugin packages from the
+app's `package.json`.
+
+`config/sounding.js` is still available for core Sounding runtime overrides, such
+as datastore, auth, browser projects, or diagnostics. It is not where users
+register plugins.
+
+## Discovery
+
+Sounding discovers package names that match either of these patterns:
+
+- `sounding-plugin-*`
+- `@sounding/plugin-*`
+
+For local monorepo development, Sounding also discovers plugins under
+`plugins/*` when each plugin folder has its own `package.json` with a matching
+package name.
+
+For example:
+
+```txt
+my-sails-app/
+  package.json
+  plugins/
+    stress/
+      package.json
+      index.js
+```
+
+If `plugins/stress/package.json` is named `sounding-plugin-stress`, Sounding can
+load it while you work locally.
+
+## What plugins can add
+
+A plugin can add three public surfaces:
+
+- CLI commands, such as `sounding stress`
+- focused test methods, such as `test.stress(...)`
+- trial context helpers, such as `{ stress }`
+
+The plugin returns those surfaces from its factory:
+
+```js
+module.exports = function stressPlugin(api) {
+  return {
+    name: 'stress',
+
+    commands: {
+      stress(argv, context) {
+        return runStressCommand(argv, {
+          ...context,
+          api
+        })
+      }
+    },
+
+    testMethods: {
+      stress: {
+        mode: 'stress',
+        options: {
+          transport: 'http'
+        }
+      }
+    },
+
+    trial({ sails, config, world, appPath, events }) {
+      return {
+        stress: createStressClient({
+          api,
+          sails,
+          getConfig: () => config,
+          world,
+          appPath,
+          events
+        })
+      }
+    }
+  }
+}
+```
+
+That shape is intentionally close to Sails' hook idea: install a package, let it
+extend the runtime, and keep the app-facing API calm.
+
+## Commands
+
+Commands are registered under `commands`.
+
+```js
+commands: {
+  example(argv, context) {
+    context.stdout.write('Hello from Sounding\n')
+
+    return {
+      status: 0
+    }
+  }
+}
+```
+
+If a plugin registers `example`, users can run:
+
+```bash
+npx sounding example
+```
+
+Command handlers receive:
+
+- `argv`, the command arguments after the command name
+- `context.appPath`, the Sails app path
+- `context.stdout`
+- `context.stderr`
+- `context.api`, the Sounding plugin API
+
+Commands should return an object with a numeric `status` when they want to
+control the process exit code.
+
+## Test methods
+
+Plugins can add focused test methods when a feature deserves its own lane.
+
+The stress plugin adds `test.stress(...)`:
+
+```js
+test.stress(
+  'billing summary stays fast',
+  { world: 'subscribed-creator' },
+  async ({ stress, expect }) => {
+    const result = await stress
+      .get('/api/billing/summary')
+      .as('owner')
+      .concurrently(20)
+      .for(10)
+      .seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+  }
+)
+```
+
+`test.stress()` is still a Sounding trial. The plugin only sets helpful defaults
+for that lane, such as `transport: 'http'`.
+
+## Trial helpers
+
+Plugins can add keys to the trial context through `trial()`.
+
+```js
+trial({ sails, config, world, events }) {
+  return {
+    example: createExampleClient({
+      sails,
+      config,
+      world,
+      events
+    })
+  }
+}
+```
+
+The returned object is merged into the trial context:
+
+```js
+test('uses a plugin helper', async ({ example }) => {
+  await example.run()
+})
+```
+
+Keep trial helpers small and product-facing. If a helper needs a heavy engine,
+put that engine dependency in the plugin package instead of Sounding core.
+
+## Plugin API
+
+The plugin factory receives a small Sails-aware API:
+
+```js
+module.exports = function myPlugin(api) {
+  // ...
+}
+```
+
+Available helpers include:
+
+| API                                            | Purpose                                                        |
+| ---------------------------------------------- | -------------------------------------------------------------- |
+| `api.appPath`                                  | The resolved app path Sounding is running against.             |
+| `api.events`                                   | Shared plugin event bus.                                       |
+| `api.createAppManager()`                       | Load or lift the Sails app for command-style plugins.          |
+| `api.createSessionCookie(sails, session)`      | Create a real Sails session cookie for HTTP runs.              |
+| `api.createSoundingError(details)`             | Create a structured Sounding error.                            |
+| `api.resolveAuthConfig(input)`                 | Resolve the app's auth convention.                             |
+| `api.resolveWorldActor(input)`                 | Resolve an actor alias from the active world.                  |
+| `api.resolveActorHeaders(actor)`               | Read actor-provided request headers.                           |
+| `api.resolveActorSession(actor, auth)`         | Build session data from an actor and auth convention.          |
+| `api.resolveBaseUrl(input)`                    | Resolve a base URL from app config.                            |
+| `api.resolveUrl(input)`                        | Resolve a request target to an absolute URL.                   |
+| `api.createRequestActorUnresolvedError(input)` | Build the same actor resolution error used by request clients. |
+| `api.loadDependencyFromApp(input)`             | Load a dependency from the app with a friendly install error.  |
+
+That API lets plugins feel native without duplicating Sounding internals.
+
+## Events
+
+Sounding exposes an `EventEmitter` as a lifecycle and observability channel.
+
+Core emits:
+
+- `plugin:loaded`
+- `trial:plugin:before`
+- `trial:plugin:after`
+
+Plugins can emit their own events:
+
+```js
+events.emit('stress:start', options)
+events.emit('stress:done', result)
+```
+
+Events are good for:
+
+- progress output
+- custom reporters
+- logging
+- optional plugin-to-plugin integrations
+- future streaming dashboards
+
+Events should not be the main registration mechanism for public APIs. Commands,
+test methods, and trial helpers should stay explicit so users can understand what
+a plugin adds by reading its returned object.
+
+## Missing plugins
+
+When a known plugin command is missing, Sounding should explain the setup instead
+of forcing that feature into core.
+
+For example, running `sounding stress` without the stress plugin points users to:
+
+```bash
+npm install -D sounding-plugin-stress
+```
+
+That is the whole point of the plugin split: the API can feel first-party, while
+the dependency stays optional.
+
+## First plugin
+
+The first official plugin is [Stress testing](/sounding/stress-testing).

--- a/docs/sounding/stress-testing.md
+++ b/docs/sounding/stress-testing.md
@@ -1,0 +1,445 @@
+---
+title: Stress Testing
+editLink: true
+---
+
+# Stress testing
+
+Sounding stress testing lives in `sounding-plugin-stress`.
+
+The plugin adds a Sails-native load-testing surface without making every
+Sounding install carry a load engine dependency.
+
+## What Sounding learned from Pest
+
+Pest's stress testing has two nice ideas:
+
+- a terminal command for quick checks
+- an expectation-friendly API for tests that should guard performance over time
+
+Sounding keeps those ideas, then makes them Sails-native.
+
+The command is:
+
+```bash
+npx sounding stress /api/health
+```
+
+The trial API is:
+
+```js
+test.stress('health endpoint stays fast', async ({ stress, expect }) => {
+  const result = await stress
+    .get('/api/health')
+    .concurrently(10)
+    .for(5)
+    .seconds()
+
+  expect(result.requests.failed().count()).toBe(0)
+  expect(result.requests.duration().p95()).toBeLessThan(250)
+})
+```
+
+The Sails-native parts are where Sounding becomes its own thing:
+
+- relative paths can lift and stress the local Sails app
+- worlds can prepare product state before the load run
+- actor aliases can become real Sails session cookies
+- deployed URLs can still be stressed directly
+- the load engine stays in a plugin instead of core
+
+## Install
+
+Install the plugin in a Sails app that already uses Sounding:
+
+```bash
+npm install -D sounding-plugin-stress
+```
+
+No `config/sounding.js` registration is required. Once installed, Sounding
+discovers the plugin automatically from `package.json`.
+
+Think of the dev dependency as the registration:
+
+```json
+{
+  "devDependencies": {
+    "sounding": "^0.2.0",
+    "sounding-plugin-stress": "^0.1.0"
+  }
+}
+```
+
+There is no `plugins` array to maintain.
+
+The plugin adds:
+
+- `npx sounding stress`
+- `test.stress(...)`
+- a `stress` trial helper
+
+## Autocannon
+
+The first engine behind `sounding-plugin-stress` is
+[`autocannon`](https://github.com/mcollina/autocannon).
+
+`autocannon` is a Node.js HTTP benchmarking tool with a programmatic API. That
+matters for Sounding because Sails, Sounding, and the test runner are already in
+Node. The plugin can call the engine directly, pass normalized options, and turn
+the raw result into a stable Sounding result object.
+
+Sounding maps its API to `autocannon` like this:
+
+| Sounding                                     | Engine option                                |
+| -------------------------------------------- | -------------------------------------------- |
+| `.concurrently(25)` / `--concurrency=25`     | `connections: 25`                            |
+| `.for(10).seconds()` / `--duration=10`       | `duration: 10`                               |
+| `.post('/api/invoices')` / `--method=POST`   | `method: 'POST'`                             |
+| `.headers({...})` / `--header "Name: value"` | `headers`                                    |
+| `.json(payload)` / `--json`                  | `body` plus `content-type: application/json` |
+
+The trial result is not an `autocannon` object. It is a Sounding result with
+stable metrics:
+
+```js
+result.requests.count()
+result.requests.rate()
+result.requests.failed().count()
+result.requests.duration().p95()
+result.testRun.concurrency()
+```
+
+The raw engine output is still available at `result.raw` when you need to debug
+engine-specific details.
+
+This keeps the dependency boundary honest: `autocannon` gives us a proven load
+engine, while Sounding owns the Sails-aware API, actor/session setup, result
+shape, and docs.
+
+## CLI
+
+Use `sounding stress <target>` for ad hoc checks, CI smoke load, and quick
+performance baselines.
+
+Stress an external or deployed URL directly:
+
+```bash
+npx sounding stress https://staging.example.com/api/health \
+  --duration=10 \
+  --concurrency=25
+```
+
+Stress a local Sails route:
+
+```bash
+npx sounding stress /api/health \
+  --duration=10 \
+  --concurrency=25
+```
+
+When the target is a relative path and no `--base-url` is provided, Sounding
+lifts the local Sails app and stresses the real HTTP route.
+
+Stress a Sails-shaped path against a chosen host:
+
+```bash
+npx sounding stress /api/health \
+  --base-url=https://staging.example.com \
+  --duration=10 \
+  --concurrency=25
+```
+
+That mode does not lift the local app. It resolves the path against the host you
+provided.
+
+## Worlds and actors
+
+Local Sails stress runs can load a world and use actor aliases:
+
+```bash
+npx sounding stress /api/billing/summary \
+  --world=subscribed-creator \
+  --as=owner \
+  --duration=10 \
+  --concurrency=20
+```
+
+Sounding lifts the app, loads the world, resolves `owner`, creates the matching
+Sails session cookie, and runs real HTTP traffic through the route.
+
+Remote and `--base-url` runs cannot use `--world` or `--as` because the remote
+server does not share the local test world. Use headers or tokens instead:
+
+```bash
+npx sounding stress https://staging.example.com/api/me \
+  --header "Authorization: Bearer $TOKEN" \
+  --duration=10 \
+  --concurrency=25
+```
+
+## Methods, bodies, and headers
+
+Use `--method` for any HTTP method:
+
+```bash
+npx sounding stress /api/events \
+  --method=POST \
+  --json '{"name":"invoice.created"}'
+```
+
+Method shorthands are available:
+
+```bash
+npx sounding stress /api/health --get
+npx sounding stress /api/invoices --post='{"plan":"pro"}'
+npx sounding stress /api/invoices/1 --patch='{"memo":"updated"}'
+npx sounding stress /api/session --delete
+```
+
+Add headers with `--header`. Repeat it when you need more than one header:
+
+```bash
+npx sounding stress /api/invoices \
+  --post='{"plan":"pro"}' \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "x-test-lane: stress"
+```
+
+Use `--json` for JSON payloads and `--body` for raw bodies:
+
+```bash
+npx sounding stress /api/events \
+  --method=POST \
+  --json '{"kind":"checkout.completed"}'
+
+npx sounding stress /api/upload-token \
+  --put \
+  --body raw-payload
+```
+
+## CLI reference
+
+```txt
+sounding stress <target> [options]
+
+Targets:
+  /api/health                         Lift the local Sails app and stress a route.
+  https://example.com/api/health      Stress an external URL directly.
+  /api/health --base-url=<url>        Stress a path on a chosen host.
+
+Options:
+  --duration <seconds>                Duration in seconds. Defaults to 10.
+  --concurrency <requests>            Concurrent requests. Defaults to 1.
+  --connections <requests>            Alias for --concurrency.
+  --method <method>                   HTTP method.
+  --get, --head, --options            Method shorthands.
+  --post, --put, --patch, --delete    Method shorthands. Body-capable flags accept JSON.
+  --header "Name: value"              Add a request header. May be repeated.
+  --json '<payload>'                  Send a JSON body.
+  --body <payload>                    Send a raw body.
+  --base-url <url>                    Resolve a relative target against this host.
+  --world <scenario>                  Load a Sounding world before stressing a local app.
+  --as <actor>                        Use a world actor alias for local Sails auth/session.
+```
+
+## Trial API
+
+Use `test.stress()` when load is the behavior being proven.
+
+```js
+const { test } = require('sounding')
+
+test.stress(
+  'billing summary stays fast under creator load',
+  { world: 'subscribed-creator' },
+  async ({ stress, expect }) => {
+    const result = await stress
+      .get('/api/billing/summary')
+      .as('owner')
+      .concurrently(20)
+      .for(10)
+      .seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+    expect(result.requests.duration().p95()).toBeLessThan(250)
+  }
+)
+```
+
+`test.stress()` is still a normal Sounding trial. The plugin gives it an HTTP
+transport default, then adds the `stress` helper to the trial context.
+
+You can also use the helper from an explicitly HTTP trial:
+
+```js
+test(
+  'health endpoint has no failed requests',
+  { transport: 'http' },
+  async ({ stress, expect }) => {
+    const result = await stress
+      .get('/api/health')
+      .concurrently(25)
+      .for(10)
+      .seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+  }
+)
+```
+
+## Fluent stress client
+
+The stress client supports common HTTP methods:
+
+```js
+stress.request(method, target, payload)
+stress.get(target)
+stress.head(target)
+stress.options(target, payload)
+stress.post(target, payload)
+stress.put(target, payload)
+stress.patch(target, payload)
+stress.delete(target, payload)
+```
+
+Chains are promise-like. Awaiting a chain runs it:
+
+```js
+const result = await stress.get('/api/health')
+```
+
+Use `.run()` when you want the execution point to be explicit:
+
+```js
+const result = await stress.get('/api/health').concurrently(10).run()
+```
+
+Chain helpers:
+
+```js
+const result = await stress
+  .post('/api/invoices')
+  .as('owner')
+  .baseUrl('https://staging.example.com')
+  .header('x-test-lane', 'stress')
+  .headers({ accept: 'application/json' })
+  .json({ plan: 'pro' })
+  .concurrently(20)
+  .for(10)
+  .seconds()
+```
+
+Available chain helpers:
+
+| API                     | Purpose                                     |
+| ----------------------- | ------------------------------------------- |
+| `.as(actor)`            | Use an actor object or world actor alias.   |
+| `.baseUrl(url)`         | Resolve a relative target against a host.   |
+| `.header(name, value)`  | Add one request header.                     |
+| `.headers(object)`      | Merge request headers.                      |
+| `.json(payload)`        | Send a JSON payload and set `content-type`. |
+| `.body(payload)`        | Send a raw payload.                         |
+| `.concurrently(count)`  | Set concurrent requests.                    |
+| `.for(count).seconds()` | Run for a duration in seconds.              |
+| `.run()`                | Execute the chain explicitly.               |
+
+## Actor auth
+
+`as(actor)` accepts:
+
+- an actor object
+- a world actor alias, such as `owner`
+- an actor object with `headers` or `sounding.headers`
+- an actor object whose identity can be converted into the configured auth session
+
+For local Sails runs, Sounding can turn the actor into a real Sails session
+cookie before the load run starts.
+
+For remote targets, use request headers:
+
+```js
+const result = await stress
+  .get('https://staging.example.com/api/me')
+  .header('authorization', `Bearer ${token}`)
+  .concurrently(10)
+  .for(5)
+  .seconds()
+```
+
+## Metrics
+
+The result object is built for assertions:
+
+```js
+result.requests.count()
+result.requests.rate()
+result.requests.failed().count()
+result.requests.failed().rate()
+result.requests.duration().min()
+result.requests.duration().med()
+result.requests.duration().median()
+result.requests.duration().mean()
+result.requests.duration().average()
+result.requests.duration().p90()
+result.requests.duration().p95()
+result.requests.duration().p99()
+result.requests.duration().max()
+result.requests.ttfb().duration().p95()
+result.requests.download().data().count()
+result.requests.download().data().rate()
+result.requests.upload().data().count()
+result.requests.upload().data().rate()
+result.testRun.concurrency()
+result.testRun.duration()
+result.toJSON()
+result.raw
+```
+
+For example:
+
+```js
+expect(result.requests.failed().count()).toBe(0)
+expect(result.requests.duration().p95()).toBeLessThan(250)
+expect(result.requests.rate()).toBeGreaterThan(100)
+```
+
+## Output
+
+The CLI prints a compact summary:
+
+```txt
+STRESS GET http://127.0.0.1:1337/api/health
+Requests: 6088 total, 6090/s, 0 failed
+Latency: med 0ms, p95 0ms, max 6ms
+Run: 1s, concurrency 1
+```
+
+The command exits with status `1` when failed requests are detected.
+
+## Engine
+
+The first engine is `autocannon`, owned by `sounding-plugin-stress`.
+
+Sounding owns the public API and normalized result model. That keeps trial code
+stable if the plugin adds another engine later.
+
+This is different from making `autocannon` a direct Sounding dependency. The
+plugin boundary keeps core installs light and makes heavier future features, such
+as mutation testing, follow the same shape.
+
+## When to use stress testing
+
+Use stress trials for lightweight performance contracts:
+
+- an endpoint should not return failed requests under expected concurrency
+- p95 latency should stay below a known threshold
+- authenticated hot paths should survive realistic local load
+- a deployed staging endpoint should stay healthy before release
+
+Do not use stress trials as a full production capacity plan by themselves. They
+are a fast feedback loop for regressions and obvious bottlenecks.
+
+## Plugin details
+
+Read [Plugins](/sounding/plugins) for how Sounding discovers plugins and how a
+plugin can register commands, focused test methods, trial helpers, and events.

--- a/docs/sounding/stress-testing.md
+++ b/docs/sounding/stress-testing.md
@@ -269,6 +269,10 @@ test.stress(
 `test.stress()` is still a normal Sounding trial. The plugin gives it an HTTP
 transport default, then adds the `stress` helper to the trial context.
 
+It belongs to the same declaration family as `test.it()`, `test.only()`,
+`test.skip()`, and `test.concurrent()`. Use it when the trial itself is about
+load behavior. Use `test.it()` for ordinary behavior trials.
+
 You can also use the helper from an explicitly HTTP trial:
 
 ```js

--- a/docs/sounding/trial-context.md
+++ b/docs/sounding/trial-context.md
@@ -22,6 +22,16 @@ test('guest is redirected from dashboard', async ({ get, expect }) => {
 
 That object passed into the callback is the **trial context**.
 
+The behavior-reading alias receives the same context:
+
+```js
+test.it('guest is redirected from dashboard', async ({ get, expect }) => {
+  const response = await get('/dashboard')
+
+  expect(response).toRedirectTo('/login')
+})
+```
+
 If you are looking for the higher-level definition of a trial itself, read [Trials](/sounding/trials).
 
 The trial context gives each trial:

--- a/docs/sounding/trials.md
+++ b/docs/sounding/trials.md
@@ -30,6 +30,19 @@ test('guest is redirected from dashboard', async ({ get, expect }) => {
 })
 ```
 
+If you prefer the behavior-reading alias, use `test.it()`:
+
+```js
+test.it('guest is redirected from dashboard', async ({ get, expect }) => {
+  const response = await get('/dashboard')
+
+  expect(response).toRedirectTo('/login')
+})
+```
+
+`test()` and `test.it()` run through the same Sounding trial wrapper. The alias
+exists so suites can read naturally without creating a second testing dialect.
+
 ## Call signatures
 
 Executable trials use one of these forms:
@@ -37,8 +50,12 @@ Executable trials use one of these forms:
 ```js
 test(name, handler)
 test(name, options, handler)
+test.it(name, handler)
+test.it(name, options, handler)
 test.only(name, handler)
 test.only(name, options, handler)
+test.it.only(name, handler)
+test.it.only(name, options, handler)
 ```
 
 `name` should be a non-empty behavior name, `options` should be an object, and `handler` should be the function that receives the trial context.
@@ -60,6 +77,15 @@ Non-executable planning forms still follow Node's test runner:
 ```js
 test.skip(name)
 test.todo(name)
+test.it.skip(name)
+test.it.todo(name)
+```
+
+Independent trials can use the concurrent aliases:
+
+```js
+test.concurrent(name, handler)
+test.it.concurrent(name, handler)
 ```
 
 ## What makes a good trial

--- a/docs/sounding/what-is-sounding.md
+++ b/docs/sounding/what-is-sounding.md
@@ -96,6 +96,16 @@ Use `test()` with `page` when a flow is truly about the browser:
 
 Use `test()` and `sails.sounding.mailbox` to assert on outgoing transactional email like magic links, invites, password resets, and billing notifications.
 
+## Plugin-powered features
+
+Sounding keeps heavier or specialized features in installable plugins. The first
+plugin-powered surface is [Stress testing](/sounding/stress-testing), which adds
+`sounding stress`, `test.stress(...)`, and a `stress` trial helper through
+`sounding-plugin-stress`.
+
+Read [Plugins](/sounding/plugins) for how plugin discovery, commands, trial
+helpers, and lifecycle events work.
+
 ## Common problems it helps avoid
 
 Sounding helps avoid:


### PR DESCRIPTION
Closes #99

## Summary
- add a Sounding Plugins guide covering auto-discovery, plugin package naming, commands, test methods, trial helpers, API helpers, and events
- add a Stress Testing guide for sounding-plugin-stress, including install-only setup, CLI usage, worlds/actors, fluent trial API, metrics, autocannon notes, and engine boundaries
- link the new pages from the Sounding sidebar, getting started guide, and overview

## Verification
- npm run lint
- npm run build