### PR TITLE
docs(slipway): explain private dashboard access

### DIFF
--- a/docs/slipway/ingress-and-firewall.md
+++ b/docs/slipway/ingress-and-firewall.md
@@ -61,6 +61,40 @@ sudo ss -lntp
 `slipway-proxy` should show public `80` and `443`. The `slipway` dashboard and
 deployed apps should show `127.0.0.1` bindings.
 
+## Headless or private-network dashboard access
+
+Headless describes how the server is operated, not how its ports must be
+published. From another machine on the same network, first open:
+
+```text
+http://SERVER_IP
+```
+
+This is the recommended path. The browser reaches Caddy on port `80`, and
+Caddy reaches the private dashboard over Docker. Dashboard port `1337` does not
+need to be public.
+
+If your network design specifically requires direct `http://SERVER_IP:1337`
+access, opt in to publishing only that port:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env SLIPWAY_DASHBOARD_HOST=0.0.0.0 bash /tmp/install-slipway.sh
+```
+
+This does not publish deployed-app ports. The installer persists the setting
+in `/etc/slipway/.env`, and future installer runs keep it until changed.
+
+Direct port `1337` bypasses Caddy and its TLS termination. Limit inbound TCP
+`1337` to the trusted LAN or VPN CIDR in both the host firewall and the VPS
+provider firewall. Avoid exposing it to the public internet.
+
+To return the dashboard to the Caddy-only path:
+
+```bash
+sudo env SLIPWAY_DASHBOARD_HOST=127.0.0.1 bash /tmp/install-slipway.sh
+```
+
 ## Explicit raw IP and port access
 
 Direct `http://SERVER_IP:PORT` URLs can help when diagnosing a deployment
@@ -71,6 +105,9 @@ Enable them deliberately:
 curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
 sudo env SLIPWAY_APP_PORT_HOST=0.0.0.0 bash /tmp/install-slipway.sh
 ```
+
+`SLIPWAY_APP_PORT_HOST` controls the deployed-app range independently from
+`SLIPWAY_DASHBOARD_HOST`. Do not set it merely to reach the Slipway dashboard.
 
 Redeploy the app so Docker recreates its binding, then allow TCP `1338–1500`
 in the provider firewall. Verify from another network:

--- a/docs/slipway/server-installation.md
+++ b/docs/slipway/server-installation.md
@@ -106,6 +106,29 @@ The request enters through Caddy on port 80. The Slipway dashboard listens on
 production, [configure a custom domain](/slipway/custom-domain) to enable HTTPS.
 :::
 
+### Headless or private-network server
+
+A headless server does not require a different installation. From another
+machine on the same trusted network, open `http://SERVER_IP`. That request uses
+Caddy on port `80`, so the dashboard can remain private on `127.0.0.1:1337`.
+
+If you deliberately need direct `http://SERVER_IP:1337` access instead, publish
+only the dashboard port:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env SLIPWAY_DASHBOARD_HOST=0.0.0.0 bash /tmp/install-slipway.sh
+```
+
+Binding to `0.0.0.0` listens on every server interface and bypasses Caddy's
+TLS. Restrict TCP `1337` to your trusted LAN or VPN in both the host firewall
+and your provider firewall. Do not also publish the app port range unless you
+need raw app `IP:port` access; see
+[Ingress and Firewall](/slipway/ingress-and-firewall#explicit-raw-ip-and-port-access).
+
+The installer saves the selected binding in `/etc/slipway/.env`, so later
+installer runs preserve it until you explicitly change it.
+
 ::: warning Provider Firewall
 The installer can configure an active firewall on the server, but it cannot change a firewall or security group managed by your VPS provider. Allow the required ports in the provider's control panel too. See [Network Requirements](/slipway/requirements#network-requirements) for the complete port list.
 :::


### PR DESCRIPTION
## What changed

- explain that headless servers can normally reach Slipway through Caddy at `http://SERVER_IP`
- document the dashboard-only `SLIPWAY_DASHBOARD_HOST=0.0.0.0` override
- keep raw deployed-app ports as a separate opt-in
- document persistence, rollback, TLS, and firewall implications

## Why

Operators should not need to search release notes or expose the entire deployed-app port range merely to reach the Slipway dashboard from a trusted private network.

## Validation

- `npx prettier --check docs/slipway/server-installation.md docs/slipway/ingress-and-firewall.md`
- `npm run build`
- verified the new sections in the generated VitePress HTML

Closes #130