### PR TITLE
docs(slipway): explain the release flag helper contract

### DIFF
--- a/docs/slipway/release-flags.md
+++ b/docs/slipway/release-flags.md
@@ -74,6 +74,13 @@ if (useNewCheckout) {
 }
 ```
 
+`flags.enabled` is a regular Sails helper machine. The hook waits for the
+built-in helpers hook and furnishes the helper through the same Sails API used
+by hooks such as `sails-hook-mail`. Sails therefore validates the declared
+`key`, `req`, `context`, and `defaultValue` inputs before flag evaluation runs.
+If the application already defines `sails.helpers.flags.enabled`, Slipway keeps
+the application-owned helper and logs a warning instead of replacing it.
+
 Always choose the default explicitly. Slipway returns that value when the flag
 is unknown or the control plane has never been reachable. Flag evaluation does
 not make the application request fail.


### PR DESCRIPTION
## What changed

- document that `flags.enabled` is furnished as a genuine Sails helper machine
- explain that Sails validates the declared helper inputs before evaluation
- document the app-owned-helper collision behavior

## Verification

- `npm run lint`
- `npm run build`

Closes #128