### PR TITLE
docs(slipway): explain firewall requirements

### DIFF
--- a/docs/slipway/first-deploy.md
+++ b/docs/slipway/first-deploy.md
@@ -116,6 +116,20 @@ $ slipway slide
   URL: https://my-sails-app.example.com
 ```
 
+## Verify Direct Access
+
+Slipway assigns the deployment a direct URL using a port from `1338–1500`. Test it from your computer or another network so the request crosses the provider firewall:
+
+```bash
+curl -I --connect-timeout 5 http://YOUR_SERVER_IP:ALLOCATED_PORT/health
+```
+
+A successful health response confirms that the app is running and the allocated port is reachable publicly. If the deployment log confirms a healthy container and a live Docker mapping but this request times out, allow the allocated port in both the VPS provider firewall and any active host firewall.
+
+::: tip Custom Domains
+Direct URLs are useful during setup and troubleshooting. Applications with a [custom domain](/slipway/custom-domain) receive traffic through ports `80` and `443` instead.
+:::
+
 ## Set Environment Variables
 
 Most Sails apps need environment variables. Set them before or after deploying:

--- a/docs/slipway/philosophy-and-architecture.md
+++ b/docs/slipway/philosophy-and-architecture.md
@@ -131,6 +131,8 @@ Slipway uses [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-p
 
 No Nginx config files. No manual cert renewal. No `certbot` cron jobs.
 
+The allocated port also provides a direct `http://SERVER_IP:PORT` endpoint. That endpoint must be allowed through both the server's host firewall and any firewall managed by the VPS provider. Domain traffic only requires public access to ports `80` and `443`.
+
 ### How Deployments Work
 
 Slipway uses **blue-green deployments** for zero downtime:

--- a/docs/slipway/requirements.md
+++ b/docs/slipway/requirements.md
@@ -50,14 +50,20 @@ Slipway's install script will automatically install Docker if it's not already p
 
 ## Network Requirements
 
-| Port | Purpose                                  | Required    |
-| ---- | ---------------------------------------- | ----------- |
-| 80   | HTTP traffic                             | Yes         |
-| 443  | HTTPS traffic                            | Yes         |
-| 1337 | Slipway dashboard (before custom domain) | Yes         |
-| 22   | SSH access                               | Recommended |
+| Port      | Purpose                                   | Required                          |
+| --------- | ----------------------------------------- | --------------------------------- |
+| 80        | HTTP traffic and certificate provisioning | Yes                               |
+| 443       | HTTPS traffic                             | Yes                               |
+| 1337      | Slipway dashboard before adding a domain  | Yes during initial setup          |
+| 1338–1500 | Direct application URLs using `IP:port`   | Only when direct access is needed |
+| 22        | SSH access                                | Recommended                       |
 
-Make sure these ports are open in your firewall/security group.
+These ports may need to be allowed at two separate network boundaries:
+
+1. **The host firewall** running on the server, such as UFW or firewalld. The installer adds the Slipway ports when either firewall is already active. It does not enable a firewall or change SSH rules.
+2. **The provider firewall or security group** managed by Hetzner, DigitalOcean, AWS, or your VPS provider. Slipway cannot change these rules, so you must configure them in your provider's control panel.
+
+Applications served through a configured domain only need public access to ports `80` and `443`. Open `1338–1500` when you want Slipway's direct application URLs to be reachable from outside the server.
 
 ## CLI Requirements
 

--- a/docs/slipway/server-installation.md
+++ b/docs/slipway/server-installation.md
@@ -35,7 +35,8 @@ This script will:
 4. Generate secrets (`SESSION_SECRET` and `DATA_ENCRYPTION_KEY`) and save them to `/etc/slipway/.env`
 5. Start the Caddy reverse proxy
 6. Pull and start the Slipway dashboard
-7. Display your access URL
+7. Add Slipway's ports to UFW or firewalld when either host firewall is active
+8. Display your access URL
 
 ## What Gets Installed
 
@@ -99,6 +100,10 @@ http://YOUR_SERVER_IP:1337
 
 ::: warning Before Custom Domain
 Until you configure a custom domain, Slipway runs on port 1337 with HTTP. For production use, you should [configure a custom domain](/slipway/custom-domain) to enable HTTPS.
+:::
+
+::: warning Provider Firewall
+The installer can configure an active firewall on the server, but it cannot change a firewall or security group managed by your VPS provider. Allow the required ports in the provider's control panel too. See [Network Requirements](/slipway/requirements#network-requirements) for the complete port list.
 :::
 
 ## Manual Installation


### PR DESCRIPTION
## Summary
- document the host and VPS-provider firewall boundaries
- list the direct application port range and when it must be public
- add an external direct-access smoke test and focused timeout diagnosis
- clarify that custom-domain traffic only requires ports 80 and 443

## Verification
- `npm run lint`
- `npm run build`

## Dependency
Merge after sailscastshq/slipway#246, which implements the documented installer and direct-access behavior.

Resolves sailscastshq/slipway#241 once the implementation PR is merged.