### PR TITLE
docs(slipway): document recent platform improvements

### DIFF
--- a/docs/slipway/bridge.md
+++ b/docs/slipway/bridge.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: Bridge
 titleTemplate: Slipway
-description: An auto-generated data management interface for your Sails models. View, create, edit, and manage your data.
+description: Manage Waterline records through a server-enforced, configurable resource interface.
 prev:
   text: Helm
   link: /slipway/helm
@@ -17,151 +17,271 @@ editLink: true
 
 # Bridge
 
-Bridge is an auto-generated data management interface for your Sails applications.
+Bridge is Slipway's data management interface for Sails applications. It discovers the Waterline models in a running app and provides list, detail, create, edit, and delete surfaces without requiring a second admin schema.
 
-## What is Bridge?
+Use the zero-configuration interface for internal tools and early applications. Add a resource contract when Bridge should become a deliberately curated operational or content-management surface.
 
-Bridge automatically generates a full data management interface from your Sails models:
+## Requirements
 
-- **List views** with sorting, search, and pagination
-- **Create/Edit forms** with proper field types
-- **Relationship management** (belongsTo, hasMany)
-- **Bulk delete**
-- **Detail views** with related records
+- The target Sails app must be running.
+- The models you want to manage must be available through `sails.models`.
+- The signed-in Slipway user must have access to the project and environment.
 
-No configuration required—Bridge introspects your models and generates the UI automatically.
+Open an app in Slipway, use its ellipsis menu, and select **Bridge**.
 
-## Accessing Bridge
+## Zero-configuration discovery
 
-### Via Dashboard
+Without Bridge configuration, Slipway derives sensible defaults from Waterline metadata:
 
-1. Go to your project in Slipway
-2. Select an environment and click the app name from the Apps list
-3. Click the ellipsis dropdown menu and select **Bridge**
-4. Browse your models
+- labels from model and attribute names;
+- a compact list of useful columns;
+- search across visible string attributes;
+- create and edit forms for writable attributes;
+- relationship selectors for `model` associations;
+- related-record lists for `collection` associations; and
+- the model's actual primary key for record routes.
 
-Your app must be running for Bridge to work — it reads model definitions from the running container.
+Encrypted and protected attributes are not exposed by the default visible surfaces.
 
-## How It Works
+Bridge introspects the running container and caches the normalized contract for 10 minutes. Redeploy the app or wait for the cache to refresh after changing model metadata or `config/slipway.js`.
 
-Bridge works by remotely introspecting your deployed Sails app:
+## Configure the resource contract
 
-1. Slipway executes code inside your running container via `docker exec`
-2. It reads all your model definitions — attributes, types, validations, associations
-3. It caches this schema (refreshed every 10 minutes)
-4. All CRUD operations are executed remotely in the container context
+Create `config/slipway.js` in the application repository:
 
-This means Bridge always reflects your **actual model definitions** — no separate config to keep in sync.
-
-## Auto-Generated Interface
-
-### Model Detection
-
-Bridge automatically detects all models in `api/models/`:
-
-```
-api/models/
-├── User.js       → Bridge shows "User" with all attributes
-├── Post.js       → Bridge shows "Post" with all attributes
-├── Comment.js    → Bridge shows "Comment" with all attributes
-└── Order.js      → Bridge shows "Order" with all attributes
-```
-
-### Field Type Mapping
-
-Waterline types are automatically mapped to appropriate UI controls:
-
-| Waterline Type | Bridge Control |
-| -------------- | -------------- |
-| `string`       | Text input     |
-| `text`         | Textarea       |
-| `number`       | Number input   |
-| `boolean`      | Toggle switch  |
-| `json`         | JSON editor    |
-| `ref` (date)   | Date picker    |
-
-### Relationship Detection
-
-Associations are automatically rendered:
-
-```javascript
-// api/models/Post.js
-module.exports = {
-  attributes: {
-    title: { type: 'string' },
-    content: { type: 'string' },
-
-    // belongsTo — rendered as dropdown
-    author: { model: 'user' },
-
-    // hasMany — rendered as related list
-    comments: { collection: 'comment', via: 'post' }
-  }
-}
-```
-
-## Features
-
-### List View
-
-The list view provides:
-
-- **Sortable columns** — Click headers to sort
-- **Search** — Search across record fields
-- **Pagination** — Navigate through records
-- **Record counts** — See total records per model
-
-### Create/Edit Forms
-
-Forms are auto-generated based on your model attributes:
-
-- Required fields are marked
-- Field types match your Waterline definitions
-- Validation rules (isEmail, isIn, etc.) are respected
-- `encrypt` fields are handled appropriately
-
-### Detail View
-
-View a single record with all its data and relationships. Associated records are shown inline — belongsTo shows the related record, hasMany shows the collection.
-
-### Bulk Delete
-
-Select multiple records from the list view and delete them in one action.
-
-## Configuration
-
-Bridge configuration is done via `config/slipway.js` in your Sails app:
-
-```javascript
-// config/slipway.js
+```js
 module.exports.slipway = {
   bridge: {
-    // Models to exclude from Bridge
-    hidden: ['Session', 'Archive']
+    schemaVersion: 1,
+    resources: {
+      course: {
+        label: 'Courses',
+        singularLabel: 'Course',
+        group: 'Content',
+        title: 'title',
+        search: ['title'],
+        list: ['title', 'published', 'createdAt'],
+        show: [
+          'id',
+          'title',
+          'description',
+          'thumbnailUrl',
+          'published',
+          'creator'
+        ],
+        create: [
+          'title',
+          'description',
+          'thumbnailUrl',
+          'published',
+          'creator'
+        ],
+        edit: ['title', 'description', 'thumbnailUrl', 'published', 'creator'],
+        filters: ['published'],
+        sort: {
+          field: 'createdAt',
+          direction: 'DESC'
+        },
+        actions: {
+          bulkDelete: false
+        },
+        fields: {
+          title: {
+            label: 'Course title',
+            placeholder: 'A clear, specific course title'
+          },
+          description: {
+            label: 'Course description',
+            type: 'richtext',
+            format: 'markdown',
+            help: 'The public description shown on the course page.'
+          },
+          thumbnailUrl: {
+            label: 'Thumbnail',
+            type: 'upload',
+            upload: {
+              kind: 'image',
+              storage: 'bridge',
+              directory: 'courses/thumbnails',
+              store: 'url'
+            }
+          }
+        }
+      },
+
+      auditLog: false
+    }
   }
 }
 ```
 
-::: tip
-Bridge reads your model definitions directly — it doesn't need you to duplicate your schema in a config file. Configuration is only needed for customizing Bridge's behavior, not describing your models.
+`schemaVersion: 1` is the current contract. Slipway rejects unsupported versions, unknown resource options, and references to fields that do not exist. This makes configuration mistakes visible instead of silently exposing a different surface.
+
+## Discovery modes
+
+`discover` defaults to `true`. Configured resources are merged over discovered Waterline metadata, while unconfigured models retain generated defaults.
+
+Set `discover: false` to expose only explicitly listed resources:
+
+```js
+module.exports.slipway = {
+  bridge: {
+    schemaVersion: 1,
+    discover: false,
+    resources: {
+      course: {
+        group: 'Content'
+      }
+    }
+  }
+}
+```
+
+Hide one resource by setting it to `false`:
+
+```js
+resources: {
+  course: {},
+  auditLog: false
+}
+```
+
+You can also use `{ hidden: true }` when a complete resource object is easier to generate programmatically.
+
+## Resource options
+
+| Option          | Purpose                                                        |
+| --------------- | -------------------------------------------------------------- |
+| `label`         | Plural name shown in navigation                                |
+| `singularLabel` | Singular name used by forms and record pages                   |
+| `group`         | Navigation group, such as `Content` or `People`                |
+| `title`         | Attribute used to identify a record in menus and relationships |
+| `search`        | Attributes included in text search                             |
+| `list`          | Columns selected and rendered in the list                      |
+| `show`          | Attributes selected for the detail page                        |
+| `create`        | Attributes accepted when creating records                      |
+| `edit`          | Attributes accepted when updating records                      |
+| `filters`       | Attributes available to filter controls                        |
+| `sort`          | Default `{ field, direction }` ordering                        |
+| `hidden`        | Remove the resource from Bridge                                |
+| `actions`       | Enable or disable resource operations                          |
+| `fields`        | Presentation metadata for individual attributes                |
+
+Bridge always includes the model's primary key in `list` and `show`, even when it is omitted from the configured arrays.
+
+## Actions
+
+Every action defaults to `true`:
+
+```js
+actions: {
+  viewAny: true,
+  view: true,
+  create: true,
+  update: true,
+  delete: true,
+  bulkDelete: false
+}
+```
+
+Disabled actions are removed from the interface and rejected by the server. Hiding a button is not the security boundary.
+
+## Field options
+
+| Option        | Purpose                                         |
+| ------------- | ----------------------------------------------- |
+| `label`       | Human-readable field name                       |
+| `type`        | Explicit input renderer                         |
+| `format`      | Stored format, such as `markdown`               |
+| `help`        | Short guidance shown below the field            |
+| `placeholder` | Empty input hint                                |
+| `readOnly`    | Display the field without accepting mutations   |
+| `sortable`    | Allow or prevent list sorting                   |
+| `options`     | Values for a select field                       |
+| `default`     | Initial value in a create form                  |
+| `currency`    | Serializable currency display metadata          |
+| `relation`    | Serializable relationship metadata              |
+| `upload`      | Upload behaviour and canonical storage metadata |
+
+The form supports text, email, password, number, select, toggle, JSON, and long-form inputs. Set `type: 'richtext'` and `format: 'markdown'` to activate the TipTap visual editor while keeping the model value as Markdown.
+
+The editor supports Markdown shortcuts, a compact formatting menu when text is selected, and direct Markdown source editing. Before entering visual mode, Bridge verifies that the value can round-trip safely. Unsupported Markdown stays in source mode instead of being silently rewritten. Rich-text fields without the explicit `markdown` format continue to use a multiline input.
+
+Raw HTML is denied automatically. You do not need another field option. Bridge disables the save with an inline error and repeats the validation on the server before running the target application's mutation. Normal Markdown and autolinks continue to work.
+
+Treat the stored Markdown as untrusted when the application displays it. Parse it with raw HTML disabled and sanitize the generated HTML before rendering. Editor validation protects the Bridge mutation boundary; output sanitization protects the application's readers.
+
+Unrecognized field types use a safe text fallback.
+
+All field metadata must be serializable because the normalized contract is sent to the Bridge client. Functions, symbols, cyclic objects, and secrets are rejected or must remain outside the contract.
+
+## Primary keys
+
+Bridge treats record identifiers as opaque values:
+
+- numeric IDs work normally, including `0`;
+- UUID and other string primary keys are URL-encoded;
+- long identifiers are compacted visually but remain available in full; and
+- queries use the model's configured `primaryKey`, not an assumed `id` column.
+
+Do not parse a Bridge URL to infer that an application's records use integers.
+
+## Server enforcement
+
+The resource contract is an authorization boundary as well as UI configuration:
+
+- list queries select only configured `list` fields;
+- detail and edit queries select only their configured surfaces;
+- create and update payloads reject attributes outside `create` or `edit`;
+- Markdown-backed rich-text mutations reject raw HTML by default;
+- hidden resources and disabled actions cannot be reached by calling their endpoints directly;
+- sort fields and directions are allowlisted; and
+- search values are serialized as data before execution in the target container.
+
+Unknown resources, fields, actions, and configuration options fail closed.
+
+::: warning Keep credentials out of the contract
+Never place R2, S3, database, or API credentials in `config/slipway.js` field metadata. Use app, environment, or instance environment variables. Bridge upload providers use `BRIDGE_`-prefixed variables so each app can override an environment or instance default without exposing credentials to the browser.
 :::
+
+## Upload field boundary
+
+An upload field describes what a future or installed upload renderer should do; it does not contain provider credentials:
+
+```js
+thumbnailUrl: {
+  type: 'upload',
+  upload: {
+    kind: 'image',
+    storage: 'bridge',
+    directory: 'courses/thumbnails',
+    store: 'url'
+  }
+}
+```
+
+The stored model value should be the canonical public URL. Configure provider credentials with `BRIDGE_`-prefixed environment variables at the app level for an app-specific bucket, at the environment level for shared project defaults, or globally for instance defaults.
 
 ## Troubleshooting
 
-### Models Not Appearing
+### Models do not appear
 
-1. Make sure your app is running
-2. Check the model is in `api/models/` and exports a valid Sails model
-3. Wait up to 10 minutes for the model cache to refresh, or redeploy
+1. Confirm the app is running.
+2. Confirm the model is loaded in `sails.models`.
+3. Check `discover` and the resource's `hidden` value.
+4. Check the deployment logs for an unsupported contract option.
+5. Redeploy or allow the 10-minute introspection cache to refresh.
 
-### Relationships Not Working
+### A form field is missing
 
-1. Ensure associations are properly defined with `model:` or `collection:` + `via:`
-2. Check the referenced model exists
-3. Verify the `via` attribute matches the association name on the other side
+Check the correct surface: `create`, `edit`, or `show`. Protected, encrypted, generated timestamp, read-only, and primary-key fields are not writable by default.
 
-## What's Next?
+### A save is rejected
 
-- Use [Helm](/slipway/helm) for direct database queries
-- Set up [Auto-Deploy](/slipway/auto-deploy) for continuous deployment
-- Configure [Team Management](/slipway/team-management) for access control
+Bridge rejects forged or stale attributes before executing the mutation. Reload the page and compare the submitted field with the resource contract.
+
+## What's next?
+
+- Use [Helm](/slipway/helm) for one-off model and helper exploration.
+- Use [Content](/slipway/content) for Git-backed Markdown collections.
+- Configure [Team Management](/slipway/team-management) to control access to the Slipway project.

--- a/docs/slipway/content.md
+++ b/docs/slipway/content.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: Content
 titleTemplate: Slipway
-description: Edit markdown content files directly from the Slipway dashboard. A visual CMS for sails-content powered apps.
+description: Manage sails-content Markdown and JSON files from a visual, Git-backed editor in Slipway.
 prev:
   text: Bridge
   link: /slipway/bridge
@@ -17,237 +17,197 @@ editLink: true
 
 # Content
 
-Content is a **visual CMS** for your [sails-content](https://docs.sailscasts.com/sails-content) powered applications. Edit markdown files, manage frontmatter, and deploy changes—all from the Slipway dashboard.
-
-## What is Content?
-
-Content provides a web-based interface for managing your `sails-content` files:
-
-- **Browse collections** - Navigate your content directory structure
-- **Edit markdown** - Visual editor with live preview
-- **Manage frontmatter** - Edit metadata fields directly
-- **One-click deploy** - Save changes and trigger a deploy
-
-No need to push to git for simple content updates.
+Content is Slipway's Git-backed editor for
+[sails-content](https://docs.sailscasts.com/sails-content) applications. It lets
+an editor manage Markdown, frontmatter, images, and JSON without leaving the
+dashboard while keeping the repository as the source of truth.
 
 ## Requirements
 
-Content is available when your app uses [sails-content](https://docs.sailscasts.com/sails-content):
+Install `sails-content` in the application:
 
 ```bash
 npm install sails-content
 ```
 
-Slipway automatically detects `sails-content` during deployment and enables the Content feature.
+Slipway detects the hook during deployment and enables Content for that
+application. A connected Git repository is recommended: it gives every change
+a durable commit and lets **Save & Deploy** deploy the exact revision that was
+just saved.
 
-## Accessing Content
+## Open Content
 
-### Via Dashboard
+1. Open the project and environment.
+2. Choose **Content**.
+3. Select the application when the environment contains more than one app.
+4. Open a collection and document.
 
-1. Go to your project in Slipway
-2. Select an environment
-3. Click the **Content** icon (document icon with violet color)
-4. Browse your collections
+The production environment uses:
 
-### Via Direct URL
-
-```
-https://your-slipway-instance.com/projects/myapp/content
-```
-
-Or with a specific environment:
-
-```
-https://your-slipway-instance.com/projects/myapp/environments/staging/content
+```text
+/projects/:projectSlug/content
 ```
 
-## Content Structure
+Other environments include the environment slug:
 
-Content follows the standard `sails-content` directory structure:
-
+```text
+/projects/:projectSlug/environments/:environmentSlug/content
 ```
+
+Content follows the normal `sails-content` directory structure:
+
+```text
 content/
 ├── blog/
 │   ├── hello-world.md
-│   ├── getting-started.md
-│   └── advanced-features.md
+│   └── getting-started.md
 ├── docs/
-│   ├── introduction.md
-│   ├── installation.md
-│   └── api-reference.md
-└── pages/
-    ├── about.md
-    └── contact.md
+│   └── installation.md
+└── settings/
+    └── site.json
 ```
 
-Each subdirectory becomes a **collection** in the Content Manager.
+Each directory is shown as a collection. Markdown and JSON files appear as
+records inside it.
 
-## Collections
+## Create a document
 
-### Viewing Collections
+Choose **New content** from a collection, then enter a slug and optional title.
+The slug becomes the filename. For example, `getting-started` creates
+`getting-started.md`.
 
-The Content Manager lists all collections with:
+Slipway creates a Markdown document with initial frontmatter and commits it as:
 
-- Collection name
-- Number of files
-- Individual file listings
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│ Content Manager                               sails-content     │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│ 📁 blog                                    3 files        [+]   │
-│ ├── hello-world                                                 │
-│ ├── getting-started                                             │
-│ └── advanced-features                                           │
-│                                                                 │
-│ 📁 docs                                    3 files        [+]   │
-│ ├── introduction                                                │
-│ ├── installation                                                │
-│ └── api-reference                                               │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
+```text
+chore(content): create blog/getting-started
 ```
 
-### Creating New Content
+Use meaningful, URL-safe slugs because applications commonly use them in public
+routes.
 
-1. Click the **+** button next to a collection
-2. Enter a slug (becomes the filename)
-3. Optionally add a title
-4. Click **Create**
+## Visual Markdown editor
 
-The new file is created with basic frontmatter:
+Markdown files open in a minimal TipTap editor. The document still remains
+Markdown on disk; the visual editor is an authoring surface, not a proprietary
+content format.
+
+You can:
+
+- write headings, paragraphs, lists, blockquotes, links, code, and horizontal
+  rules;
+- use Markdown shortcuts such as `## ` for a heading or `- ` for a list;
+- select text to open the compact formatting menu for bold, italic,
+  strikethrough, inline code, and links;
+- press `Cmd/Ctrl + K` to add a link to selected text;
+- press `Cmd/Ctrl + S` to save;
+- paste a public image URL, or paste and drop image files when uploads are
+  configured.
+
+Choose **Markdown** in the header whenever you want to edit the source directly.
+Choose **Visual** to return to the TipTap surface.
+
+### Safe Markdown round trips
+
+Slipway checks that TipTap can parse and serialize the document without changing
+its meaning. If a file contains syntax the visual editor cannot preserve
+exactly, Slipway keeps it in Markdown mode and explains why. The source remains
+editable and is not silently rewritten.
+
+This protection is important for hand-written Markdown that uses custom HTML,
+unusual extensions, or other constructs outside the visual editor's supported
+set.
+
+## Metadata
+
+Frontmatter appears in a collapsed **Metadata** section above the document.
+Open it to edit values such as title, description, author, publication date, or
+tags.
 
 ```markdown
 ---
-title: My New Post
-createdAt: 2024-01-20T10:30:00.000Z
+title: Getting Started with Sails
+description: Build and deploy your first Sails application.
+published: true
+tags: ['sails', 'deployment']
 ---
-
-# My New Post
-
-Start writing your content here.
 ```
 
-## Editor
+String, number, boolean, array, and object values are serialized back to valid
+frontmatter. Use Markdown mode when a document needs advanced YAML formatting
+that the form cannot represent safely.
 
-### Split View
+## Images
 
-The default editor shows a split view:
+When upload storage is configured in Slipway settings, paste or drop an image
+into the visual editor. Slipway:
 
-- **Left**: Edit panel with frontmatter and markdown body
-- **Right**: Live preview of rendered content
+1. accepts AVIF, GIF, JPEG, PNG, and WebP files up to 5 MB;
+2. uploads the file through the authenticated Content endpoint;
+3. validates the returned URL;
+4. inserts the image URL and editable alt text into the Markdown.
 
-### Editor Modes
+If uploads are not configured, paste a public image URL instead. Storage
+credentials stay in Slipway settings and are never written into the content
+file.
 
-Toggle between modes using the toolbar:
+## Save and deploy
 
-| Mode        | Description                     |
-| ----------- | ------------------------------- |
-| **Edit**    | Full-width editor, no preview   |
-| **Split**   | Side-by-side editor and preview |
-| **Preview** | Full-width preview only         |
+The main **Save** action records the change without deploying. Its menu also
+offers **Save & Deploy**.
 
-### Raw Mode
+With a connected GitHub repository, saving:
 
-Click the code icon to toggle raw mode:
+1. checks that the file has not changed since the editor loaded it;
+2. commits the update to the application's configured branch;
+3. refreshes Slipway's local build context only after the repository write
+   succeeds.
 
-- Edit the complete file including YAML frontmatter
-- Useful for complex frontmatter or troubleshooting
+Updates use a conventional commit such as:
 
-### Keyboard Shortcuts
-
-| Shortcut       | Action                 |
-| -------------- | ---------------------- |
-| `Cmd/Ctrl + S` | Save without deploying |
-
-## Frontmatter
-
-### Editing Frontmatter
-
-The editor displays frontmatter fields as form inputs:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│ FRONTMATTER                                                     │
-├─────────────────────────────────────────────────────────────────┤
-│ title      │ Getting Started with Sails                       │ │
-│ author     │ John Doe                                          │ │
-│ date       │ 2024-01-20                                        │ │
-│ tags       │ ["sails", "nodejs", "tutorial"]                   │ │
-└─────────────────────────────────────────────────────────────────┘
+```text
+chore(content): update blog/getting-started
 ```
 
-### Supported Types
+**Save & Deploy** then queues a deployment pinned to that commit SHA. A later
+push to the branch cannot change what that deployment builds.
 
-Frontmatter values are preserved as their original types:
+For applications without a writable repository source, Slipway can keep the
+local content source in sync, but durable repository history and exact Git
+revisions require a connected repository.
 
-- **Strings**: Regular text input
-- **Numbers**: Preserved as numbers
-- **Booleans**: true/false values
-- **Arrays**: JSON arrays
-- **Objects**: JSON objects
-
-## Saving and Deploying
-
-### Save Only
-
-Click **Save** to write changes to the file without deploying:
-
-- Changes are saved to disk immediately
-- The running app won't see changes (SSG mode)
-- Use this when making multiple edits
-
-### Save & Deploy
-
-Click **Save & Deploy** to:
-
-1. Save the file
-2. Trigger a new deployment
-3. Redirect to the deployment page
-
-::: tip SSG Mode
-sails-content uses Static Site Generation (SSG). Content is compiled at build time, so changes require a redeploy to take effect.
+::: tip Static content
+Applications that compile content at build time need **Save & Deploy** before
+the change appears in the running release.
 :::
 
-## Deleting Content
+## Concurrent edits
 
-1. Open the content file in the editor
-2. Click the trash icon in the toolbar
-3. Confirm the deletion
+The editor remembers the Git blob SHA that was loaded. If another person or
+process changes the file first, Slipway rejects the stale save instead of
+overwriting the newer content.
 
-::: warning
-Deleting content removes the file permanently. Consider saving a backup before deleting important content.
-:::
+Reload the document, review the newer version, reapply the intended edit, and
+save again.
 
-## File Types
+## Delete a document
 
-Content supports both Markdown and JSON files:
+Open the save menu, choose **Delete**, and confirm the destructive action.
+Slipway checks the loaded blob SHA before deleting and records a commit such as:
 
-### Markdown Files (.md)
-
-Standard markdown with YAML frontmatter:
-
-```markdown
----
-title: Hello World
-author: Jane Doe
-publishedAt: 2024-01-20
----
-
-# Hello World
-
-This is the body content in **markdown**.
+```text
+chore(content): delete blog/getting-started
 ```
 
-### JSON Files (.json)
+The repository history remains the recovery path for Git-backed content.
+Deleting local-only content cannot be undone from the dashboard.
 
-Structured data without a markdown body:
+## JSON files
+
+JSON records use a source editor rather than the visual Markdown surface:
 
 ```json
 {
-  "title": "Site Configuration",
+  "title": "Site configuration",
   "navigation": [
     { "label": "Home", "url": "/" },
     { "label": "About", "url": "/about" }
@@ -255,119 +215,36 @@ Structured data without a markdown body:
 }
 ```
 
-## API Endpoints
-
-Content provides REST API endpoints for programmatic access:
-
-### List Collections
-
-```bash
-GET /api/v1/projects/:projectSlug/content/collections
-```
-
-### Get Content
-
-```bash
-GET /api/v1/projects/:projectSlug/content/:collection/:file
-```
-
-### Create Content
-
-```bash
-POST /api/v1/projects/:projectSlug/content/:collection
-
-{
-  "slug": "my-new-post",
-  "title": "My New Post",
-  "body": "Initial content..."
-}
-```
-
-### Update Content
-
-```bash
-PUT /api/v1/projects/:projectSlug/content/:collection/:file
-
-{
-  "frontmatter": { "title": "Updated Title" },
-  "body": "Updated content...",
-  "deploy": true
-}
-```
-
-### Delete Content
-
-```bash
-DELETE /api/v1/projects/:projectSlug/content/:collection/:file
-```
-
-## Best Practices
-
-### 1. Use Meaningful Slugs
-
-Slugs become URLs, so use descriptive, URL-friendly names:
-
-```
-# Good
-getting-started-with-sails
-api-authentication-guide
-
-# Avoid
-post-1
-untitled-2024-01-20
-```
-
-### 2. Consistent Frontmatter
-
-Use consistent frontmatter fields across collections:
-
-```yaml
----
-title: Post Title
-description: Brief description for SEO
-author: Author Name
-publishedAt: 2024-01-20
-tags: ['tag1', 'tag2']
----
-```
-
-### 3. Preview Before Deploying
-
-Use the preview mode to check rendering before deploying.
-
-### 4. Batch Edits Together
-
-When making multiple edits, save without deploying, then deploy once at the end.
+Slipway preserves the raw JSON file and applies the same Git conflict protection
+when saving it.
 
 ## Troubleshooting
 
-### Content Not Appearing
+### Content is not available
 
-If the Content feature isn't showing:
+1. Confirm `sails-content` is installed in the application.
+2. Deploy the application so Slipway can detect its features.
+3. Confirm you are viewing the correct application and environment.
 
-1. Verify `sails-content` is in your `package.json`
-2. Deploy your app (detection happens during deployment)
-3. Check the environment page for the content icon
+### Visual mode is unavailable
 
-### Changes Not Visible
+Read the warning above the Markdown source. The file contains syntax that
+Slipway cannot round-trip safely. Continue in Markdown mode or simplify the
+unsupported construct.
 
-Remember that sails-content uses SSG:
+### A save conflicts
 
-1. Save your changes
-2. Click "Save & Deploy"
-3. Wait for the deployment to complete
-4. Your changes are now live
+The repository version changed after the editor loaded. Reload before making
+another save so the newer change is not overwritten.
 
-### Frontmatter Parse Errors
+### A saved change is not live
 
-If frontmatter isn't parsing correctly:
+Use **Save & Deploy** and wait for the pinned deployment to become healthy.
+Saving alone does not rebuild an application that compiles content at build
+time.
 
-1. Switch to raw mode
-2. Check YAML syntax (proper indentation, colons, quotes)
-3. Validate complex values are proper JSON/YAML
+## What's next?
 
-## What's Next?
-
-- Learn about [sails-content](https://docs.sailscasts.com/sails-content) for setting up content in your app
-- Use [Helm](/slipway/helm) for database queries
-- Set up [Auto-Deploy](/slipway/auto-deploy) for git-based deployments
+- Configure [file uploads](/slipway/file-uploads) for pasted and dropped images.
+- Use [Auto-Deploy](/slipway/auto-deploy) for other repository changes.
+- Learn more about [sails-content](https://docs.sailscasts.com/sails-content).

--- a/docs/slipway/creating-projects.md
+++ b/docs/slipway/creating-projects.md
@@ -255,26 +255,27 @@ slipway project:update my-sails-app \
 ## Deleting Projects
 
 ::: danger Destructive Action
-Deleting a project removes all environments, deployments, and data.
+Deleting a project removes its applications, environments, routes, and
+deployment records from Slipway. Recovery data is retained by default.
 :::
 
-```bash
-slipway project:destroy my-sails-app
-```
+Open **Project Settings**, choose **Delete project**, and confirm the action.
+Slipway stops active work, removes traffic routes and running containers, and
+cleans up the project's control-plane records.
 
-You'll be prompted to confirm:
+By default, service volumes, backups, application source, and Docker images are
+retained as recovery data. Select **Also permanently delete retained data** only
+when you intentionally want to purge those artifacts as well.
 
-```
-Are you sure you want to delete 'my-sails-app'?
-This will delete:
-  - 2 environments (production, staging)
-  - 15 deployments
-  - All environment variables
+::: warning Purging cannot be undone
+The purge option deletes service volumes, backups, source, and Docker images.
+Confirm that any required database backup or source revision exists somewhere
+outside the Slipway host first.
+:::
 
-Type 'my-sails-app' to confirm: my-sails-app
-
-✓ Project deleted
-```
+Environment, application, and service deletion use the same explicit retention
+model. Automatically-created preview environments are an exception: Slipway
+purges them when their lifecycle ends because they are temporary by design.
 
 ## Best Practices
 

--- a/docs/slipway/database-services.md
+++ b/docs/slipway/database-services.md
@@ -28,6 +28,21 @@ Slipway provisions and manages databases for your Sails applications from the sa
 | **Redis**      | Key-Value  | Caching, sessions, queues       |
 | **MongoDB**    | Document   | Document-based storage          |
 
+## Tested image versions
+
+Slipway provisions new services from tested numeric Docker tags and records the immutable digest or image ID that Docker actually ran. New services never store `latest`.
+
+| Service    | Default | Other tested line | Automated upgrade |
+| ---------- | ------- | ----------------- | ----------------- |
+| PostgreSQL | 17      | 16                | 16 → 17           |
+| MySQL      | 8.4     | 8.0               | 8.0 → 8.4         |
+| Redis      | 7.2     | —                 | Not yet           |
+| MongoDB    | 8.0     | 7.0               | 7.0 → 8.0         |
+
+Docker may publish newer patches within a supported line, but restarting, recreating, restoring, or updating Slipway reuses the exact image recorded for that service.
+
+Existing services created with `latest` are migrated conservatively. Slipway inspects the running container, records its actual image and digest, and leaves its volume untouched. If the original container no longer exists, the version remains visibly unresolved rather than being guessed.
+
 ## Creating a Database
 
 ### Via CLI
@@ -37,10 +52,15 @@ Slipway provisions and manages databases for your Sails applications from the sa
 slipway db:create mydb
 
 # Explicit type
-slipway db:create mydb --type=postgres
+slipway db:create mydb --type=postgresql
 slipway db:create cache --type=redis
 slipway db:create docs --type=mongodb
+
+# Choose another tested line
+slipway db:create legacy-db --type=postgresql --version=16
 ```
+
+Custom versions must be numeric tags such as `17.4` or `8.0.12`. Mutable aliases, image variants, repository names, and shell syntax—such as `latest`, `17-alpine`, or `postgres:17`—are rejected.
 
 ### Via Dashboard
 
@@ -104,6 +124,25 @@ slipway db:unlink mydb myapp
 ```
 
 This removes the environment variable. The database itself is not deleted.
+
+## Upgrading a service
+
+Supported adjacent upgrades appear on the service settings page. An upgrade is a recoverable data migration, not an in-place image restart:
+
+1. Slipway creates and verifies a logical backup in configured object storage.
+2. It resolves the target image before interrupting the running service.
+3. It starts the target version on a fresh named volume.
+4. It restores the verified backup and waits for the database to become ready.
+5. It promotes the restored container to the canonical service name.
+6. It retains the stopped previous container and volume for explicit recovery.
+
+The settings page streams every step. Backup, image pull, startup, and restore failures stop before promotion.
+
+Slipway only automates tested adjacent major-version upgrades. It does not automate downgrades, skipped releases, custom-version upgrades, or Redis upgrades without a verified restore path.
+
+::: warning Verify before cleanup
+After an upgrade, verify application reads and writes before deleting the retained previous container or volume. The service settings page records the exact previous container and backup used for recovery.
+:::
 
 ## Connecting Directly
 
@@ -298,6 +337,12 @@ slipway db:restore mydb mydb-2024-01-20-143022.sql.gz --from-s3
 ::: danger Destructive Operation
 Restoring a backup will **replace all data** in the database. Make sure you have a recent backup before restoring.
 :::
+
+### Large backups and restores
+
+Backup creation, object-storage upload/download, restore, and Dock SQL imports are streamed through files and child processes instead of being buffered into Slipway's memory. Slipway checks disk capacity before materializing temporary data and enforces configured byte limits while streaming.
+
+This lets backup size be governed by available disk and configured limits rather than the Slipway Node.js process heap. A failed stream or database process produces an explicit error and cleans up its temporary files.
 
 ### Download Backup
 

--- a/docs/slipway/deployment-logs.md
+++ b/docs/slipway/deployment-logs.md
@@ -278,6 +278,20 @@ If `--app` is omitted, logs are shown for the default app.
 - Time range selection
 - Download logs
 
+### Browser-tab deployment status
+
+Slipway also reflects deployment state in the browser favicon, so you can keep working in another tab without losing the outcome:
+
+| Favicon state | Meaning                                     |
+| ------------- | ------------------------------------------- |
+| Deploying     | At least one deployment is queued or active |
+| Success       | A deployment completed successfully         |
+| Failed        | A deployment failed                         |
+| Cancelled     | A deployment was cancelled                  |
+| Idle          | No active or recently completed deployment  |
+
+Active work always takes precedence over a completed state. Success remains visible for about 10 seconds; failed and cancelled states remain for about 12 seconds. Opening or returning to the relevant Slipway tab acknowledges the terminal state, after which the normal idle icon returns.
+
 ## Configuring Sails Logging
 
 ### Log Levels

--- a/docs/slipway/dock.md
+++ b/docs/slipway/dock.md
@@ -85,6 +85,21 @@ Results display in a formatted table with:
 - Query execution time
 - Scrollable data view
 
+When the editor contains more than one SQL statement, Dock keeps a separate,
+labeled result for every statement. Select the result tabs to move between
+rowsets, command summaries, and errors. The tabs support the left and right
+arrow keys, and each rowset can be copied as CSV independently.
+
+```sql
+SELECT count(*) AS creators FROM creators;
+SELECT count(*) AS teams FROM teams;
+```
+
+The results remain in statement order. If a later statement fails outside an
+explicit transaction, Dock preserves the earlier results so you can see exactly
+what ran before the failure. If you need all-or-nothing behavior, wrap the
+statements in `BEGIN` and `COMMIT`.
+
 ### Safety Features
 
 Dock blocks dangerous queries that could harm your database:
@@ -94,6 +109,21 @@ Dock blocks dangerous queries that could harm your database:
 - System table modifications
 
 For destructive operations, use a dedicated migration or backup first.
+
+## Importing SQL and database dumps
+
+Use **Import** to paste SQL or upload a database dump. Slipway streams uploaded
+data through a temporary file rather than loading the complete backup into
+application memory.
+
+The default maximum import size is 500 MB. Operators can change it with the
+database operation limits in Slipway's server configuration. An oversized
+upload is rejected before it reaches the database, and the temporary file is
+removed after either success or failure.
+
+PostgreSQL custom-format dumps and MySQL/SQL text imports use their native
+database clients. Import errors are returned in Dock so a failed restore does
+not look successful.
 
 ## Table Browser
 
@@ -360,6 +390,15 @@ For long-running queries:
 1. Default timeout is 30 seconds
 2. Optimize your query (add indexes, limit results)
 3. For complex reports, consider using a read replica
+
+### Import Rejected
+
+If a dump is rejected before it begins:
+
+1. Check its size against the configured import limit.
+2. Confirm that its format matches the selected database service.
+3. Check available host disk space; streaming avoids a memory spike but the
+   temporary upload still needs disk capacity.
 
 ### Migration Fails
 

--- a/docs/slipway/environment-variables.md
+++ b/docs/slipway/environment-variables.md
@@ -131,6 +131,44 @@ slipway slide
 Future versions will support automatic container restarts when variables change.
 :::
 
+## Referencing other variables
+
+Values may reference another effective environment variable with `$NAME` or `${NAME}`:
+
+```bash
+HOST=app.internal
+ORIGIN=http://$HOST:${PORT}
+HEALTH_URL=${ORIGIN}/health
+```
+
+When the container starts, Slipway resolves the merged global, environment, app, and Slipway-owned runtime values:
+
+```text
+HOST=app.internal
+ORIGIN=http://app.internal:1337
+HEALTH_URL=http://app.internal:1337/health
+```
+
+`PORT` is the internal port assigned to the running application, not the public host port.
+
+Use `$$` for a literal dollar sign:
+
+```bash
+TEMPLATE=literal=$$PORT resolved=$PORT
+```
+
+This becomes:
+
+```text
+TEMPLATE=literal=$PORT resolved=1337
+```
+
+::: info Safe expansion
+Expansion is performed without a shell. Command substitutions, backticks, and other shell-like text are passed to Docker as literal data and are never executed. Unknown references and cyclic references remain unchanged instead of being guessed.
+:::
+
+Expanded values are limited to 1 MiB, and deeply recursive reference graphs stop safely. Keep reference chains short enough that another operator can understand the effective value.
+
 ## Environment-Specific Variables
 
 ### Multiple Environments

--- a/docs/slipway/how-deployments-work.md
+++ b/docs/slipway/how-deployments-work.md
@@ -21,24 +21,41 @@ Understanding the deployment process helps you debug issues and optimize your wo
 
 ## The Deployment Pipeline
 
-When you run `slipway slide`, here's what happens:
+Every deployment—CLI, Git, dashboard, API, or Content—enters the same coordinated pipeline:
 
 ```
-┌──────────────┐    ┌──────────────┐    ┌──────────────┐
-│   Package    │ -> │    Build     │ -> │    Push      │
-│   Source     │    │    Image     │    │   to Server  │
-└──────────────┘    └──────────────┘    └──────────────┘
-                                               │
-                                               ▼
-┌──────────────┐    ┌──────────────┐    ┌──────────────┐
-│   Update     │ <- │    Start     │ <- │    Stop      │
-│   Proxy      │    │    New       │    │    Old       │
-└──────────────┘    └──────────────┘    └──────────────┘
+Source readiness → Queue → Build image → Start candidate
+       → Health check → Transactional traffic cutover → Finalize
 ```
+
+Slipway keeps the current release serving traffic until the candidate is healthy and the proxy update has been verified.
 
 ## Step-by-Step
 
-### 1. Package Source Code
+### 1. Verify source readiness
+
+Before creating active work, Slipway confirms that the target app has deployable source:
+
+- a connected Git repository and branch;
+- a source archive previously pushed by the Slipway CLI; or
+- an exact commit created by the Content Manager.
+
+Dashboard redeploys work for both Git-connected and CLI-pushed applications. If no source is available, Slipway stops during preflight and displays the actionable reason instead of creating an unexplained failed deployment.
+
+### 2. Queue and coordinate
+
+Only one deployment can build or change traffic for an app at a time. Additional deployments remain **Queued** and start in order after the active deployment reaches a terminal state.
+
+This prevents two builds, rollbacks, or proxy updates for the same app from racing each other. Different apps can still deploy independently.
+
+Slipway records the queue and lease in its database. After a Slipway or host restart, reconciliation:
+
+- resumes eligible queued work;
+- marks interrupted work with an accurate terminal state;
+- removes abandoned candidate containers and proxy transactions; and
+- restores the app's status from the running Docker container.
+
+### 3. Package or fetch source code
 
 ```bash
 $ slipway slide
@@ -55,7 +72,7 @@ Slipway packages your code using `git archive`:
 - `node_modules/` is excluded (installed during build)
 - Untracked files are excluded
 
-### 2. Upload to Server
+### 4. Upload to Server
 
 ```bash
   ▶ Uploading to server...
@@ -65,7 +82,7 @@ Slipway packages your code using `git archive`:
 
 The archive is uploaded to your Slipway server via HTTPS.
 
-### 3. Build Docker Image
+### 5. Build Docker Image
 
 ```bash
   ▶ Building image...
@@ -87,7 +104,7 @@ Slipway builds a Docker image using your `Dockerfile`:
 - Assets compiled (if using Shipwright/Vite)
 - Image tagged with deployment ID
 
-### 4. Stop Old Container (Zero-Downtime)
+### 6. Start a candidate release
 
 ```bash
   ▶ Starting zero-downtime deployment...
@@ -101,7 +118,7 @@ For zero-downtime deploys:
 3. Once healthy, traffic switches
 4. Old container stops
 
-### 5. Start New Container
+### 7. Verify candidate health
 
 ```bash
   ▶ Starting new container...
@@ -118,7 +135,7 @@ The new container:
 - Links to database services
 - Starts the Sails application
 
-### 6. Update Proxy Routes
+### 8. Cut over traffic transactionally
 
 ```bash
   ▶ Updating proxy routes...
@@ -132,7 +149,17 @@ Caddy is updated to route traffic to the new container:
 - WebSocket support enabled
 - SSL termination active
 
-### 7. Cleanup
+The cutover is a transaction:
+
+1. Slipway snapshots the current route.
+2. It writes the candidate route.
+3. Caddy validates and reloads the configuration.
+4. Slipway verifies that the expected route is active.
+5. Only then does it finalize the new release and stop the previous container.
+
+If writing, reloading, or verifying the route fails, Slipway restores the previous route and keeps the previous release serving traffic.
+
+### 9. Cleanup
 
 ```bash
   ▶ Cleaning up...
@@ -143,6 +170,25 @@ Caddy is updated to route traffic to the new container:
   ✓ Deployed myapp (abc123) in 42s
     https://myapp.example.com
 ```
+
+## Cancelling a deployment
+
+Cancelling is cooperative process termination, not only a status change. Slipway stops an active Docker build, health check, source operation, or rollback; removes candidate artifacts; releases the app's deployment lease; and starts the next queued deployment when appropriate.
+
+If cancellation happens before traffic cutover, the current release remains untouched. If a cutover transaction has begun, Slipway restores the previous verified route before cleanup.
+
+The deployment page records who cancelled the work and whether any candidate release was removed.
+
+## Deployment history
+
+Deployment history is ordered from the app's actual current and active state:
+
+1. executing work;
+2. current releases;
+3. queued deployments in queue order; and
+4. completed history from newest to oldest.
+
+Each row identifies the app, status, source, actor, branch, commit, and creation time. The history updates active statuses without requiring a full page refresh.
 
 ## The Dockerfile
 

--- a/docs/slipway/lookout.md
+++ b/docs/slipway/lookout.md
@@ -55,6 +55,22 @@ The **Infrastructure** tab shows real-time resource usage for all running contai
 
 Click a container to expand its 24-hour history chart.
 
+### Collection and retention health
+
+Lookout stores infrastructure samples and application telemetry in
+`db/observability.db`. The host-health card shows the latest collector and
+retention state, including:
+
+- the last attempt and last successful run;
+- the number of retained rows;
+- a stale or failed state and the latest error.
+
+Docker collection and storage maintenance are deliberately independent.
+Container metrics are collected every 30 seconds, while the
+`maintain-observability` Quest job checks disk health and removes expired rows
+every 5 minutes. Retention therefore continues even when Docker is temporarily
+unavailable or no application containers are running.
+
 ## Requests
 
 The **Requests** tab shows HTTP traffic from the last hour:
@@ -140,6 +156,35 @@ module.exports.slipway = {
 ::: tip
 When deployed via Slipway, you don't need to set `telemetryUrl` or `telemetryToken` — they're injected automatically.
 :::
+
+## Data retention
+
+Slipway keeps enough history for diagnosis without allowing observability data
+to grow without a bound.
+
+| Data                                              | Default  | Environment variable                           |
+| ------------------------------------------------- | -------- | ---------------------------------------------- |
+| Container CPU, memory, network, and I/O samples   | 24 hours | `SLIPWAY_CONTAINER_METRICS_RETENTION_HOURS`    |
+| Requests, exceptions, queries, and app-level data | 7 days   | `SLIPWAY_APPLICATION_TELEMETRY_RETENTION_DAYS` |
+
+Retention removes at most 500 rows per table in one batch and performs at most
+20 batches per table during a maintenance run. Operators can tune those bounds
+with:
+
+```bash
+SLIPWAY_OBSERVABILITY_PRUNE_BATCH_SIZE=500
+SLIPWAY_OBSERVABILITY_MAX_PRUNE_BATCHES=20
+```
+
+Values must be positive. The prune batch is capped at 900 rows to stay within
+SQLite's statement parameter limit.
+
+### Existing installations
+
+On startup, Slipway creates any missing observability tables and indexes. It
+migrates legacy container samples from `db/app.db` in bounded, idempotent
+batches, verifies the copied row count, and only then removes the legacy rows.
+An interrupted migration safely resumes on the next startup.
 
 ## What's Next?
 


### PR DESCRIPTION
## Summary

- document Bridge resource contracts, rich-text behavior, and the default raw-HTML denial
- document recent deployment, environment, database, Dock, Content, and Lookout improvements
- clarify operational boundaries and troubleshooting guidance

## Validation

- `npm run lint`
- `npm run build`

Closes sailscastshq/slipway#216
