### PR TITLE
docs(slipway): explain secure ingress modes

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -951,6 +951,10 @@ function slipwayGuide() {
       items: [
         { text: 'Configuration', link: '/slipway/configuration' },
         { text: 'Instance URL', link: '/slipway/instance-url' },
+        {
+          text: 'Ingress & Firewall',
+          link: '/slipway/ingress-and-firewall'
+        },
         { text: 'Custom Domain & SSL', link: '/slipway/custom-domain' },
         { text: 'Settings', link: '/slipway/settings' },
         { text: 'Notifications', link: '/slipway/notifications' },

--- a/docs/slipway/cli-authentication.md
+++ b/docs/slipway/cli-authentication.md
@@ -36,7 +36,7 @@ $ slipway login
 
   Slipway CLI
 
-  Server URL: http://203.0.113.50:1337
+  Server URL: https://slipway.example.com
 ```
 
 The CLI looks for the server URL in this order:
@@ -54,7 +54,7 @@ After entering the server URL, your browser will open to complete authentication
   Opening browser for authentication...
 
   If the browser doesn't open, visit:
-  http://203.0.113.50:1337/cli/authorize?code=abc123
+  https://slipway.example.com/cli/authorize?code=abc123
 
   Waiting for authorization...
 ```
@@ -175,7 +175,7 @@ If the browser doesn't open automatically, copy the authorization URL and open i
 
 ```
 If the browser doesn't open, visit:
-http://203.0.113.50:1337/cli/authorize?code=abc123
+https://slipway.example.com/cli/authorize?code=abc123
 ```
 
 ### Authorization Timeout

--- a/docs/slipway/configuration.md
+++ b/docs/slipway/configuration.md
@@ -23,41 +23,33 @@ Slipway can be configured through environment variables and the dashboard settin
 
 ### Environment Variables
 
-Configure Slipway via environment variables when starting the Docker container:
+The installer persists server settings in `/etc/slipway/.env`. Prefer
+rerunning the installer with explicit environment overrides because it also
+keeps Docker bindings and active firewall rules consistent.
 
-| Variable         | Description                         | Default                |
-| ---------------- | ----------------------------------- | ---------------------- |
-| `PORT`           | Port Slipway listens on             | `1337`                 |
-| `NODE_ENV`       | Environment mode                    | `production`           |
-| `SLIPWAY_URL`    | Public URL of your Slipway instance | Required               |
-| `SLIPWAY_SECRET` | Secret key for encryption           | Required               |
-| `DATABASE_PATH`  | Path to SQLite database             | `/app/data/slipway.db` |
+| Variable                 | Description                            | Default        |
+| ------------------------ | -------------------------------------- | -------------- |
+| `PORT`                   | Internal Slipway application port      | `1337`         |
+| `NODE_ENV`               | Environment mode                       | `production`   |
+| `SLIPWAY_URL`            | Public URL of your Slipway instance    | Detected       |
+| `SLIPWAY_INGRESS`        | `public` or `cloudflare-tunnel`        | `public`       |
+| `SLIPWAY_PROXY_HOST`     | Host interface for Caddy               | Mode-dependent |
+| `SLIPWAY_DASHBOARD_HOST` | Host interface for the dashboard port  | `127.0.0.1`    |
+| `SLIPWAY_APP_PORT_HOST`  | Host interface for allocated app ports | `127.0.0.1`    |
+| `SESSION_SECRET`         | Session-signing secret                 | Generated      |
+| `DATA_ENCRYPTION_KEY`    | Encryption key for stored credentials  | Generated      |
 
-### Example Docker Run
-
-```bash
-docker run -d \
-  --name slipway \
-  --network slipway \
-  --restart unless-stopped \
-  -p 1337:1337 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v slipway-data:/app/data \
-  -e NODE_ENV=production \
-  -e PORT=1337 \
-  -e SLIPWAY_URL="https://slipway.yourdomain.com" \
-  -e SLIPWAY_SECRET="your-32-character-secret" \
-  ghcr.io/sailscastshq/slipway:latest
-```
-
-### Generate a Secret
+### Explicit direct app access
 
 ```bash
-openssl rand -hex 32
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env SLIPWAY_APP_PORT_HOST=0.0.0.0 bash /tmp/install-slipway.sh
 ```
 
-::: warning Keep It Secret
-Never commit your `SLIPWAY_SECRET` to version control or share it publicly.
+::: warning Public boundary
+`0.0.0.0` means every server interface. It is an explicit opt-in, not a safer
+replacement for Caddy. Read [Ingress and Firewall](/slipway/ingress-and-firewall)
+before opening the app port range at your VPS provider.
 :::
 
 ## Dashboard Settings

--- a/docs/slipway/custom-domain.md
+++ b/docs/slipway/custom-domain.md
@@ -7,8 +7,8 @@ title: Custom Domain & SSL
 titleTemplate: Slipway
 description: Configure custom domains and automatic SSL certificates for your Slipway applications.
 prev:
-  text: Instance URL
-  link: /slipway/instance-url
+  text: Ingress and Firewall
+  link: /slipway/ingress-and-firewall
 next:
   text: Settings
   link: /slipway/settings
@@ -27,6 +27,11 @@ Slipway uses **Caddy** as its reverse proxy, which provides:
 - **Automatic certificate renewal**
 - **HTTP/2 and HTTP/3 support**
 - **WebSocket proxying** (critical for Sails real-time features)
+
+These certificate steps describe the default public VPS mode. In optional
+Cloudflare Tunnel mode, Cloudflare terminates browser TLS and Caddy serves
+plain HTTP on the loopback origin. See
+[Ingress and Firewall](/slipway/ingress-and-firewall).
 
 When you add a domain, Caddy automatically:
 

--- a/docs/slipway/first-deploy.md
+++ b/docs/slipway/first-deploy.md
@@ -116,18 +116,22 @@ $ slipway slide
   URL: https://my-sails-app.example.com
 ```
 
-## Verify Direct Access
+## Verify the public route
 
-Slipway assigns the deployment a direct URL using a port from `1338–1500`. Test it from your computer or another network so the request crosses the provider firewall:
+Open the URL reported by the successful deployment or request its health path:
 
 ```bash
-curl -I --connect-timeout 5 http://YOUR_SERVER_IP:ALLOCATED_PORT/health
+curl -I https://YOUR_APP_DOMAIN/health
 ```
 
-A successful health response confirms that the app is running and the allocated port is reachable publicly. If the deployment log confirms a healthy container and a live Docker mapping but this request times out, allow the allocated port in both the VPS provider firewall and any active host firewall.
+Fresh installations keep the allocated container port on loopback and route
+public traffic through Caddy. If you deliberately need a raw
+`http://SERVER_IP:PORT` diagnostic URL, enable the documented direct-access
+mode first.
 
-::: tip Custom Domains
-Direct URLs are useful during setup and troubleshooting. Applications with a [custom domain](/slipway/custom-domain) receive traffic through ports `80` and `443` instead.
+::: tip Ingress modes
+See [Ingress and Firewall](/slipway/ingress-and-firewall) for Caddy defaults,
+explicit raw-port access, and optional Cloudflare Tunnel mode.
 :::
 
 ## Set Environment Variables

--- a/docs/slipway/ingress-and-firewall.md
+++ b/docs/slipway/ingress-and-firewall.md
@@ -1,0 +1,149 @@
+---
+head:
+  - - meta
+    - property: 'og:image'
+      content: https://docs.sailscasts.com/slipway-social.png
+title: Ingress and Firewall
+titleTemplate: Slipway
+description: Understand Slipway's public Caddy, raw IP access, and optional Cloudflare Tunnel modes.
+prev:
+  text: Instance URL
+  link: /slipway/instance-url
+next:
+  text: Custom Domain & SSL
+  link: /slipway/custom-domain
+editLink: true
+---
+
+# Ingress and Firewall
+
+Slipway has one default public traffic path:
+
+```text
+Internet → Caddy (80/443) → Slipway dashboard or app container
+```
+
+Fresh installations publish only Caddy. The dashboard binds to
+`127.0.0.1:1337`, deployed apps bind to loopback ports in `1338–1500`, and
+Caddy reaches them over the private `slipway` Docker network.
+
+## What loopback means
+
+`127.0.0.1` is the server's loopback interface: a service bound there accepts
+connections originating on that same server only. It is not the server's
+public IP and it is not a private LAN address.
+
+If you open `127.0.0.1` on your laptop, it refers to your laptop—not the VPS.
+This is why Slipway can keep internal ports available to Caddy and health
+checks without exposing those ports to the internet.
+
+## Default public VPS mode
+
+| Port        | Default binding      | Purpose                               |
+| ----------- | -------------------- | ------------------------------------- |
+| `22`        | Provider/host choice | SSH; Slipway does not change it       |
+| `80`        | `0.0.0.0`            | Caddy HTTP and certificate challenges |
+| `443`       | `0.0.0.0`            | Caddy HTTPS                           |
+| `1337`      | `127.0.0.1`          | Slipway dashboard behind Caddy        |
+| `1338–1500` | `127.0.0.1`          | App containers behind Caddy           |
+
+The installer aligns active UFW or firewalld rules with these bindings. It
+does not enable a firewall or change SSH policy. At the VPS provider, allow
+inbound TCP `80` and `443`, retain your chosen SSH rule, and deny the rest.
+
+Inspect the effective bindings:
+
+```bash
+sudo docker ps --format 'table {{.Names}}\t{{.Ports}}'
+sudo ss -lntp
+```
+
+`slipway-proxy` should show public `80` and `443`. The `slipway` dashboard and
+deployed apps should show `127.0.0.1` bindings.
+
+## Explicit raw IP and port access
+
+Direct `http://SERVER_IP:PORT` URLs can help when diagnosing a deployment
+without DNS, but they bypass Caddy TLS and enlarge the public attack surface.
+Enable them deliberately:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env SLIPWAY_APP_PORT_HOST=0.0.0.0 bash /tmp/install-slipway.sh
+```
+
+Redeploy the app so Docker recreates its binding, then allow TCP `1338–1500`
+in the provider firewall. Verify from another network:
+
+```bash
+curl -I --connect-timeout 5 http://SERVER_IP:ALLOCATED_PORT/health
+```
+
+Return to private app ports by rerunning the installer with
+`SLIPWAY_APP_PORT_HOST=127.0.0.1`, redeploying existing apps, and closing the
+range in the provider firewall.
+
+## Upgrading an older installation
+
+The first upgraded installer preserves missing dashboard and app host settings
+as public. This prevents a security release from silently breaking an existing
+raw URL. Harden the host explicitly when you are ready:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env \
+  SLIPWAY_DASHBOARD_HOST=127.0.0.1 \
+  SLIPWAY_APP_PORT_HOST=127.0.0.1 \
+  bash /tmp/install-slipway.sh
+```
+
+Redeploy existing apps, then remove `1337` and `1338–1500` from the provider
+firewall. Existing app containers keep their previous Docker binding until
+they are replaced.
+
+## Optional Cloudflare Tunnel mode
+
+Tunnel mode changes the path to:
+
+```text
+Internet → Cloudflare → outbound cloudflared tunnel → loopback Caddy → container
+```
+
+Install with a real dashboard hostname:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env \
+  SLIPWAY_INGRESS=cloudflare-tunnel \
+  SLIPWAY_URL=https://slipway.example.com \
+  bash /tmp/install-slipway.sh
+```
+
+This binds Caddy, the dashboard, and app ports to loopback. Point the tunnel at
+`http://127.0.0.1:80` and preserve the incoming hostname so Caddy can choose the
+correct Slipway route:
+
+```yaml
+tunnel: YOUR_TUNNEL_UUID
+credentials-file: /etc/cloudflared/YOUR_TUNNEL_UUID.json
+
+ingress:
+  - hostname: slipway.example.com
+    service: http://127.0.0.1:80
+  - hostname: '*.apps.example.com'
+    service: http://127.0.0.1:80
+  - service: http_status:404
+```
+
+Do not set `httpHostHeader`. Add each custom app domain as a tunnel public
+hostname, or use a wildcard for the generated app domain. Webhooks, SSE,
+telemetry, and CLI requests use the same HTTP route.
+
+Cloudflare Tunnel makes outbound connections, so the provider firewall can
+deny all inbound Slipway ports. Restrictive egress firewalls must permit
+Cloudflare Tunnel on TCP/UDP `7844`. See Cloudflare's
+[tunnel firewall guide](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/)
+and [ingress configuration reference](https://developers.cloudflare.com/tunnel/advanced/local-management/configuration-file/).
+Tunnel mode adds Cloudflare as an availability and DNS dependency; default
+public VPS mode has fewer moving parts and remains the recommended starting
+point.

--- a/docs/slipway/initial-setup.md
+++ b/docs/slipway/initial-setup.md
@@ -24,7 +24,7 @@ After installing Slipway, you'll need to complete the initial setup to create yo
 Open your browser and navigate to:
 
 ```
-http://YOUR_SERVER_IP:1337
+http://YOUR_SERVER_IP
 ```
 
 You'll see the Slipway welcome screen.
@@ -76,7 +76,7 @@ slipway login
 
 You'll be prompted for:
 
-1. **Server URL** — Your Slipway instance URL (e.g., `http://203.0.113.50:1337`)
+1. **Server URL** — Your Slipway instance URL (e.g., `http://203.0.113.50`)
 2. **Browser Authentication** — Opens a browser window to authenticate
 
 After authenticating in the browser, the CLI will save your credentials locally.
@@ -85,7 +85,7 @@ After authenticating in the browser, the CLI will save your credentials locally.
 You can also set the `SLIPWAY_SERVER` environment variable to avoid entering the URL each time:
 
 ```bash
-export SLIPWAY_SERVER=http://203.0.113.50:1337
+export SLIPWAY_SERVER=http://203.0.113.50
 slipway login
 ```
 

--- a/docs/slipway/instance-url.md
+++ b/docs/slipway/instance-url.md
@@ -10,8 +10,8 @@ prev:
   text: Configuration
   link: /slipway/configuration
 next:
-  text: Custom Domain & SSL
-  link: /slipway/custom-domain
+  text: Ingress and Firewall
+  link: /slipway/ingress-and-firewall
 editLink: true
 ---
 
@@ -28,13 +28,12 @@ The instance URL is the public address of your Slipway server. It's used for:
 
 ### During Installation
 
-The install script prompts for the URL, or you can set it via environment variable:
+The installer detects the server IP by default. Set a domain explicitly when
+you already have one:
 
 ```bash
-docker run -d \
-  --name slipway \
-  -e SLIPWAY_URL="https://slipway.yourdomain.com" \
-  ...
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env SLIPWAY_URL=https://slipway.yourdomain.com bash /tmp/install-slipway.sh
 ```
 
 ### After Installation
@@ -58,25 +57,15 @@ docker run -d \
 
 ## URL Formats
 
-### IP Address (Development)
+### IP Address through Caddy
 
 ```
-http://203.0.113.50:1337
-```
-
-- No SSL
-- Uses port number
-- Fine for testing
-
-### Domain with Port (Not Recommended)
-
-```
-http://slipway.example.com:1337
+http://203.0.113.50
 ```
 
 - No SSL
-- Requires port in URL
-- Not recommended for production
+- Uses standard HTTP port 80
+- Useful until a domain is configured
 
 ### Domain with SSL (Recommended)
 
@@ -128,7 +117,9 @@ Expected response:
 2. **Check firewall** allows traffic:
    - Port 80 (HTTP)
    - Port 443 (HTTPS)
-   - Port 1337 (if using IP)
+
+   Port `1337` should remain private. IP-based setup traffic enters through
+   Caddy on port `80`.
 
 3. **Check Slipway is running**:
    ```bash

--- a/docs/slipway/philosophy-and-architecture.md
+++ b/docs/slipway/philosophy-and-architecture.md
@@ -123,15 +123,18 @@ Both sit on the `slipway` Docker network. When you deploy apps or create service
 
 Slipway uses [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) which reads Docker labels to auto-configure routes. When you deploy an app and assign a domain:
 
-1. Slipway allocates a port (from the 1338–1500 range)
-2. Your app container starts on that port
+1. Slipway allocates a host port (from the 1338–1500 range)
+2. Your app container publishes that port on the server's loopback interface
 3. Slipway updates Caddy's routes via its admin API (`localhost:2019`)
 4. Caddy provisions an SSL certificate automatically (via Let's Encrypt)
 5. Traffic flows: `yourdomain.com → Caddy → your-app:port`
 
 No Nginx config files. No manual cert renewal. No `certbot` cron jobs.
 
-The allocated port also provides a direct `http://SERVER_IP:PORT` endpoint. That endpoint must be allowed through both the server's host firewall and any firewall managed by the VPS provider. Domain traffic only requires public access to ports `80` and `443`.
+The allocated port is private by default. Caddy is the single public HTTP/S
+entry point and reaches the app over Docker's private network. A direct
+`http://SERVER_IP:PORT` endpoint is available only when an operator explicitly
+enables it and opens the matching host and provider firewall rules.
 
 ### How Deployments Work
 

--- a/docs/slipway/requirements.md
+++ b/docs/slipway/requirements.md
@@ -50,20 +50,25 @@ Slipway's install script will automatically install Docker if it's not already p
 
 ## Network Requirements
 
-| Port      | Purpose                                   | Required                          |
-| --------- | ----------------------------------------- | --------------------------------- |
-| 80        | HTTP traffic and certificate provisioning | Yes                               |
-| 443       | HTTPS traffic                             | Yes                               |
-| 1337      | Slipway dashboard before adding a domain  | Yes during initial setup          |
-| 1338–1500 | Direct application URLs using `IP:port`   | Only when direct access is needed |
-| 22        | SSH access                                | Recommended                       |
+| Port      | Purpose                                    | Required                      |
+| --------- | ------------------------------------------ | ----------------------------- |
+| 80        | HTTP traffic and certificate provisioning  | Yes in the default mode       |
+| 443       | HTTPS traffic                              | Yes in the default mode       |
+| 1337      | Slipway dashboard loopback binding         | No public access              |
+| 1338–1500 | Optional direct application `IP:port` URLs | Only after explicitly enabled |
+| 22        | SSH access                                 | Recommended                   |
 
-These ports may need to be allowed at two separate network boundaries:
+Public bindings may need to be allowed at two separate network boundaries:
 
-1. **The host firewall** running on the server, such as UFW or firewalld. The installer adds the Slipway ports when either firewall is already active. It does not enable a firewall or change SSH rules.
+1. **The host firewall** running on the server, such as UFW or firewalld. The installer aligns Slipway's public bindings when either firewall is already active. It does not enable a firewall or change SSH rules.
 2. **The provider firewall or security group** managed by Hetzner, DigitalOcean, AWS, or your VPS provider. Slipway cannot change these rules, so you must configure them in your provider's control panel.
 
-Applications served through a configured domain only need public access to ports `80` and `443`. Open `1338–1500` when you want Slipway's direct application URLs to be reachable from outside the server.
+Fresh installations expose only Caddy on ports `80` and `443`. The dashboard
+and deployed applications bind to `127.0.0.1`, which means they are reachable
+from the server itself but not directly from the internet. Open `1338–1500`
+only after explicitly enabling raw `IP:port` access. Cloudflare Tunnel mode can
+keep every Slipway origin port private. See [Ingress and Firewall](/slipway/ingress-and-firewall)
+for each supported mode.
 
 ## CLI Requirements
 

--- a/docs/slipway/server-installation.md
+++ b/docs/slipway/server-installation.md
@@ -35,7 +35,7 @@ This script will:
 4. Generate secrets (`SESSION_SECRET` and `DATA_ENCRYPTION_KEY`) and save them to `/etc/slipway/.env`
 5. Start the Caddy reverse proxy
 6. Pull and start the Slipway dashboard
-7. Add Slipway's ports to UFW or firewalld when either host firewall is active
+7. Align active UFW or firewalld rules with the selected public bindings
 8. Display your access URL
 
 ## What Gets Installed
@@ -57,9 +57,9 @@ Docker already installed
 Creating Docker network...
 Network ready
 Detecting server IP...
-Server URL: http://203.0.113.50:1337
 Generating secrets...
-Secrets generated and saved to /etc/slipway/.env
+Configuration saved to /etc/slipway/.env
+Server URL: http://203.0.113.50
 Starting Caddy proxy...
 Caddy proxy running
 Pulling latest Slipway image...
@@ -72,7 +72,9 @@ Waiting for Slipway to start...
   Slipway installed successfully!
 ========================================================
 
-  Dashboard: http://203.0.113.50:1337
+  Dashboard: http://203.0.113.50
+  Public ingress: TCP 80 and 443 through Caddy
+  Direct app ports: private (set SLIPWAY_APP_PORT_HOST=0.0.0.0 to opt in)
 
   Next steps:
   1. Open the dashboard URL above to complete setup
@@ -81,7 +83,7 @@ Waiting for Slipway to start...
 
   To deploy apps, install the CLI:
     npm install -g slipway-cli
-    slipway login --server http://203.0.113.50:1337
+    slipway login --server http://203.0.113.50
 
 ========================================================
 ```
@@ -95,81 +97,26 @@ The actual output uses colored text to highlight status messages. Green indicate
 After installation, access your Slipway dashboard at:
 
 ```
-http://YOUR_SERVER_IP:1337
+http://YOUR_SERVER_IP
 ```
 
-::: warning Before Custom Domain
-Until you configure a custom domain, Slipway runs on port 1337 with HTTP. For production use, you should [configure a custom domain](/slipway/custom-domain) to enable HTTPS.
+::: info One public HTTP path
+The request enters through Caddy on port 80. The Slipway dashboard listens on
+`127.0.0.1:1337`, so it cannot be reached directly from another machine. For
+production, [configure a custom domain](/slipway/custom-domain) to enable HTTPS.
 :::
 
 ::: warning Provider Firewall
 The installer can configure an active firewall on the server, but it cannot change a firewall or security group managed by your VPS provider. Allow the required ports in the provider's control panel too. See [Network Requirements](/slipway/requirements#network-requirements) for the complete port list.
 :::
 
-## Manual Installation
+## Choose another ingress mode
 
-If you prefer to install manually or customize the setup:
-
-### 1. Install Docker
-
-```bash
-curl -fsSL https://get.docker.com | sh
-systemctl enable docker
-systemctl start docker
-```
-
-### 2. Create Network
-
-```bash
-docker network create slipway
-```
-
-### 3. Generate Secrets
-
-```bash
-SESSION_SECRET=$(openssl rand -hex 32)
-DATA_ENCRYPTION_KEY=$(openssl rand -base64 32)
-
-# Persist secrets for future updates
-sudo mkdir -p /etc/slipway
-echo "SESSION_SECRET=$SESSION_SECRET" | sudo tee /etc/slipway/.env
-echo "DATA_ENCRYPTION_KEY=$DATA_ENCRYPTION_KEY" | sudo tee -a /etc/slipway/.env
-sudo chmod 600 /etc/slipway/.env
-```
-
-### 4. Start Caddy
-
-```bash
-docker run -d \
-  --name slipway-proxy \
-  --network slipway \
-  --restart unless-stopped \
-  -p 80:80 \
-  -p 443:443 \
-  -p 1337:1337 \
-  -v /var/run/docker.sock:/var/run/docker.sock:ro \
-  -v slipway-certs:/data \
-  -e CADDY_INGRESS_NETWORKS=slipway \
-  lucaslorentz/caddy-docker-proxy:latest
-```
-
-### 5. Start Slipway
-
-```bash
-docker run -d \
-  --name slipway \
-  --network slipway \
-  --restart unless-stopped \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v slipway-db:/app/db \
-  -e NODE_ENV=production \
-  -e PORT=1337 \
-  -e SLIPWAY_URL="http://YOUR_SERVER_IP:1337" \
-  -e SESSION_SECRET="$SESSION_SECRET" \
-  -e DATA_ENCRYPTION_KEY="$DATA_ENCRYPTION_KEY" \
-  -l "caddy=:1337" \
-  ghcr.io/sailscastshq/slipway:latest
-```
+The default is the smallest production setup: public Caddy, private dashboard,
+and private app ports. Raw `IP:port` access and Cloudflare Tunnel are explicit
+installer modes because they change the server's public boundary. Read
+[Ingress and Firewall](/slipway/ingress-and-firewall) for the exact commands,
+upgrade behavior, and verification steps.
 
 ## Troubleshooting
 
@@ -184,11 +131,12 @@ sudo usermod -aG docker $USER
 
 ### Port Already in Use
 
-If port 1337, 80, or 443 is already in use:
+If port 80 or 443 is already in use:
 
 ```bash
 # Find what's using the port
-sudo lsof -i :1337
+sudo lsof -i :80
+sudo lsof -i :443
 
 # Stop the conflicting service or change Slipway's port
 ```


### PR DESCRIPTION
## Summary
- explain loopback and Slipway's Caddy-only public default
- document explicit raw IP:port access, legacy upgrade behavior, and optional Cloudflare Tunnel mode
- correct installation, initial setup, first deploy, CLI, instance URL, configuration, architecture, and custom-domain guidance
- add the focused ingress guide to the Slipway navigation
- remove the outdated manual container recipe that exposed the dashboard directly

## Verification
- npm run lint
- npm run build
- audited remaining Slipway port references for public 1337 and implicit direct-port claims

Companion documentation for https://github.com/sailscastshq/slipway/pull/310.

Fixes sailscastshq/slipway#202