### PR TITLE
docs: document Bachs for Sails Pay

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -553,7 +553,8 @@ function SailsPayGuide() {
         { text: 'Lemon Squeezy', link: 'sails-pay/lemonsqueezy' },
         { text: 'Flutterwave', link: 'sails-pay/flutterwave' },
         { text: 'Paga', link: 'sails-pay/paga' },
-        { text: 'Paystack', link: 'sails-pay/paystack' }
+        { text: 'Paystack', link: 'sails-pay/paystack' },
+        { text: 'Bachs', link: 'sails-pay/bachs' }
       ]
     },
     {
@@ -570,6 +571,11 @@ function SailsPayGuide() {
           link: 'sails-pay/verify-transaction'
         }
       ]
+    },
+    {
+      text: 'Webhooks',
+      collapsed: false,
+      items: [{ text: 'Verifying webhooks', link: 'sails-pay/webhooks' }]
     },
     {
       text: 'Subscriptions',

--- a/docs/sails-pay/bachs.md
+++ b/docs/sails-pay/bachs.md
@@ -1,0 +1,322 @@
+---
+head:
+  - - meta
+    - property: 'og:image'
+      content: https://docs.sailscasts.com/sails-pay-social.png
+title: Bachs
+titleTemplate: Sails Pay
+description: Learn how to use the Bachs adapter for Sails Pay
+prev:
+  text: Paystack
+  link: /sails-pay/paystack
+next:
+  text: Creating checkouts
+  link: /sails-pay/checkout
+editLink: true
+---
+
+# Bachs
+
+[Bachs](https://bachs.io) is a billing and payments platform for hosted checkout, product-based payments, webhook-confirmed collections, refunds, and multi-currency payment flows.
+
+The `@sails-pay/bachs` adapter lets Sails applications create Bachs hosted checkouts through the same `sails.pay.checkout()` API used by other Sails Pay providers.
+
+## Provider capabilities
+
+Relevant Bachs capabilities include:
+
+- **Checkout Sessions**: Create hosted product checkouts from Bachs products or product collections.
+- **Pure Checkout**: Create hosted checkouts from runtime amount and currency data.
+- **Charge verification**: Retrieve charge status with `sails.pay.verify({ chargeId })`.
+- **Checkout lookup**: Fetch checkout or checkout-session details after redirect or webhook delivery.
+- **Webhook signatures**: Verify `X-Bachs-Timestamp` and `X-Bachs-Signature` using HMAC SHA-256.
+- **Refunds**: Create full or partial refunds for completed charges.
+
+## Getting started with Bachs
+
+Before integrating Bachs with Sails Pay:
+
+1. Create a Bachs account at [bachs.io](https://bachs.io).
+2. Generate a sandbox or live secret API key.
+3. Create products in Bachs if you want product-based checkout sessions.
+4. Configure a webhook destination and copy its signing secret.
+5. Add return and cancel URLs for your application.
+
+::: tip
+Use sandbox keys starting with `sk_sandbox_` during development. The adapter automatically uses `https://sandbox-api.bachs.io` for sandbox keys unless you provide `baseUrl`.
+:::
+
+## Installation
+
+Install Sails Pay and the Bachs adapter:
+
+```sh
+npm i sails-pay @sails-pay/bachs
+```
+
+## Specifying the adapter
+
+In `config/pay.js`, create a payment provider and set the `adapter` property to `@sails-pay/bachs`.
+
+```js
+module.exports.pay = {
+  provider: 'default',
+  providers: {
+    default: {
+      adapter: '@sails-pay/bachs'
+    }
+  }
+}
+```
+
+## Configuration
+
+You can configure the Bachs adapter for both production and local development.
+
+### Local development
+
+In `config/local.js`, specify your sandbox values:
+
+```js
+module.exports = {
+  pay: {
+    providers: {
+      default: {
+        adapter: '@sails-pay/bachs',
+        apiKey: 'sk_sandbox_xxxxxxxxxxxxxxxxxxxxxx',
+        returnUrl: 'http://localhost:1337/payment/return',
+        cancelUrl: 'http://localhost:1337/payment/cancel',
+        webhookSecret: 'whsec_xxxxxxxxxxxxxxxxxxxxxx'
+      }
+    }
+  }
+}
+```
+
+### Production
+
+For production, use environment variables in `config/pay.js`:
+
+```js
+module.exports.pay = {
+  provider: 'default',
+  providers: {
+    default: {
+      adapter: '@sails-pay/bachs',
+      apiKey: process.env.BACHS_API_KEY,
+      baseUrl: process.env.BACHS_BASE_URL,
+      returnUrl: process.env.BACHS_RETURN_URL,
+      cancelUrl: process.env.BACHS_CANCEL_URL,
+      webhookSecret: process.env.BACHS_WEBHOOK_SECRET
+    }
+  }
+}
+```
+
+::: tip
+Do not commit live API keys or webhook secrets. Keep them in environment variables or your deployment platform's secret store.
+:::
+
+## Configuring values
+
+### **`apiKey`** (required)
+
+Your Bachs secret API key. Sandbox keys start with `sk_sandbox_`; live keys start with `sk_live_`.
+
+### **`baseUrl`** (optional)
+
+Override the Bachs API base URL.
+
+When omitted, the adapter chooses the base URL from the API key:
+
+| API key prefix | Base URL                       |
+| -------------- | ------------------------------ |
+| `sk_sandbox_`  | `https://sandbox-api.bachs.io` |
+| anything else  | `https://api.bachs.io`         |
+
+### **`returnUrl`** (optional)
+
+The URL Bachs redirects to after a Checkout Session payment. Bachs appends `?checkout_id=<id>` to the return URL.
+
+### **`successUrl`** (optional)
+
+The URL Bachs redirects to after a Pure Checkout payment. You usually only need `returnUrl` when using product Checkout Sessions.
+
+### **`cancelUrl`** (optional)
+
+The URL Bachs redirects to when the customer cancels checkout.
+
+### **`webhookSecret`** (required for webhook verification)
+
+The signing secret for your Bachs webhook destination.
+
+## Default environment variables
+
+If you don't provide configuration values, the adapter will automatically look for these environment variables as fallbacks:
+
+| Config Value    | Environment Variable   |
+| --------------- | ---------------------- |
+| `apiKey`        | `BACHS_API_KEY`        |
+| `baseUrl`       | `BACHS_BASE_URL`       |
+| `returnUrl`     | `BACHS_RETURN_URL`     |
+| `successUrl`    | `BACHS_SUCCESS_URL`    |
+| `cancelUrl`     | `BACHS_CANCEL_URL`     |
+| `webhookSecret` | `BACHS_WEBHOOK_SECRET` |
+
+## Product checkout sessions
+
+Use product checkout sessions when your pricing lives in Bachs products.
+
+```js
+const checkoutUrl = await sails.pay.checkout({
+  items: [{ product: 'prod_abc123', quantity: 1 }],
+  customer: {
+    email: loggedInUser.email,
+    name: loggedInUser.fullName
+  },
+  reference: purchase.reference,
+  metadata: {
+    purchase: purchase.id.toString(),
+    user: loggedInUser.id.toString()
+  },
+  returnUrl: `${sails.config.custom.baseUrl}/payment/return`,
+  cancelUrl: `${sails.config.custom.baseUrl}/payment/cancel`,
+  idempotencyKey: purchase.reference
+})
+```
+
+The adapter keeps your Sails code camelCase and maps to Bachs snake case at the HTTP boundary:
+
+| Sails Pay input             | Bachs request field            |
+| --------------------------- | ------------------------------ |
+| `items`                     | `product_cart`                 |
+| `items[].product`           | `product_cart[].product_id`    |
+| `productCollectionId`       | `product_collection_id`        |
+| `billingCurrency`           | `billing_currency`             |
+| `allowedPaymentMethodTypes` | `allowed_payment_method_types` |
+| `returnUrl`                 | `return_url`                   |
+| `cancelUrl`                 | `cancel_url`                   |
+| `customer.customerId`       | `customer.customer_id`         |
+| `customer.phoneNumber`      | `customer.phone_number`        |
+| `idempotencyKey`            | `Idempotency-Key` header       |
+
+::: tip
+For product checkout sessions, Bachs requires exactly one of `items` or `productCollectionId`.
+:::
+
+## Selection-mode checkout
+
+Use `productCollectionId` when you want customers to choose from a Bachs product collection.
+
+```js
+const checkoutUrl = await sails.pay.checkout({
+  productCollectionId: 'pgrp_1a2b3c4d5e',
+  customer: {
+    email: loggedInUser.email,
+    name: loggedInUser.fullName
+  },
+  returnUrl: `${sails.config.custom.baseUrl}/payment/return`,
+  cancelUrl: `${sails.config.custom.baseUrl}/payment/cancel`
+})
+```
+
+## Pure checkout
+
+Use Pure Checkout when you do not want to pre-create Bachs products.
+
+```js
+const checkoutUrl = await sails.pay.checkout({
+  amount: '50.00',
+  currency: 'USD',
+  customerEmail: 'customer@example.com',
+  customerName: 'Jane Doe',
+  successUrl: `${sails.config.custom.baseUrl}/payment/success`,
+  cancelUrl: `${sails.config.custom.baseUrl}/payment/cancel`,
+  reference: 'order_9876',
+  metadata: {
+    order: '9876'
+  }
+})
+```
+
+For Pure Checkout, the adapter maps `successUrl` to Bachs `success_url`.
+
+## Checkout lookup
+
+After a Checkout Session payment, Bachs redirects the customer to `returnUrl` with `checkout_id` in the query string.
+
+```js
+const checkout = await sails.pay.checkout.get({
+  checkoutId: this.req.query.checkout_id
+})
+```
+
+The checkout includes `charge` once the customer submits payment.
+
+## Charge verification
+
+Bachs verifies payments by `chargeId`, not by checkout reference.
+
+```js
+const charge = await sails.pay.verify({
+  chargeId: 'chr_1a2b3c4d5e6f'
+})
+```
+
+If your app only has `checkoutId`, fetch the checkout first with `sails.pay.checkout.get({ checkoutId })` and read `checkout.charge.charge_id`.
+
+## Webhook signature verification
+
+Bachs signs webhook deliveries with `X-Bachs-Timestamp` and `X-Bachs-Signature`.
+
+```js
+const isValid = await sails.pay.webhooks.verify({
+  rawBody: this.req.rawBody,
+  timestamp: this.req.get('X-Bachs-Timestamp'),
+  signature: this.req.get('X-Bachs-Signature')
+})
+```
+
+::: warning
+Webhook verification requires the exact raw request body. If Sails or another body parser has already parsed and re-serialized the JSON body, the signature can fail even when the event is legitimate.
+:::
+
+Important payment events include:
+
+- `collection.succeeded`
+- `collection.failed`
+- `collection.abandoned`
+- `collection.underpaid`
+
+Always grant access from webhook-confirmed payment state, not from the redirect URL alone.
+
+For route handling, invalid signature responses, and idempotency guidance, see [Verifying webhooks](/sails-pay/webhooks).
+
+## Refunds
+
+Create a refund for a completed charge:
+
+```js
+const refund = await sails.pay.refund.create({
+  chargeId: 'chr_1a2b3c4d5e6f',
+  reference: 'refund_9876',
+  amount: '25.00',
+  reason: 'Customer request',
+  idempotencyKey: 'refund_9876'
+})
+```
+
+## Next steps
+
+- [Creating checkouts](/sails-pay/checkout) - Redirect users to complete payment
+- [Verify transaction](/sails-pay/verify-transaction) - Confirm charge status
+- [Verifying webhooks](/sails-pay/webhooks) - Verify provider webhook deliveries
+
+## Additional resources
+
+- [Bachs Checkout Sessions](https://docs.bachs.io/guides/checkout/checkout-sessions)
+- [Bachs Pure Checkout](https://docs.bachs.io/guides/checkout/pure-checkout)
+- [Get Checkout Session](https://docs.bachs.io/api-reference/checkout-sessions/get-checkout-session)
+- [Get Charge Status](https://docs.bachs.io/guides/payments/get-charge-status)
+- [Bachs Webhooks](https://docs.bachs.io/guides/webhooks/overview)
+- [Create Refund](https://docs.bachs.io/api-reference/refunds/create-refund)

--- a/docs/sails-pay/checkout.md
+++ b/docs/sails-pay/checkout.md
@@ -7,8 +7,8 @@ title: Creating checkouts
 titleTemplate: Sails Pay
 description: Learn how to create payment checkouts with Sails Pay
 prev:
-  text: Paystack
-  link: /sails-pay/paystack
+  text: Bachs
+  link: /sails-pay/bachs
 next:
   text: Verify transaction
   link: /sails-pay/verify-transaction
@@ -25,6 +25,7 @@ The `sails.pay.checkout()` method creates a payment checkout URL that you can re
 - [Flutterwave](/sails-pay/flutterwave)
 - [Paystack](/sails-pay/paystack)
 - [Paga](/sails-pay/paga)
+- [Bachs](/sails-pay/bachs)
   :::
 
 ## Basic usage
@@ -321,6 +322,104 @@ module.exports = {
   }
 }
 ```
+
+### Bachs parameters
+
+Bachs supports product Checkout Sessions and Pure Checkout through `sails.pay.checkout()`.
+
+#### Product Checkout Session parameters
+
+| Parameter                   | Type   | Required | Description                                                 |
+| --------------------------- | ------ | -------- | ----------------------------------------------------------- |
+| `items`                     | Array  | Yes      | Product cart items. Each item uses `product` or `productId` |
+| `productCollectionId`       | String | Yes      | Product collection ID for selection-mode checkout           |
+| `customer`                  | Object | Yes      | Customer details or an existing Bachs customer ID           |
+| `billingCurrency`           | String | No       | Currency used to select the product price row               |
+| `allowedPaymentMethodTypes` | Array  | No       | Payment method allowlist, such as `bank_transfer` or `card` |
+| `returnUrl`                 | String | No       | URL Bachs redirects to after checkout-session payment       |
+| `cancelUrl`                 | String | No       | URL Bachs redirects to when checkout is cancelled           |
+| `reference`                 | String | No       | Unique merchant reference                                   |
+| `metadata`                  | Object | No       | Metadata returned in webhook payloads                       |
+| `idempotencyKey`            | String | No       | Value sent as the `Idempotency-Key` header                  |
+
+Provide exactly one of `items` or `productCollectionId`.
+
+#### Pure Checkout parameters
+
+| Parameter          | Type   | Required | Description                                        |
+| ------------------ | ------ | -------- | -------------------------------------------------- |
+| `amount`           | String | Yes      | Decimal amount string, such as `"50.00"`           |
+| `currency`         | String | Yes      | Currency code, such as `"USD"` or `"NGN"`          |
+| `currencyOptions`  | Object | No       | Per-currency amount overrides                      |
+| `customerEmail`    | String | Yes      | Customer email address                             |
+| `customerName`     | String | No       | Customer full name                                 |
+| `successUrl`       | String | No       | URL Bachs redirects to after Pure Checkout payment |
+| `cancelUrl`        | String | No       | URL Bachs redirects to when checkout is cancelled  |
+| `reference`        | String | No       | Unique merchant reference                          |
+| `metadata`         | Object | No       | Metadata returned in webhook payloads              |
+| `expiresInMinutes` | Number | No       | Minutes until the checkout expires                 |
+
+#### Bachs product checkout example
+
+```js
+module.exports = {
+  friendlyName: 'Bachs checkout',
+
+  inputs: {
+    productId: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      responseType: 'redirect'
+    }
+  },
+
+  fn: async function ({ productId }) {
+    const loggedInUser = await User.findOne({
+      id: this.req.session.userId
+    }).select(['email', 'fullName'])
+
+    const purchase = await Purchase.create({
+      reference: `ORD-${Date.now()}`,
+      user: loggedInUser.id
+    }).fetch()
+
+    const checkoutUrl = await sails.pay.checkout({
+      items: [{ product: productId, quantity: 1 }],
+      customer: {
+        email: loggedInUser.email,
+        name: loggedInUser.fullName
+      },
+      reference: purchase.reference,
+      metadata: {
+        purchase: purchase.id.toString(),
+        user: loggedInUser.id.toString()
+      },
+      returnUrl: `${sails.config.custom.baseUrl}/payment/return`,
+      cancelUrl: `${sails.config.custom.baseUrl}/payment/cancel`,
+      idempotencyKey: purchase.reference
+    })
+
+    return checkoutUrl
+  }
+}
+```
+
+The adapter keeps your Sails code camelCase and maps to Bachs snake case internally:
+
+| Sails Pay input             | Bachs request field            |
+| --------------------------- | ------------------------------ |
+| `items`                     | `product_cart`                 |
+| `items[].product`           | `product_cart[].product_id`    |
+| `productCollectionId`       | `product_collection_id`        |
+| `billingCurrency`           | `billing_currency`             |
+| `allowedPaymentMethodTypes` | `allowed_payment_method_types` |
+| `returnUrl`                 | `return_url`                   |
+| `idempotencyKey`            | `Idempotency-Key` header       |
 
 ## Using a specific provider
 

--- a/docs/sails-pay/getting-started.md
+++ b/docs/sails-pay/getting-started.md
@@ -48,6 +48,10 @@ npm i @sails-pay/paystack
 npm i @sails-pay/paga
 ```
 
+```sh [Bachs]
+npm i @sails-pay/bachs
+```
+
 :::
 
 ::: tip
@@ -60,3 +64,4 @@ Next, follow the instructions below to setup your preferred payment provider.
 - [Flutterwave](/sails-pay/flutterwave)
 - [Paystack](/sails-pay/paystack)
 - [Paga](/sails-pay/paga)
+- [Bachs](/sails-pay/bachs)

--- a/docs/sails-pay/paystack.md
+++ b/docs/sails-pay/paystack.md
@@ -10,8 +10,8 @@ prev:
   text: Paga
   link: /sails-pay/paga
 next:
-  text: Creating checkouts
-  link: /sails-pay/checkout
+  text: Bachs
+  link: /sails-pay/bachs
 editLink: true
 ---
 

--- a/docs/sails-pay/providers.md
+++ b/docs/sails-pay/providers.md
@@ -29,6 +29,7 @@ Sails Pay currently supports the following payment providers:
 | [Flutterwave](/sails-pay/flutterwave)    | `@sails-pay/flutterwave`  |
 | [Paystack](/sails-pay/paystack)          | `@sails-pay/paystack`     |
 | [Paga](/sails-pay/paga)                  | `@sails-pay/paga`         |
+| [Bachs](/sails-pay/bachs)                | `@sails-pay/bachs`        |
 
 ## Configuring a provider
 

--- a/docs/sails-pay/subscriptions.md
+++ b/docs/sails-pay/subscriptions.md
@@ -7,8 +7,8 @@ title: Retrieving subscriptions
 titleTemplate: Sails Pay
 description: Learn how to retrieve and manage subscriptions with Sails Pay
 prev:
-  text: Verify transaction
-  link: /sails-pay/verify-transaction
+  text: Verifying webhooks
+  link: /sails-pay/webhooks
 next: false
 editLink: true
 ---

--- a/docs/sails-pay/verify-transaction.md
+++ b/docs/sails-pay/verify-transaction.md
@@ -10,21 +10,22 @@ prev:
   text: Creating checkouts
   link: /sails-pay/checkout
 next:
-  text: Retrieving subscriptions
-  link: /sails-pay/subscriptions
+  text: Verifying webhooks
+  link: /sails-pay/webhooks
 editLink: true
 ---
 
 # Verify transaction
 
-The `sails.pay.verify()` method verifies the status of a payment transaction by its reference. This is useful for confirming payment status directly with the provider, independent of webhooks.
+The `sails.pay.verify()` method verifies the status of a payment transaction directly with the provider, independent of webhooks. The lookup key depends on the adapter: Paystack verifies by `reference`, while Bachs verifies by `chargeId`.
 
 ::: info Adapter support
 
 - [Paystack](/sails-pay/paystack)
+- [Bachs](/sails-pay/bachs)
   :::
 
-## Basic usage
+## Paystack basic usage
 
 ```js
 const transaction = await sails.pay.verify({
@@ -33,6 +34,16 @@ const transaction = await sails.pay.verify({
 ```
 
 The method returns the full transaction object from the payment provider, including `status`, `amount`, `currency`, and `metadata`.
+
+## Bachs basic usage
+
+```js
+const charge = await sails.pay.verify({
+  chargeId: 'chr_1a2b3c4d5e6f'
+})
+```
+
+Bachs verifies a charge by `chargeId`. If your app only has `checkoutId`, fetch the checkout first with `sails.pay.checkout.get({ checkoutId })`, then read `checkout.charge.charge_id`.
 
 ## Example in an action
 
@@ -88,6 +99,13 @@ module.exports = {
 | ----------- | ------ | -------- | ---------------------------------------------------------- |
 | `reference` | String | Yes      | The transaction reference used to initiate the transaction |
 | `secretKey` | String | No       | Override the configured secret key                         |
+
+### Bachs parameters
+
+| Parameter  | Type   | Required | Description                     |
+| ---------- | ------ | -------- | ------------------------------- |
+| `chargeId` | String | Yes      | The Bachs charge ID to verify   |
+| `apiKey`   | String | No       | Override the configured API key |
 
 ## Response
 
@@ -202,6 +220,15 @@ module.exports = {
 }
 ```
 
+### Bachs checkout return verification
+
+When Bachs redirects the customer back to your `returnUrl`, it appends `checkout_id`. Use that value to fetch the checkout and inspect the embedded charge.
+
+```js
+const checkout = await sails.pay.checkout.get({ checkoutId })
+const charge = checkout.charge
+```
+
 ## Using a specific provider
 
 If you have multiple payment providers configured, you can specify which one to use:
@@ -214,8 +241,12 @@ const transaction = await sails.pay.verify({ reference: '...' })
 const transaction = await sails.pay
   .provider('paystack')
   .verify({ reference: '...' })
+
+// Use Bachs
+const charge = await sails.pay.provider('bachs').verify({ chargeId: '...' })
 ```
 
 ## Additional resources
 
 - [Paystack Verify Transaction API](https://paystack.com/docs/api/transaction/#verify)
+- [Bachs Get Charge Status](https://docs.bachs.io/guides/payments/get-charge-status)

--- a/docs/sails-pay/webhooks.md
+++ b/docs/sails-pay/webhooks.md
@@ -1,0 +1,182 @@
+---
+head:
+  - - meta
+    - property: 'og:image'
+      content: https://docs.sailscasts.com/sails-pay-social.png
+title: Verifying webhooks
+titleTemplate: Sails Pay
+description: Learn how to verify and handle payment webhooks with Sails Pay
+prev:
+  text: Verify transaction
+  link: /sails-pay/verify-transaction
+next:
+  text: Retrieving subscriptions
+  link: /sails-pay/subscriptions
+editLink: true
+---
+
+# Verifying webhooks
+
+Payment redirects are useful for user experience, but webhooks are the server-to-server confirmation your application should trust for granting access, marking invoices paid, and reconciling orders.
+
+Sails Pay exposes webhook verification through the provider namespace:
+
+```js
+await sails.pay.webhooks.verify({
+  // provider-specific signing inputs
+})
+```
+
+The public API stays the same, while each adapter maps the provider's headers and signing rules internally.
+
+::: info Adapter support
+
+- [Bachs](/sails-pay/bachs)
+  :::
+
+## Basic Bachs verification
+
+Bachs signs webhook deliveries with `X-Bachs-Timestamp` and `X-Bachs-Signature`.
+
+```js
+const isValid = await sails.pay.webhooks.verify({
+  rawBody: this.req.rawBody,
+  timestamp: this.req.get('X-Bachs-Timestamp'),
+  signature: this.req.get('X-Bachs-Signature')
+})
+```
+
+The Bachs adapter verifies the HMAC SHA-256 signature, checks the timestamp tolerance, and returns `true` when the delivery is valid.
+
+## Webhook action example
+
+A webhook action should verify the request before it reads the event as trusted payment state.
+
+```js
+// api/controllers/webhooks/bachs.js
+module.exports = {
+  friendlyName: 'Handle Bachs webhook',
+
+  exits: {
+    success: {
+      statusCode: 200
+    },
+    unauthorized: {
+      statusCode: 401
+    }
+  },
+
+  fn: async function () {
+    try {
+      await sails.pay.webhooks.verify({
+        rawBody: this.req.rawBody,
+        timestamp: this.req.get('X-Bachs-Timestamp'),
+        signature: this.req.get('X-Bachs-Signature')
+      })
+    } catch (error) {
+      if (error.exit === 'invalidSignature') {
+        throw 'unauthorized'
+      }
+
+      throw error
+    }
+
+    const event =
+      typeof this.req.body === 'string'
+        ? JSON.parse(this.req.body)
+        : this.req.body
+
+    switch (event.type) {
+      case 'collection.succeeded':
+        // Mark the order as paid, grant access, or activate the purchase.
+        break
+
+      case 'collection.failed':
+      case 'collection.abandoned':
+      case 'collection.underpaid':
+        // Keep the order pending or mark it as failed.
+        break
+
+      default:
+        sails.log.info(`Unhandled Bachs webhook event: ${event.type}`)
+    }
+
+    return { received: true }
+  }
+}
+```
+
+## Route configuration
+
+Webhook endpoints must be publicly reachable by the payment provider.
+
+```js
+// config/routes.js
+module.exports.routes = {
+  'POST /webhooks/bachs': {
+    action: 'webhooks/bachs',
+    csrf: false
+  }
+}
+```
+
+If your app uses route policies, make sure the webhook endpoint is not behind user authentication.
+
+```js
+// config/policies.js
+module.exports.policies = {
+  'webhooks/*': true
+}
+```
+
+## Raw request body
+
+Signature verification must use the exact raw request body sent by the provider. If the JSON body has already been parsed and re-serialized, the signature can fail even when the event is legitimate.
+
+Pass the raw body into `sails.pay.webhooks.verify()`:
+
+```js
+await sails.pay.webhooks.verify({
+  rawBody: this.req.rawBody,
+  timestamp: this.req.get('X-Bachs-Timestamp'),
+  signature: this.req.get('X-Bachs-Signature')
+})
+```
+
+## Provider inputs
+
+The method name stays standard, but the signing inputs depend on the active provider.
+
+| Provider | Inputs                                                                                     |
+| -------- | ------------------------------------------------------------------------------------------ |
+| Bachs    | `rawBody`, `timestamp`, `signature`, optional `webhookSecret`, optional `toleranceSeconds` |
+
+For Bachs, `timestamp` should come from `X-Bachs-Timestamp` and `signature` should come from `X-Bachs-Signature`.
+
+## Response codes
+
+Return `200` after the event is processed or acknowledged. Return `401` when signature verification fails.
+
+| Status | When                                                                    |
+| ------ | ----------------------------------------------------------------------- |
+| `200`  | Event processed successfully, or an unknown event type was acknowledged |
+| `401`  | Missing, stale, or invalid webhook signature                            |
+
+Returning a non-2xx status tells the payment provider to retry delivery. That is useful for temporary failures, but noisy for event types you intentionally do not handle.
+
+## Idempotency
+
+Payment providers can deliver the same webhook more than once. Your handler should be idempotent: processing the same event twice should leave your database in the same final state.
+
+Use provider event IDs, checkout IDs, charge IDs, or your own payment reference to find the existing local record before creating or granting access.
+
+```js
+const payment = await Payment.findOne({
+  provider: 'bachs',
+  chargeId: event.data.charge_id
+})
+
+if (payment && payment.status === 'paid') {
+  return { received: true }
+}
+```


### PR DESCRIPTION
Closes #101

## Summary
- add a Bachs provider page for Sails Pay
- add Bachs to the Sails Pay provider sidebar and provider tables
- add a shared Webhooks section documenting sails.pay.webhooks.verify()
- update checkout and transaction docs for Bachs checkout lookup and charge verification

## Verification
- npm run build