### PR TITLE
docs(slipway): align platform guides with implementation

### DIFF
--- a/docs/slipway/bosun.md
+++ b/docs/slipway/bosun.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: Bosun
 titleTemplate: Slipway
-description: Self-administration dashboard for your Slipway instance. Monitor system health, query databases, manage environment variables, and track activity.
+description: Inspect and repair the Slipway instance itself with process health, live logs, SQLite and Helm consoles, schema migration, and activity history.
 prev:
   text: Lookout
   link: /slipway/lookout
@@ -17,95 +17,263 @@ editLink: true
 
 # Bosun
 
-Bosun is the **self-administration dashboard** for your Slipway instance. It gives you system-level visibility and management tools — entity counts, process health, a SQLite console, environment variable management, and an activity feed — all from one page.
+Bosun is the self-administration surface for the Slipway instance. Project
+tools such as Dock and Helm operate a deployed application; Bosun operates
+Slipway itself.
 
-## Accessing Bosun
+That distinction matters. A Bosun SQL statement can change an internal SQLite
+database, and Bosun Helm can call Slipway's own models and helpers. Use Bosun
+for inspection, migrations, and deliberate repair—not as an everyday project
+console.
 
-Click **Bosun** in the sidebar or navigate to `/bosun`.
+## Open Bosun
+
+Choose **Bosun** from the Slipway sidebar or open:
+
+```text
+/bosun
+```
+
+The selected tab and console target are reflected in the URL. For example:
+
+```text
+/bosun?tab=console&mode=helm
+/bosun?tab=console&db=observability
+/bosun?tab=migrate&db=cache
+```
+
+This makes a diagnostic view bookmarkable without placing query text or
+returned data in the URL.
+
+## Choose the right surface
+
+| Need                                                                      | Surface                     |
+| ------------------------------------------------------------------------- | --------------------------- |
+| Inspect the Slipway process, internal databases, or instance logs         | Bosun                       |
+| Run Sails-aware JavaScript inside a deployed application                  | [Helm](/slipway/helm)       |
+| Query or migrate an attached PostgreSQL, MySQL, MongoDB, or Redis service | [Dock](/slipway/dock)       |
+| Inspect application and container telemetry                               | [Lookout](/slipway/lookout) |
 
 ## Overview
 
-The **Overview** tab shows the current state of your Slipway instance:
+The **Overview** tab is a compact health snapshot of the running Slipway
+process.
 
-| Section       | What's shown                                                         |
-| ------------- | -------------------------------------------------------------------- |
-| **Stats**     | Counts of projects, apps, deployments, backups                       |
-| **Process**   | Uptime, memory usage (RSS, heap), Node.js version, PID               |
-| **Databases** | File sizes for the three SQLite databases: app, observability, cache |
+| Area      | What it shows                                                      |
+| --------- | ------------------------------------------------------------------ |
+| Counts    | Projects, applications, deployments, and backups                   |
+| Process   | Uptime, Node.js version, PID, platform, heap use, and RSS          |
+| Databases | Current file size for `app.db`, `observability.db`, and `stash.db` |
+| Logs      | Live stdout and stderr from the `slipway` Docker container         |
 
-## Environment
+The counts are operational context, not billing analytics. Database size is the
+file size on disk at page load; use the console for row-level investigation.
 
-The **Environment** tab shows the instance-level environment variables that configure your Slipway process itself — values from `/etc/slipway/.env` and any custom overrides you add through the UI.
+### Live instance logs
 
-- **View** all configured variables (values are masked by default)
-- **Add** custom instance variables with key-value inputs
-- **Remove** custom variables you no longer need
-- **Reveal** masked values by clicking the eye icon
+Open **Logs** to start an authenticated Server-Sent Events stream backed by:
 
-Known instance variables (`SESSION_SECRET`, `DATA_ENCRYPTION_KEY`, `SLIPWAY_URL`, `NODE_ENV`, `PORT`, `SLIPWAY_SSL`) are read directly from the running process.
+```text
+docker logs --follow --tail 200 --timestamps slipway
+```
 
-::: tip
-These are **instance** variables that configure Slipway itself. For variables injected into deployed applications, use [Global Environment Variables](/slipway/global-environment-variables).
-:::
+The browser keeps at most 2,000 lines and trims back to the latest 1,500 when
+that bound is exceeded. Closing the disclosure stops the Docker follow process.
+Auto-scroll disengages when you move away from the bottom so new output does
+not pull you away from the line you are reading.
+
+Instance logs are available only when Slipway can reach Docker and the
+container is named `slipway`. A source checkout running directly on the host
+shows a friendly unavailable state instead.
 
 ## Console
 
-The **Console** tab provides a read-only SQLite REPL for querying Slipway's internal databases directly.
+The **Console** tab has two modes that share the same full-height workspace:
 
-### Available databases
+- **SQL** operates one of Slipway's internal SQLite databases.
+- **Helm** runs Sails-aware JavaScript against the Slipway application.
 
-| Database          | File                  | Contents                                                             |
-| ----------------- | --------------------- | -------------------------------------------------------------------- |
-| **app**           | `db/app.db`           | Projects, environments, apps, services, deployments, users, settings |
-| **observability** | `db/observability.db` | Telemetry spans, exceptions, metrics, container metrics              |
-| **cache**         | `db/stash.db`         | Cached helper results                                                |
+The SQL and Helm editors each keep up to 20 deduplicated entries in the current
+page session. This is convenience history, not a durable audit log; refreshing
+the page clears it.
 
-### Usage
+### SQL mode
 
-1. Select a database from the pill selector in the actions bar
-2. Write a SQL query (SELECT, PRAGMA, or EXPLAIN)
-3. Press **Cmd+Enter** (or click **Run**) to execute
-4. Results appear in a table below the query input
+Select the database before running a statement:
 
-You can toggle between **table** and **JSON** views, and export results as JSON or CSV.
+| Selector        | File                  | Typical contents                                                                    |
+| --------------- | --------------------- | ----------------------------------------------------------------------------------- |
+| `app`           | `db/app.db`           | users, teams, projects, environments, apps, services, deployments, settings         |
+| `observability` | `db/observability.db` | request spans, exceptions, application metrics, container metrics, collector health |
+| `cache`         | `db/stash.db`         | persisted `sails-stash` cache entries                                               |
 
-### Examples
+Run one SQLite statement at a time with **Run** or <kbd>Cmd/Ctrl Enter</kbd>.
+Reader statements return columns and rows. A write returns its changed-row
+count and last inserted row ID. The browser receives at most 1,000 rows and
+marks a larger result as truncated. Results can be copied or downloaded as JSON
+or CSV.
 
 ```sql
--- List all tables in the app database
-SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
-
--- Recent deployments with status
-SELECT id, status, git_branch, created_at FROM deployments ORDER BY created_at DESC LIMIT 20;
-
--- Check database page size and journal mode
-PRAGMA page_size;
-PRAGMA journal_mode;
-
--- Count records per table
-SELECT 'projects' as tbl, COUNT(*) as cnt FROM projects
-UNION ALL SELECT 'environments', COUNT(*) FROM environments
-UNION ALL SELECT 'deployments', COUNT(*) FROM deployments;
+SELECT name
+FROM sqlite_master
+WHERE type = 'table'
+ORDER BY name;
 ```
 
-::: warning
-Only **read-only** queries are allowed. INSERT, UPDATE, DELETE, DROP, and other destructive statements are blocked. The database is opened in read-only mode as an additional safety layer.
+```sql
+SELECT id, status, git_branch, created_at
+FROM deployments
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+::: danger Bosun SQL can write
+The database is opened normally, not in read-only mode. `INSERT`, `UPDATE`,
+`DELETE`, schema statements, and other valid SQLite writes can execute. Bosun
+does not infer intent or add an automatic transaction. Prefer **Migrate** for
+generated schema work, take a backup, and use an explicit transaction when a
+manual repair must be atomic.
 :::
+
+### Helm mode
+
+Bosun Helm uses the same bounded parser and structured result viewer as project
+Helm, but it boots Slipway itself:
+
+```javascript
+await User.find().select(['id', 'email', 'createdAt']).limit(10)
+```
+
+You can use Slipway models, helpers, and config, run a selection, inspect
+intermediate values with `// @inspect`, trace queries with
+`// @trace queries`, stop an execution, and view table, tree, raw, and console
+output where applicable. Sails-aware completion is loaded from the running
+Slipway application.
+
+The shared runtime applies the same default 30-second timeout and bounded
+source, logs, result, query trace, and inspection output described in
+[Helm](/slipway/helm). It also prevents a late response from an older run from
+replacing the current result.
+
+::: danger Bosun Helm is privileged
+Project Helm resolves and audits a project target and applies the production
+write-arm heuristic. Bosun Helm is an instance repair console and does not use
+that project production guard. Code can mutate Slipway records, call helpers,
+and produce external side effects. Review the selected source and return
+bounded data.
+:::
+
+## Migrate
+
+The **Migrate** tab compares Slipway's current Waterline model metadata with one
+of its three internal SQLite schemas. It is the production path for bringing an
+existing Slipway database forward when a release adds tables, columns, renamed
+attributes, or indexes.
+
+The workflow is:
+
+1. select `app`, `observability`, or `cache`;
+2. let Bosun read the Waterline models assigned to that datastore;
+3. review the schema summary and every generated SQLite statement;
+4. select the affected model groups you intend to apply;
+5. confirm the exact statement count; and
+6. apply, then let Bosun compute the diff again.
+
+SQLite cannot perform every column alteration in place. When required, the
+generated migration rebuilds a table, copies compatible data, replaces the old
+table, and recreates indexes.
+
+Statements are executed in order. Bosun stops on the first error and reports
+which statements succeeded. It attempts `ROLLBACK` when an error occurs, but
+the whole list is not automatically wrapped in one transaction; statements
+that committed before the failure can remain applied. Re-run the diff before
+deciding what to do next.
+
+::: warning Back up before migrating
+The Migrate tab is safer than pasting generated SQL blindly because it derives
+and previews the diff, but it still modifies the live internal database. Keep a
+copy of the relevant `db/*.db` file or a current server backup before applying
+a release migration.
+:::
+
+## Environment
+
+The **Environment** tab displays a merged view of:
+
+- selected variables from the running process—`SESSION_SECRET`,
+  `DATA_ENCRYPTION_KEY`, `SLIPWAY_URL`, `NODE_ENV`, `PORT`, and `SLIPWAY_SSL`;
+  and
+- key-value overrides saved in Slipway's `Setting` model under
+  `instanceEnvVars`.
+
+Values are masked until revealed. Adding or removing a value updates the saved
+settings object immediately.
+
+::: warning Saved does not mean applied to the process
+The Environment tab does not rewrite `/etc/slipway/.env`, mutate
+`process.env`, or restart the container. Existing process variables remain in
+effect until the server environment is changed and Slipway is restarted. Use
+the installer or server configuration for boot-time settings. The UI-stored
+values are available to features that explicitly read `instanceEnvVars`.
+:::
+
+For variables injected into deployed applications, use
+[Global Environment Variables](/slipway/global-environment-variables) or the
+environment and application settings instead.
 
 ## Activity
 
-The **Activity** tab shows a unified feed of recent events across your instance:
+The **Activity** tab combines three sources into a newest-first operational
+feed:
 
-| Type            | What's shown                                                   |
-| --------------- | -------------------------------------------------------------- |
-| **Deployments** | Status, git branch/commit, trigger type, environment, duration |
-| **Backups**     | Status, service name, size, type (manual/scheduled)            |
-| **Audit logs**  | Action performed, resource type, user, IP address              |
+| Filter      | Details                                                         |
+| ----------- | --------------------------------------------------------------- |
+| Deployments | status, app, branch, commit, trigger, environment, and duration |
+| Backups     | status, service, size, backup type, and duration                |
+| Audit       | action, actor, resource, request IP, and bounded action details |
 
-Use the filter buttons (All, Deploys, Backups, Audit) to narrow the feed.
+Choose **All**, **Deployments**, **Backups**, or **Audit**. A filtered request
+returns up to 30 records by default; the endpoint accepts 1–100. The combined
+view takes a bounded share from each source and sorts the result, so use a
+specific filter when you need a deeper chronological list of one activity
+type.
 
-## What's Next?
+## Safe operating workflow
 
-- Use [Lookout](/slipway/lookout) for application-level observability
-- Configure [Global Environment Variables](/slipway/global-environment-variables) in detail
-- Set up [Notifications](/slipway/notifications) for deployment alerts
+1. Start with **Overview** and live logs to identify the affected subsystem.
+2. Use a bounded `SELECT` or `PRAGMA` in SQL mode to verify database state.
+3. Use **Migrate** when the problem is model/schema drift.
+4. Use Bosun Helm only when a Sails model or helper is the clearest repair
+   boundary.
+5. Verify the result with another read and review **Activity** or the audit log
+   where the operation emits one.
+
+## Troubleshooting
+
+### Logs are unavailable
+
+Confirm Slipway is running in Docker as a container named `slipway` and that
+the process can invoke the configured Docker binary.
+
+### SQL reports `no such table` or `no such column`
+
+Confirm the selected database. Then open **Migrate** and inspect its diff. Do
+not create an empty replacement table manually unless the generated migration
+cannot represent the required change.
+
+### A migration partially fails
+
+Read the per-statement results, take a fresh backup or copy before further
+changes, and recompute the diff. Earlier successful statements may already be
+present.
+
+### An environment change has no effect
+
+The UI saved the setting but did not restart or reconfigure the process. Apply
+the value to the server's actual environment and restart Slipway.
+
+## What's next?
+
+- Use [Lookout](/slipway/lookout) for application and container observability.
+- Use [Helm](/slipway/helm) for a deployed application's Sails runtime.
+- Use [Dock](/slipway/dock) for attached database and cache services.

--- a/docs/slipway/bridge.md
+++ b/docs/slipway/bridge.md
@@ -537,6 +537,25 @@ deployments. Bridge uses them to match configuration with the server result.
 Cards are displayed in their configured order. A contract may contain up to 12
 dashboards and 24 cards per dashboard.
 
+### Dashboard contract
+
+`dashboard` is shorthand for a single dashboard named `overview`. Use either
+`dashboard` or `dashboards`, never both. A dashboard must contain at least one
+card.
+
+| Option        | Required           | Default                      | Contract                                                    |
+| ------------- | ------------------ | ---------------------------- | ----------------------------------------------------------- |
+| `label`       | No                 | Humanized dashboard key      | String, at most 80 characters                               |
+| `description` | No                 | None                         | String, at most 240 characters                              |
+| `default`     | No                 | First dashboard in its scope | Boolean; only one default per scope and resource            |
+| `scope`       | No                 | `environment`                | `global`, `project`, `environment`, or `resource`           |
+| `resource`    | For resource scope | None                         | Visible Bridge resource identity; rejected for other scopes |
+| `cards`       | Yes                | —                            | Non-empty object with at most 24 cards                      |
+
+Dashboard and card keys must begin with a letter and contain only letters and
+numbers. Use stable camelCase keys such as `contentHealth` and `recentLessons`.
+Unknown configuration keys fail validation instead of being silently ignored.
+
 ### Multiple dashboards and scope
 
 Use `dashboards` instead of `dashboard` when the app needs multiple views:
@@ -578,6 +597,42 @@ resource dashboard appears above that resource's records and must declare its
 uses the first configured dashboard for that scope. When a scope has multiple
 dashboards, Bridge shows a compact selector.
 
+Defaults are grouped by scope and, for resource dashboards, by resource. A
+course dashboard and a lesson dashboard can therefore each be their own
+default. Two course dashboards cannot both be marked default.
+
+### Card contract
+
+Every card has a `type` and can use these common options:
+
+| Option        | Required        | Contract                                                                 |
+| ------------- | --------------- | ------------------------------------------------------------------------ |
+| `type`        | Yes             | `metric`, `recent`, `action`, `trend`, `partition`, or `custom`          |
+| `label`       | No              | String up to 80 characters; otherwise derived from the card key and type |
+| `description` | No              | String up to 240 characters                                              |
+| `resource`    | Depends on type | Must name a visible resource in the same Bridge contract                 |
+
+`metric`, `recent`, and `action` require a resource. On a resource-scoped
+dashboard they inherit the dashboard resource when the card omits it. Helper
+cards may declare a resource to participate in normal resource authorization,
+or omit it and make their domain authorization decision inside the helper.
+
+The six card types are intentionally narrow:
+
+| Type        | Data source            | Required options                       | Result                              |
+| ----------- | ---------------------- | -------------------------------------- | ----------------------------------- |
+| `metric`    | Waterline aggregate    | `resource`; `field` except for `count` | One finite number                   |
+| `recent`    | Bounded Waterline find | `resource`                             | Up to 10 redacted records           |
+| `action`    | Built-in Bridge route  | `resource`                             | Link to the create form             |
+| `trend`     | Target-app helper      | `helper`                               | Up to 31 labelled numeric points    |
+| `partition` | Target-app helper      | `helper`                               | Up to 12 labelled numeric segments  |
+| `custom`    | Target-app helper      | `helper`                               | Primitive value and optional detail |
+
+Bridge normalizes the complete contract when it loads the target application.
+An unknown resource, hidden resource, unavailable field, unsupported option, or
+unsafe helper identity rejects the invalid contract instead of becoming a
+partially trusted browser configuration.
+
 ### Metrics
 
 Metric cards use Waterline directly:
@@ -608,6 +663,17 @@ revenue: {
 `percent` follows `Intl.NumberFormat` semantics, so store `0.42` to display
 `42%`.
 
+`aggregate` defaults to `count`, and `format` defaults to `number`. A count card
+must not provide `field`; every other aggregate requires a readable numeric
+field. Currency codes are normalized to uppercase. Prefixes and suffixes can
+be at most 20 characters.
+
+`where` accepts serializable Waterline criteria using only fields on the
+resource's list or filter surface. Nested `and` and `or` branches are supported.
+Functions, dates, class instances, prototype keys, non-finite numbers, and
+unbounded structures are rejected. Configuration is limited to eight nested
+levels, 50 keys per object, and 100 items per array.
+
 ### Recent records and quick actions
 
 A `recent` card performs one bounded Waterline query. `limit` defaults to `5`
@@ -628,6 +694,16 @@ recentLessons: {
 }
 ```
 
+When `fields` is omitted, Bridge starts with the resource primary key, title,
+and list fields and keeps the first four unique fields. The real primary key is
+always selected even when it was not requested explicitly.
+
+`sort` defaults to the resource's configured sort. A custom sort must contain a
+readable `field`; `direction` defaults to `DESC` and accepts `ASC` or `DESC`.
+Recent cards do not accept arbitrary criteria. Use the resource contract to
+define the intended record surface or a helper-backed card for a domain-specific
+selection.
+
 An `action` card currently supports the built-in `create` action. Bridge
 derives the route from the project, environment, and resource:
 
@@ -639,6 +715,9 @@ newLesson: {
   action: 'create'
 }
 ```
+
+`action` defaults to `create`; no other action value is accepted. The card is
+removed when the resource's server-normalized `create` action is disabled.
 
 ### Helper-backed cards
 
@@ -665,8 +744,10 @@ releaseHealth: {
 }
 ```
 
-The helper receives the authenticated `actor`, the selected `dashboard`, and a
-small serializable `card` description:
+Helper identities use normal Sails dot notation such as
+`bridge.dashboard.signups`. The helper must exist in the running target app.
+It receives the authenticated `actor`, the selected `dashboard`, and a small
+serializable `card` description:
 
 ```js
 // api/helpers/bridge/dashboard/signups.js
@@ -702,6 +783,29 @@ segments. Custom helpers return `{ value, detail }`; `value` must be a string,
 finite number, or boolean. Slipway truncates labels and detail text,
 re-normalizes all helper results, and never accepts helper-provided HTML.
 
+The exact helper inputs are:
+
+| Input       | Shape                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------- |
+| `actor`     | Verified Bridge identity and role context for the current request                                 |
+| `dashboard` | `{ id, label, scope, resource }`                                                                  |
+| `card`      | `{ id, type, label, resource }`, where `resource` is a safe summary rather than the full contract |
+
+For a helper card with a resource, the summary contains its identity, primary
+key, title, labels, and attribute type metadata. It does not contain database
+records or credentials.
+
+Helper output is normalized twice: once inside the target app execution and
+again by Slipway before it becomes an Inertia prop. Trend and partition labels
+are limited to 80 characters. Custom string values are limited to 160
+characters and detail to 240. Non-finite numbers and malformed points are
+dropped.
+
+All visible cards for a dashboard are resolved in one isolated target-app
+execution. Each card has its own error boundary. A failed helper or query
+produces a generic unavailable state for that card while the remaining cards
+continue to render; internal exception details remain in Slipway logs.
+
 ### Dashboard authorization
 
 Dashboard cards use the same server-enforced resource authorization as CRUD:
@@ -716,6 +820,11 @@ Dashboard cards use the same server-enforced resource authorization as CRUD:
 
 The browser never receives a denied card, count, or record. A helper or query
 failure affects only that card; the rest of the dashboard remains usable.
+
+For sensitive business metrics, prefer both layers: associate the card with a
+resource so Bridge applies `viewAny`, then recheck the host application's
+domain role inside the helper. Do not treat a hidden UI card as an authorization
+rule—the helper is the final authority for resource-free domain data.
 
 ## Actions
 

--- a/docs/slipway/content.md
+++ b/docs/slipway/content.md
@@ -22,6 +22,24 @@ Content is Slipway's Git-backed editor for
 an editor manage Markdown, frontmatter, images, and JSON without leaving the
 dashboard while keeping the repository as the source of truth.
 
+Content edits files in the selected application's source tree. It does not
+create a second content database or synchronize a proprietary schema. The same
+files remain readable by Git, a local editor, CI, and the running Sails app.
+
+## How Content maps to an application
+
+| Content concept   | Source representation                                         |
+| ----------------- | ------------------------------------------------------------- |
+| Workspace         | The selected Slipway application                              |
+| Content root      | Detected `sails-content` directory, normally `content/`       |
+| Collection        | An immediate child directory of the content root              |
+| Record            | A direct `.md` or `.json` file in a collection                |
+| Markdown metadata | Simple frontmatter at the start of a `.md` file               |
+| Revision          | Git blob and commit SHA when a GitHub repository is connected |
+
+Content currently scans one collection level. Nested folders and file types
+other than `.md` and `.json` are not listed in the visual manager.
+
 ## Requirements
 
 Install `sails-content` in the application:
@@ -34,6 +52,10 @@ Slipway detects the hook during deployment and enables Content for that
 application. A connected Git repository is recommended: it gives every change
 a durable commit and lets **Save & Deploy** deploy the exact revision that was
 just saved.
+
+The detected feature can provide a custom `contentDir`; otherwise Slipway uses
+`content`. Deploy after installing or reconfiguring the hook so Slipway can
+refresh the application's feature metadata and source tree.
 
 ## Open Content
 
@@ -67,8 +89,8 @@ content/
     └── site.json
 ```
 
-Each directory is shown as a collection. Markdown and JSON files appear as
-records inside it.
+Each immediate, non-hidden directory is shown as a collection. Direct Markdown
+and JSON files appear as records inside it.
 
 ## Create a document
 
@@ -76,11 +98,20 @@ Choose **New content** from a collection, then enter a slug and optional title.
 The slug becomes the filename. For example, `getting-started` creates
 `getting-started.md`.
 
+The slug is required, uses lowercase letters and numbers separated by single
+hyphens, and can be at most 120 characters. A title is optional and can be at
+most 200 characters. The create action is enabled only when current validation
+passes, and the server repeats the same validation before writing.
+
 Slipway creates a Markdown document with initial frontmatter and commits it as:
 
 ```text
 chore(content): create blog/getting-started
 ```
+
+The initial file contains `createdAt`, the optional title, an H1, and a short
+writing prompt. Creating JSON records from the manager is not currently
+supported; existing JSON files remain editable.
 
 Use meaningful, URL-safe slugs because applications commonly use them in public
 routes.
@@ -120,21 +151,29 @@ set.
 ## Metadata
 
 Frontmatter appears in a collapsed **Metadata** section above the document.
-Open it to edit values such as title, description, author, publication date, or
-tags.
+Open it to edit simple `key: value` fields such as title, description, author,
+or publication date.
 
 ```markdown
 ---
 title: Getting Started with Sails
 description: Build and deploy your first Sails application.
 published: true
-tags: ['sails', 'deployment']
 ---
 ```
 
-String, number, boolean, array, and object values are serialized back to valid
-frontmatter. Use Markdown mode when a document needs advanced YAML formatting
-that the form cannot represent safely.
+The metadata form intentionally uses text inputs. It reads simple, top-level
+YAML-style pairs and writes their values back safely. It is not a complete YAML
+editor: nested objects, arrays, multiline blocks, comments, anchors, and other
+advanced YAML constructs can lose their original structure if edited through
+the form.
+
+Use **Markdown** source mode for complex frontmatter. Source mode preserves the
+complete file as written. Metadata keys must start with a letter or underscore,
+may contain letters, numbers, underscores, dots, and hyphens, and the form
+accepts at most 100 keys.
+
+Both the Markdown body and raw source are limited to 5 MB.
 
 ## Images
 
@@ -150,6 +189,17 @@ If uploads are not configured, paste a public image URL instead. Storage
 credentials stay in Slipway settings and are never written into the content
 file.
 
+Uploaded images are assigned a UUID filename below:
+
+```text
+teams/:teamId/projects/:projectId/content/:imageId.:extension
+```
+
+Slipway saves the configured public storage URL in Markdown, not the provider
+credential or a private filesystem path. The upload route verifies the signed-in
+team, project, environment, detected Content feature, MIME type, and size again
+on the server.
+
 ## Save and deploy
 
 The main **Save** action records the change without deploying. Its menu also
@@ -162,6 +212,10 @@ With a connected GitHub repository, saving:
 3. refreshes Slipway's local build context only after the repository write
    succeeds.
 
+Slipway uses the branch mapped to the current environment. If there is no
+mapping, it uses the repository's default branch and finally falls back to
+`main`.
+
 Updates use a conventional commit such as:
 
 ```text
@@ -171,9 +225,15 @@ chore(content): update blog/getting-started
 **Save & Deploy** then queues a deployment pinned to that commit SHA. A later
 push to the branch cannot change what that deployment builds.
 
-For applications without a writable repository source, Slipway can keep the
-local content source in sync, but durable repository history and exact Git
-revisions require a connected repository.
+For applications without a repository, Slipway writes the local pushed source
+tree. That is useful for editing and testing, but it is not durable Git history
+and can be replaced by a later source push. Exact revision pinning requires a
+writable connected GitHub repository.
+
+**Save & Deploy** first verifies that the app has a deployable source. It then
+queues a deployment with the commit SHA and branch returned by the successful
+content write. If source is unavailable, Content rejects the deploy action
+instead of pretending the save can be released.
 
 ::: tip Static content
 Applications that compile content at build time need **Save & Deploy** before
@@ -216,15 +276,32 @@ JSON records use a source editor rather than the visual Markdown surface:
 ```
 
 Slipway preserves the raw JSON file and applies the same Git conflict protection
-when saving it.
+when saving it. The server parses the complete value and refuses invalid JSON
+or source larger than 5 MB.
+
+## Production workflow
+
+1. Connect the app's GitHub repository with write access.
+2. Map the production and non-production branches intentionally.
+3. Edit and preview content in a non-production environment when the app builds
+   content into its assets.
+4. Use **Save** when another release process will deploy the commit.
+5. Use **Save & Deploy** when this edit should become an exact pinned release.
+6. Treat Git history as the audit and recovery path for content changes.
+
+Content prevents stale overwrites, but it is not a multi-user collaborative
+cursor editor. Two editors can work concurrently; the second stale save must
+reload and reconcile the newer Git revision.
 
 ## Troubleshooting
 
 ### Content is not available
 
 1. Confirm `sails-content` is installed in the application.
-2. Deploy the application so Slipway can detect its features.
-3. Confirm you are viewing the correct application and environment.
+2. Confirm the configured content directory contains immediate collection
+   directories with `.md` or `.json` files.
+3. Deploy the application so Slipway can detect its features.
+4. Confirm you are viewing the correct application and environment.
 
 ### Visual mode is unavailable
 
@@ -242,6 +319,12 @@ another save so the newer change is not overwritten.
 Use **Save & Deploy** and wait for the pinned deployment to become healthy.
 Saving alone does not rebuild an application that compiles content at build
 time.
+
+### GitHub rejects a save
+
+Reconnect the repository with content write access and confirm the environment
+maps to a branch the integration can update. Slipway does not fall back to a
+local write when a connected repository rejects the operation.
 
 ## What's next?
 

--- a/docs/slipway/dock.md
+++ b/docs/slipway/dock.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: Dock
 titleTemplate: Slipway
-description: Database management for production. SQL console, schema diff, migrations, and table browser—all from the Slipway dashboard.
+description: Inspect, query, export, import, and migrate PostgreSQL, MySQL, MongoDB, and Redis services attached to a Slipway environment.
 prev:
   text: Quest
   link: /slipway/quest
@@ -17,407 +17,316 @@ editLink: true
 
 # Dock
 
-Dock is Slipway's database management interface for production. Run SQL queries, compare schemas, apply migrations, and browse data without external tools or SSH access.
+Dock is Slipway's database and cache workbench. It connects to a running
+service attached to the selected environment and uses that service's real
+credentials inside the private Docker network.
 
-## What is Dock?
+Dock is not an ORM abstraction. SQL, MongoDB expressions, Redis commands,
+imports, and generated migrations execute against the selected live service.
 
-Dock provides a web-based interface for managing your PostgreSQL or MySQL database:
+## Supported services
 
-- **SQL Console** - Run queries directly against your database
-- **Table Browser** - View and navigate your data
-- **Schema Viewer** - Inspect table structures and columns
-- **Schema Diff** - Compare Waterline models with database schema
-- **One-Click Migrations** - Generate and apply schema changes
+| Service    | Console              | Browse                    | Schema              | Model diff                 | Import and export                   |
+| ---------- | -------------------- | ------------------------- | ------------------- | -------------------------- | ----------------------------------- |
+| PostgreSQL | SQL                  | tables and rows           | columns and indexes | full Waterline schema diff | SQL text and PostgreSQL custom dump |
+| MySQL      | SQL                  | tables and rows           | columns and indexes | full Waterline schema diff | SQL text                            |
+| MongoDB    | `mongosh` expression | collections and documents | collection metadata | missing collections        | JSON or compressed archive          |
+| Redis      | `redis-cli` command  | —                         | —                   | —                          | —                                   |
 
-Dock lets you manage the production database from Slipway.
+Dock appears when the environment has at least one running service of these
+types. If several services are running, the first screen is a service picker
+and the selected service ID becomes part of the Dock URL.
 
-## Requirements
+## Open Dock
 
-Dock is automatically available when your environment has a **PostgreSQL** or **MySQL** service attached:
+Choose **Dock** from an environment or from a database service action. The
+production picker uses:
 
-```bash
-slipway db:create main-db --type=postgresql
+```text
+/projects/:projectSlug/dock
 ```
 
-Once the service is running, the Dock icon appears in your environment's toolbar.
+Other environments include the environment slug:
 
-## Accessing Dock
-
-### Via Dashboard
-
-1. Go to your project in Slipway
-2. Select an environment and click the app name from the Apps list
-3. In the **Services** section, click the **Dock** icon next to a database service
-4. Start managing your database
-
-### Via Direct URL
-
-```
-https://your-slipway-instance.com/projects/myapp/dock
+```text
+/projects/:projectSlug/environments/:environmentSlug/dock
 ```
 
-Or with a specific environment:
+After selecting a service, Slipway appends its ID. Every server request
+rechecks that the service belongs to the environment, belongs to the signed-in
+user's team, and is still running.
 
-```
-https://your-slipway-instance.com/projects/myapp/environments/staging/dock
-```
+## Console
 
-## SQL Console
+### PostgreSQL and MySQL
 
-The SQL Console lets you run queries directly against your production database.
-
-### Running Queries
-
-1. Enter your SQL in the query editor
-2. Press **Cmd/Ctrl + Enter** or click **Run Query**
-3. View results in the table below
+Write SQL and use **Run** or <kbd>Cmd/Ctrl Enter</kbd>. Dock executes the query
+inside the service container with `psql` or `mysql`; it does not open the
+database port to the public internet.
 
 ```sql
-SELECT * FROM users WHERE "createdAt" > '2024-01-01' LIMIT 50;
+SELECT id, email, created_at
+FROM users
+ORDER BY created_at DESC
+LIMIT 50;
 ```
 
-### Query Results
-
-Results display in a formatted table with:
-
-- Column headers
-- Row count
-- Query execution time
-- Scrollable data view
-
-When the editor contains more than one SQL statement, Dock keeps a separate,
-labeled result for every statement. Select the result tabs to move between
-rowsets, command summaries, and errors. The tabs support the left and right
-arrow keys, and each rowset can be copied as CSV independently.
-
-```sql
-SELECT count(*) AS creators FROM creators;
-SELECT count(*) AS teams FROM teams;
-```
-
-The results remain in statement order. If a later statement fails outside an
-explicit transaction, Dock preserves the earlier results so you can see exactly
-what ran before the failure. If you need all-or-nothing behavior, wrap the
-statements in `BEGIN` and `COMMIT`.
-
-### Safety Features
-
-Dock blocks dangerous queries that could harm your database:
-
-- `DROP DATABASE` statements
-- `DROP SCHEMA` statements
-- System table modifications
-
-For destructive operations, use a dedicated migration or backup first.
-
-## Importing SQL and database dumps
-
-Use **Import** to paste SQL or upload a database dump. Slipway streams uploaded
-data through a temporary file rather than loading the complete backup into
-application memory.
-
-The default maximum import size is 500 MB. Operators can change it with the
-database operation limits in Slipway's server configuration. An oversized
-upload is rejected before it reaches the database, and the temporary file is
-removed after either success or failure.
-
-PostgreSQL custom-format dumps and MySQL/SQL text imports use their native
-database clients. Import errors are returned in Dock so a failed restore does
-not look successful.
-
-## Table Browser
-
-Browse your database tables without writing SQL.
-
-### Viewing Tables
-
-1. Click the **Tables** tab
-2. Select a table from the list
-3. View data with automatic pagination
-
-Each table shows:
-
-- Table name
-- Row count
-- Columns and their types
-
-### Pagination
-
-Large tables are paginated automatically:
-
-- Default limit: 50 rows
-- Navigate through pages
-- Sort by any column
-
-## Schema Viewer
-
-Inspect your database schema at a glance.
-
-### Table Structure
-
-For each table, Dock shows:
-
-| Column       | Info                       |
-| ------------ | -------------------------- |
-| **Name**     | Column identifier          |
-| **Type**     | PostgreSQL/MySQL data type |
-| **Nullable** | Whether NULL is allowed    |
-| **Default**  | Default value, if set      |
-| **PK**       | Primary key indicator      |
-
-### Example
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│ users                                                           │
-├─────────────────────────────────────────────────────────────────┤
-│ Column         Type                Nullable    Default     PK   │
-│ id             integer             NO          auto        ✓    │
-│ email          character varying   NO          -                │
-│ fullName       character varying   YES         -                │
-│ createdAt      timestamp           NO          now()            │
-│ updatedAt      timestamp           NO          now()            │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-## Schema Diff & Migrations
-
-The most powerful Dock feature: compare your Waterline models with the actual database schema.
-
-### How It Works
-
-1. Dock reads your Waterline model definitions from the running app
-2. Queries the database's `information_schema`
-3. Compares them and generates SQL to sync
-
-### Viewing the Diff
-
-1. Click the **Migrate** tab
-2. Dock analyzes models vs database
-3. See what changes are needed
-
-### Status Indicators
-
-| Status                   | Meaning                 |
-| ------------------------ | ----------------------- |
-| **Schema is up to date** | Database matches models |
-| **X change(s) needed**   | Migration required      |
-
-### Generated SQL
-
-For each difference, Dock generates the appropriate SQL:
-
-```sql
--- New table
-CREATE TABLE "posts" (
-  "id" SERIAL PRIMARY KEY,
-  "title" character varying(255) NOT NULL,
-  "body" text,
-  "createdAt" timestamp NOT NULL DEFAULT now()
-);
-
--- New column
-ALTER TABLE "users" ADD COLUMN "avatarUrl" character varying(255);
-```
-
-### Applying Migrations
-
-1. Review the generated SQL
-2. Click **Apply Migration**
-3. Confirm the action
-4. SQL executes against your database
-
-::: warning
-Migrations modify your production database. Always backup first and review the generated SQL carefully.
-:::
-
-## First-Time Schema Setup
-
-When deploying a new Sails app, your database starts empty. Use Dock to initialize it:
-
-1. Deploy your app (it will fail to connect to empty database)
-2. Open Dock → Migrate tab
-3. See all tables that need to be created
-4. Click **Apply Migration**
-5. Redeploy or restart your app
-
-This is much easier than manually running `sails lift` with `migrate: alter` in production.
-
-## Waterline Type Mapping
-
-Dock uses the same type mappings as the actual Sails database adapters:
-
-### PostgreSQL
-
-| Waterline | PostgreSQL         | Notes                                 |
-| --------- | ------------------ | ------------------------------------- |
-| `string`  | `TEXT`             | Not VARCHAR - PostgreSQL prefers TEXT |
-| `text`    | `TEXT`             | Long text content                     |
-| `number`  | `REAL` / `INTEGER` | REAL for floats, INTEGER for PKs      |
-| `boolean` | `BOOLEAN`          | Native PostgreSQL boolean             |
-| `json`    | `JSON`             | Native JSON type                      |
-| `ref`     | `TEXT`             | Arbitrary references                  |
-
-Auto-increment columns use `SERIAL` type.
-
-### MySQL
-
-| Waterline | MySQL              | Notes                              |
-| --------- | ------------------ | ---------------------------------- |
-| `string`  | `VARCHAR(255)`     | Length-limited strings             |
-| `text`    | `TEXT`             | Long text content                  |
-| `number`  | `REAL` / `INTEGER` | REAL for floats, INTEGER for PKs   |
-| `boolean` | `TINYINT(1)`       | MySQL boolean representation       |
-| `json`    | `LONGTEXT`         | For compatibility with older MySQL |
-| `ref`     | `LONGTEXT`         | Arbitrary references               |
-
-Auto-increment columns use `AUTO_INCREMENT` flag.
-
-### Custom Column Types
-
-If you specify `columnType` in your model, Dock uses it directly:
-
-```javascript
-attributes: {
-  uuid: {
-    type: 'string',
-    columnType: 'UUID DEFAULT uuid_generate_v4()'
-  },
-  metadata: {
-    type: 'json',
-    columnType: 'JSONB'  // Use JSONB instead of JSON
-  }
-}
-```
-
-## API Endpoints
-
-Dock provides REST API endpoints for automation:
-
-### Execute SQL
-
-```bash
-POST /api/v1/projects/:projectSlug/dock/sql
-
-{
-  "query": "SELECT * FROM users LIMIT 10"
-}
-```
-
-### Get Schema
-
-```bash
-GET /api/v1/projects/:projectSlug/dock/schema
-```
-
-### Get Schema Diff
-
-```bash
-GET /api/v1/projects/:projectSlug/dock/diff
-```
-
-### Apply Migration
-
-```bash
-POST /api/v1/projects/:projectSlug/dock/migrate
-
-{
-  "statements": [
-    {"sql": "ALTER TABLE users ADD COLUMN bio TEXT;"}
-  ]
-}
-```
-
-### List Tables
-
-```bash
-GET /api/v1/projects/:projectSlug/dock/tables
-```
-
-### Browse Table Data
-
-```bash
-GET /api/v1/projects/:projectSlug/dock/tables/:table/data?limit=50&offset=0
-```
-
-## Best Practices
-
-### 1. Backup Before Migrations
-
-Always create a backup before applying schema changes:
-
-```bash
-slipway backup:create myapp postgresql
-```
-
-### 2. Test in Staging First
-
-Use a staging environment to test migrations. Apply via the Dock UI in your staging environment first, verify it works, then apply to production.
-
-### 3. Review Generated SQL
-
-Always review the SQL that Dock generates. While it handles most cases correctly, complex migrations may need manual adjustment.
-
-### 4. Use Transactions for Multiple Changes
-
-When applying multiple related changes, consider wrapping them in a transaction via the SQL Console:
+Multi-statement SQL is split and presented as one ordered result per statement.
+Each result identifies the command, status, duration, row count, affected-row
+summary, rows, or error. When a later statement fails outside an explicit
+transaction, earlier successful statements remain visible and may already be
+committed.
 
 ```sql
 BEGIN;
-ALTER TABLE orders ADD COLUMN discount DECIMAL(10,2);
-ALTER TABLE orders ADD COLUMN discountCode VARCHAR(50);
+ALTER TABLE orders ADD COLUMN discount DECIMAL(10, 2);
+ALTER TABLE orders ADD COLUMN discount_code VARCHAR(50);
 COMMIT;
 ```
 
-### 5. Keep Models and Database in Sync
+The server gives console execution 30 seconds and bounds captured process
+output to 10 MB. Query history is kept only in the current browser page and is
+capped at 20 deduplicated entries.
 
-Run schema diff regularly to catch drift between your models and database. Ideally, your CI/CD pipeline should verify this.
+### MongoDB
+
+MongoDB console input is a JavaScript expression evaluated by `mongosh`:
+
+```javascript
+db.users.find({ emailVerified: true }).limit(10).toArray()
+```
+
+Dock serializes the returned value into the same table or JSON result surface.
+Use collection operations deliberately: this is a live shell, not a read-only
+query builder.
+
+### Redis
+
+The Redis console sends one command to `redis-cli` and displays its raw output,
+error, and duration:
+
+```text
+INFO memory
+```
+
+Quick actions are provided for common inspection commands such as `PING`,
+`INFO server`, `DBSIZE`, and `CONFIG GET maxmemory`. Use the up and down arrow
+keys to navigate the current-page history. The browser keeps at most 200
+entries and trims older output after that bound.
+
+::: danger Consoles can mutate data
+Dock permits ordinary writes. It blocks only a narrow class of catastrophic
+commands: dropping a PostgreSQL/MySQL database or schema, selected system-table
+truncation, and MongoDB database/collection drop or shutdown expressions. This
+is not a general read-only policy. `UPDATE`, `DELETE`, `FLUSHALL`, and many other
+destructive operations can execute. Back up first and prefer a scoped,
+reviewable statement.
+:::
+
+## Read results
+
+Rowsets open as tables and can be viewed as JSON. A multi-statement query adds
+keyboard-accessible result tabs. Dock keeps command summaries separate from
+rowsets so an `ALTER TABLE` or `UPDATE` result does not look like an empty
+`SELECT`.
+
+Copy and export act on the selected result. CSV output quotes commas, quotes,
+and newlines. Returned values are shown as data and do not execute as page HTML.
+
+## Browse tables and collections
+
+The **Tables** or **Collections** tab lists objects with an estimated or exact
+row/document count. Select one to load a page of data.
+
+The browse endpoint defaults to 50 rows, accepts 1–1,000, and supports offset,
+order field, and ascending or descending order. SQL table and order identifiers
+must be simple identifiers; Dock rejects names that could inject SQL. MongoDB
+uses `_id` as its default order field, while SQL uses `id`.
+
+Counts can be expensive on very large collections or tables. Use the console
+with a purpose-built indexed query when the generic browser is not the right
+tool.
+
+## Inspect schema
+
+PostgreSQL and MySQL schema views show the physical table definition, including
+columns, database types, nullability, defaults, primary keys, and indexes. The
+table filter is reflected in `?schemaTables=` so a focused schema view can be
+bookmarked.
+
+MongoDB is schemaless. Dock can list collections and compare whether the
+collections expected by Waterline exist, but it does not infer a field schema
+from sample documents. Redis has no schema tab.
+
+## Compare Waterline models
+
+The **Migrate** tab compares the selected service with the application's model
+metadata.
+
+1. When the app is running, Dock first introspects its loaded Waterline models.
+2. If runtime introspection is unavailable, Dock falls back to statically
+   reading model source from the pushed build context.
+3. Dock reads the service's current schema.
+4. It maps Waterline attributes to the physical types used by the selected
+   adapter.
+5. It presents grouped, selectable statements for review.
+
+The response says whether model metadata came from `runtime` or `static`.
+Runtime is preferable because it includes the application's effective loaded
+model definitions. Static fallback allows first-time schema creation when the
+app cannot lift against an empty database.
+
+### What migrations generate
+
+For PostgreSQL and MySQL, Dock can generate:
+
+- table creation;
+- column rename when an attribute name maps to a different column name;
+- missing column creation;
+- compatible column type or nullability changes; and
+- missing indexes.
+
+For MongoDB, it creates missing collections only. The generated diff does not
+drop extra tables, collections, or columns automatically.
+
+An explicit Waterline `columnType` is used as the desired physical type. Review
+it carefully because it bypasses the normal logical type mapping.
+
+### Apply a migration
+
+Select the model groups, read every generated statement, choose **Apply
+Migration**, and confirm the count. Dock executes statements sequentially and
+stops on the first failure. The response reports each successful statement and
+the failing one.
+
+Dock does not automatically wrap the whole generated list in a transaction.
+Earlier statements can remain applied if a later statement fails. Recompute
+the diff before retrying.
+
+::: warning Back up and stage schema changes
+Generated SQL is a useful translation of model metadata, not a proof that the
+data can satisfy a new constraint. Test the same change in staging, inspect
+existing nulls and duplicates, and create a backup before production.
+:::
+
+## Initialize an empty database
+
+An application can fail to lift when its production datastore has no tables.
+Dock can still build a diff from pushed source:
+
+1. push or deploy the application source;
+2. create and start the database service;
+3. open **Dock → Migrate** for that service;
+4. verify that model source was loaded and review the generated tables;
+5. apply the migration; and
+6. redeploy or restart the application.
+
+If Dock reports `modelsSourceNotFound`, push source before trying again.
+
+## Export
+
+The export action can include the full database, schema only, data only, or a
+selected set of tables.
+
+| Service    | Implementation                                                                      | Notes                                                |
+| ---------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| PostgreSQL | `pg_dump --no-owner --no-acl`                                                       | supports table selection, schema-only, and data-only |
+| MySQL      | `mysqldump --single-transaction --routines --triggers`                              | supports table selection, schema-only, and data-only |
+| MongoDB    | `mongoexport` for one selected collection, otherwise compressed `mongodump` archive | schema-only does not apply                           |
+
+The current export process has a five-minute timeout and a 100 MB captured
+output buffer. Large production backups should use Slipway's backup workflow
+instead of a browser download.
+
+## Import
+
+Paste text or upload a supported file, review the destructive confirmation,
+and then import into the selected service.
+
+| Service    | Text                                              | Binary/archive                                              |
+| ---------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| PostgreSQL | `.sql` through `psql` with `ON_ERROR_STOP=1`      | `.dmp` custom dump through `pg_restore --clean --if-exists` |
+| MySQL      | `.sql` through `mysql`                            | not supported                                               |
+| MongoDB    | JSON array, optionally with `// collection: name` | gzip archive through `mongorestore --drop`                  |
+
+Uploaded PostgreSQL custom dumps must begin with the `PGDMP` signature.
+MongoDB archives must be gzip. Slipway rejects a mismatched file before calling
+the native restore client.
+
+Imports stream through a temporary file or process input so Slipway does not
+buffer a 500 MB upload in application memory. Defaults are:
+
+| Limit           | Default    |
+| --------------- | ---------- |
+| Maximum import  | 500 MB     |
+| Import timeout  | 30 minutes |
+| Captured stdout | 64 KB      |
+| Captured stderr | 64 KB      |
+
+The temporary upload is deleted after success or failure. Streaming controls
+memory use, but the host still needs enough free disk for the temporary file
+and database growth.
+
+## Authenticated endpoints
+
+The Dock UI uses the following session-authenticated routes. Add
+`/environments/:environmentSlug` after the project slug for a non-production
+environment, and pass `?service=:serviceId` when selecting a particular
+service.
+
+| Method | Path suffix                | Purpose                             |
+| ------ | -------------------------- | ----------------------------------- |
+| `POST` | `/dock/sql`                | execute SQL or a MongoDB expression |
+| `GET`  | `/dock/tables`             | list tables or collections          |
+| `GET`  | `/dock/tables/:table/data` | browse a page of data               |
+| `GET`  | `/dock/schema`             | read physical schema                |
+| `GET`  | `/dock/models`             | inspect application models          |
+| `GET`  | `/dock/diff`               | generate the model/schema diff      |
+| `POST` | `/dock/migrate`            | apply selected statements           |
+| `POST` | `/dock/export`             | export data or schema               |
+| `POST` | `/dock/import`             | import text or an uploaded dump     |
+
+The common prefix is `/api/v1/projects/:projectSlug`. These endpoints use the
+same team and environment authorization as the page; they are not public
+database APIs.
 
 ## Troubleshooting
 
-### Dock Not Appearing
+### No services appear
 
-If the Dock icon doesn't show:
+Confirm the service is PostgreSQL, MySQL, MongoDB, or Redis; belongs to the
+selected environment; and has `running` status. A stopped service is removed
+from the picker.
 
-1. Verify you have a PostgreSQL or MySQL service attached
-2. Check the service is running (`status: running`)
-3. The icon only appears when service is active
+### A query times out
 
-### Query Timeout
+Console SQL and MongoDB execution has a 30-second timeout. Add a limit, inspect
+the query plan, add an index, or use a dedicated reporting path for long work.
 
-For long-running queries:
+### The diff is empty or wrong
 
-1. Default timeout is 30 seconds
-2. Optimize your query (add indexes, limit results)
-3. For complex reports, consider using a read replica
+Check the reported model source. Restart the app after model changes so runtime
+metadata is current, or push the new source so static fallback can read it.
+Then verify `tableName`, `columnName`, `columnType`, and datastore assignment in
+the model.
 
-### Import Rejected
+### An import is rejected
 
-If a dump is rejected before it begins:
+Check the service, file signature, 500 MB default bound, and available host
+disk. A PostgreSQL plain SQL file belongs in text mode; `.dmp` expects the
+custom `pg_dump` format.
 
-1. Check its size against the configured import limit.
-2. Confirm that its format matches the selected database service.
-3. Check available host disk space; streaming avoids a memory spike but the
-   temporary upload still needs disk capacity.
+### A migration partially applies
 
-### Migration Fails
+Do not resubmit the old statement list blindly. Reload the diff against the
+current database, inspect which changes remain, and restore from backup if the
+partial state is unsafe.
 
-If migration fails:
+## What's next?
 
-1. Check the error message in the result
-2. The database may have constraints preventing the change
-3. Try running individual statements via SQL Console
-4. Check for dependent objects (foreign keys, views)
-
-### Schema Diff Shows Incorrect Results
-
-If diff seems wrong:
-
-1. Ensure your app is running (models are read from running container)
-2. Check that model file syntax is correct
-3. Custom `columnType` may not match expected patterns
-
-## What's Next?
-
-- Use [Helm](/slipway/helm) for debugging app issues
-- Configure [Auto-Deploy](/slipway/auto-deploy) for continuous deployment
+- Use [Backups](/slipway/database-services#backups) before destructive database
+  work.
+- Use [Helm](/slipway/helm) when the repair is clearer through application
+  models and helpers.
+- Use [Lookout](/slipway/lookout) to correlate database work with application
+  latency and errors.

--- a/docs/slipway/helm.md
+++ b/docs/slipway/helm.md
@@ -36,6 +36,21 @@ Helm gives you a live REPL connected to your running Sails application:
 - Record privacy-safe production execution audits for owners and admins
 - All without SSH or direct database access
 
+Helm is application-aware: it boots the selected Sails app and exposes that
+app's models, helpers, and configuration. Use the other operational surfaces
+when you do not need the application runtime:
+
+| Need                                            | Surface                     |
+| ----------------------------------------------- | --------------------------- |
+| Run Sails-aware JavaScript in one deployed app  | Helm                        |
+| Query a database or Redis service directly      | [Dock](/slipway/dock)       |
+| Operate Slipway's own runtime and SQLite stores | [Bosun](/slipway/bosun)     |
+| Inspect requests, failures, and resources       | [Lookout](/slipway/lookout) |
+
+Helm is not a persistent Node console. Every run gets a fresh isolated process,
+so variables, monkey patches, and in-memory state do not carry into the next
+execution. Scratchpads preserve source, not a live JavaScript context.
+
 ## Accessing Helm
 
 ### Via Dashboard
@@ -69,6 +84,29 @@ Each Helm execution has a **30-second wall-clock timeout**. This covers synchron
 ::: info Bounded output
 Helm accepts up to **64 KB of source**, captures up to **64 KB of console logs**, and bounds the serialized result. If output is too large, Helm returns the safe portion and marks the result as truncated instead of buffering without limit.
 :::
+
+### Execution and storage limits
+
+| Boundary                                           |    Default |
+| -------------------------------------------------- | ---------: |
+| Source per execution or snippet                    |      64 KB |
+| Wall-clock execution                               | 30 seconds |
+| Captured console logs                              |      64 KB |
+| Serialized final result                            |     128 KB |
+| Isolated process output                            |     256 KB |
+| Isolated process stderr                            |      64 KB |
+| Inline inspect values per loop marker              |         20 |
+| Query trace entries                                |        100 |
+| Browser scratchpads                                |         20 |
+| Production write-arm lifetime                      | 60 seconds |
+| Unpinned history retention                         |    30 days |
+| History entries per user, project, and environment |        200 |
+| Team audit retention                               |    90 days |
+| Audit entries per team                             |      5,000 |
+
+These are safety and operability bounds, not pagination promises. Use a bounded
+Waterline query, return a summary, and export through the system that owns the
+data when an investigation exceeds them.
 
 ### Stopping and reading execution status
 

--- a/docs/slipway/lookout.md
+++ b/docs/slipway/lookout.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: Lookout
 titleTemplate: Slipway
-description: Observability for your Sails applications. Monitor HTTP requests, exceptions, database queries, and cache performance from the Slipway dashboard.
+description: Understand host health, application requests, exceptions, database queries, cache behavior, jobs, and release flags from one Slipway observability surface.
 prev:
   text: Dock
   link: /slipway/dock
@@ -17,182 +17,268 @@ editLink: true
 
 # Lookout
 
-Lookout is the **observability dashboard** for your Sails applications deployed on Slipway. It gives you visibility into HTTP requests, exceptions, database queries, and cache performance — all without any external monitoring tools.
+Lookout is Slipway's built-in observability surface. It joins two different
+sources of operational data:
 
-## What Lookout Tracks
+- **infrastructure telemetry** collected by the Slipway host from managed
+  Docker containers; and
+- **application telemetry** emitted by `sails-hook-slipway` from a deployed
+  Sails application.
 
-| Category       | What's captured                                   |
-| -------------- | ------------------------------------------------- |
-| **Requests**   | HTTP method, URL, status code, duration, p95      |
-| **Exceptions** | Unhandled errors, promise rejections, stack trace |
-| **Queries**    | Slow Waterline queries above threshold            |
-| **Cache**      | Hit/miss rates, writes, deletes, top keys         |
+You can therefore start with a host or container problem, move into a slow
+request or exception, and inspect the exact application environment without
+maintaining a separate monitoring stack.
 
-## Getting Started
+## Choose the right Lookout view
 
-### 1. Install the hook
+| View                | Use it for                                                    | Data source             |
+| ------------------- | ------------------------------------------------------------- | ----------------------- |
+| Global Lookout      | Host disk, every managed running container, collector health  | Slipway host and Docker |
+| Environment Lookout | Apps and services in one project environment                  | Slipway host and Docker |
+| Application tabs    | Requests, exceptions, queries, cache, Quest, and flag cohorts | `sails-hook-slipway`    |
+
+The global view is available at `/lookout`. A project production environment
+uses `/projects/:projectSlug/lookout`; other environments include
+`/environments/:environmentSlug` in the URL.
+
+Lookout only includes containers managed by Slipway. Unrelated Docker
+containers on the same host do not appear in project views.
+
+## Enable application telemetry
+
+Install the hook in the target Sails application:
 
 ```bash
 npm install sails-hook-slipway
 ```
 
-### 2. Deploy your app
+Deploy the application through Slipway. During deployment, Slipway injects a
+private telemetry URL and environment token into the container:
 
-Slipway automatically injects `SLIPWAY_TELEMETRY_URL` and `SLIPWAY_TELEMETRY_TOKEN` into your container at deploy time. No manual configuration needed.
+```text
+SLIPWAY_TELEMETRY_URL
+SLIPWAY_TELEMETRY_TOKEN
+```
 
-### 3. View the dashboard
+The token is scoped to the environment and sent as a bearer credential to the
+ingest endpoint. It never becomes a browser prop. No public database port or
+third-party analytics account is required.
 
-Go to your project in Slipway, select an environment, and click the **Lookout** icon. Data appears within seconds of your first request.
+Infrastructure monitoring works without the target-app hook. The application
+tabs require the hook and begin filling after the app serves requests or emits
+instrumented events.
 
 ## Infrastructure
 
-The **Infrastructure** tab shows real-time resource usage for all running containers:
+Slipway samples managed app and service containers every 30 seconds. The
+environment view shows current CPU, memory, network I/O, block I/O, process
+count, container state, and recent history.
 
-- **CPU and Memory** — current percentage with sparkline history
-- **Network I/O** — bytes sent and received
-- **Block I/O** — disk read/write activity
-- **Process count** — number of running processes
+Select a container to inspect up to 24 hours of samples. Long histories are
+downsampled to at most 200 points before they reach the browser. The global
+view adds host disk usage and a summary of running containers.
 
-Click a container to expand its 24-hour history chart.
+### Container lifecycle and alerts
 
-### Collection and retention health
+Lookout reconciles the database with Docker so a container that disappears or
+stops does not remain falsely healthy in the dashboard. Recovery is recorded
+when it returns.
 
-Lookout stores infrastructure samples and application telemetry in
-`db/observability.db`. The host-health card shows the latest collector and
-retention state, including:
+CPU or memory usage above 90% for three consecutive samples produces a resource
+alert. At the default collection interval that is approximately 90 seconds,
+which avoids treating a brief build spike as an incident. A 15-minute cooldown
+prevents repeated notifications for the same sustained condition.
 
-- the last attempt and last successful run;
-- the number of retained rows;
-- a stale or failed state and the latest error.
+### Application logs
 
-Docker collection and storage maintenance are deliberately independent.
-Container metrics are collected every 30 seconds, while the
-`maintain-observability` Quest job checks disk health and removes expired rows
-every 5 minutes. Retention therefore continues even when Docker is temporarily
-unavailable or no application containers are running.
+Slipway periodically captures recent logs from managed application containers
+and keeps them in the observability store for seven days. This is useful for
+correlating a container or request failure with surrounding application output.
+Secrets can still be exposed by application logging, so do not print tokens,
+passwords, raw session objects, or sensitive records.
 
 ## Requests
 
-The **Requests** tab shows HTTP traffic from the last hour:
+The Requests tab is built from server spans emitted by the hook. It shows
+request volume, error rate, average and p95 latency, plus recent request rows.
+Each span can contain:
 
-- **Requests / hr** — total request count
-- **Error rate** — percentage of 5xx responses
-- **p95 latency** — 95th percentile response time
-- **Avg latency** — mean response time
+- HTTP method, URL or route, status, duration, and start time;
+- request and response content lengths;
+- user agent, client IP, referrer, and accepted content types; and
+- release-flag values evaluated during that request.
 
-A table of recent requests shows method, URL, status code, duration, and time.
+Health checks and common static assets are skipped so they do not distort
+application traffic. Lookout does not capture request or response bodies.
 
-When an application evaluates [release flags](/slipway/release-flags), the
-Requests tab also compares request count, average latency, and 5xx error rate
-for each flag's on and off cohorts. Expand a request to see the flag values that
-were used for it. The comparison stays hidden until a request evaluates a flag.
+::: warning Treat observability as sensitive operational data
+URLs, client IPs, user agents, query summaries, cache keys, and stack traces can
+still reveal user or system context. Keep sensitive values out of URLs and
+cache keys, and limit dashboard access to the team members who operate the app.
+:::
+
+### Release-flag cohorts
+
+When the app evaluates [release flags](/slipway/release-flags), Lookout compares
+request count, average latency, and 5xx rate for each flag's on and off cohorts.
+The comparison remains hidden until at least one request evaluates that flag.
+Expand a request to see the values that affected it.
 
 ## Exceptions
 
-The **Exceptions** tab groups errors by type and message:
+The hook captures:
 
-- Unhandled exceptions and promise rejections
-- Server errors (500 responses) with request context
-- Stack traces for each exception group
-- Count and last-seen time per group
+- errors passed through `res.serverError()`;
+- uncaught exceptions; and
+- unhandled promise rejections.
 
-## Queries
+Lookout groups them by type and message and shows counts, last-seen time,
+handled state, request context when available, and stack traces. An exception
+buffer is flushed aggressively so important failures do not wait for a full
+normal telemetry batch.
 
-The **Queries** tab shows slow Waterline queries that exceed the configured threshold (default: 100ms):
+Telemetry delivery is deliberately best effort. A network or ingest failure is
+silently tolerated by the hook so observability can never take down the target
+application.
 
-- Model name and method
-- Query criteria
-- Duration and time
+## Database queries
+
+Lookout instruments common Waterline model methods such as `find`, `findOne`,
+`create`, `update`, `destroy`, `count`, `sum`, and `avg`.
+
+Successful queries are recorded only when they meet the slow-query threshold,
+which defaults to 100 ms. Failed queries are recorded regardless of duration.
+The event contains the model, method, duration, error state, and a bounded
+summary of criteria keys—not returned records or raw SQL.
+
+Use this tab to find patterns, then use [Helm](/slipway/helm) or
+[Dock](/slipway/dock) for a deliberate investigation.
 
 ## Cache
 
-The **Cache** tab provides visibility into [sails-stash](https://docs.sailscasts.com/sails-stash) cache operations. It tracks four operations:
-
-| Operation  | Description                                   |
-| ---------- | --------------------------------------------- |
-| **Hit**    | A `get` or `fetch` found the key in the cache |
-| **Miss**   | A `get` or `fetch` did not find the key       |
-| **Write**  | A `set` stored a value in the cache           |
-| **Delete** | A `delete` removed a key from the cache       |
-
-### Requirements
-
-Cache telemetry requires [sails-stash](https://docs.sailscasts.com/sails-stash) in your Sails app:
+When `sails-hook-stash` is present, `sails-hook-slipway` instruments
+`sails.cache.get`, `fetch`, `set`, and `delete` after the stash hook loads.
 
 ```bash
 npm install sails-hook-stash
 ```
 
-When `sails-hook-slipway` detects sails-stash, it automatically instruments cache operations. No additional configuration is needed.
+The Cache tab reports hits, misses, writes, deletes, duration, hit rate, active
+keys, and recent operations. A low hit rate can mean TTLs are too short, keys
+do not match the read pattern, or cached inputs change too frequently.
 
-### Key Metrics
+Cache keys are sent as telemetry. Use identifiers that are useful to operators
+without embedding credentials or private user data.
 
-- **Hit Rate** — percentage of `get`/`fetch` calls that returned cached data. A high hit rate (>80%) means your cache is working efficiently.
-- **Total Ops / hr** — total number of cache operations in the last hour
-- **Hits / Misses** — raw counts of cache hits and misses
-- **Top Keys** — most frequently accessed cache keys with per-key hit rate
-- **Recent Operations** — live feed of cache operations with duration
+## Quest jobs
 
-### Tips
+When Quest instrumentation is enabled, the hook listens for job start,
+completion, and error events. Lookout stores duration and job inputs with the
+event. Job errors also become exceptions and can trigger the configured job
+failure notification.
 
-- A **low hit rate** may indicate short TTLs, cache keys that don't match read patterns, or that `fetch` is being called with data that changes frequently
-- Use the **Top Keys** table to identify which keys are most active and whether they have good hit ratios
-- Cache operations are typically sub-millisecond — if you see high durations, check your cache store configuration
+The [Quest](/slipway/quest) page is the primary place to run, pause, resume, and
+inspect jobs. Lookout supplies the cross-application operational context.
 
-## Configuration
+## Configure the hook
 
-The hook uses sensible defaults. All telemetry features are enabled automatically. To customize behavior, create `config/slipway.js` in your Sails app:
+Defaults are intentionally usable without app configuration:
 
-```javascript
+```js
+// config/slipway.js
 module.exports.slipway = {
   lookout: {
-    enabled: true, // Enable/disable all telemetry
-    batchSize: 50, // Metrics per batch
-    flushInterval: 10000, // Flush every 10 seconds
-    captureQueries: true, // Track Waterline queries
-    captureExceptions: true, // Track exceptions
-    captureQuestEvents: true, // Track Quest job lifecycle
-    captureCache: true, // Track sails-stash cache operations
-    slowQueryThreshold: 100 // Only record queries slower than 100ms
+    enabled: true,
+    batchSize: 50,
+    flushInterval: 10000,
+    captureQueries: true,
+    captureExceptions: true,
+    captureQuestEvents: true,
+    captureCache: true,
+    slowQueryThreshold: 100
   }
 }
 ```
 
-::: tip
-When deployed via Slipway, you don't need to set `telemetryUrl` or `telemetryToken` — they're injected automatically.
-:::
+| Option               | Default | Meaning                                           |
+| -------------------- | ------: | ------------------------------------------------- |
+| `enabled`            |  `true` | Disable all target-app telemetry when false       |
+| `batchSize`          |    `50` | Flush when a buffer reaches this many events      |
+| `flushInterval`      | `10000` | Periodic flush interval in milliseconds           |
+| `captureQueries`     |  `true` | Instrument common Waterline methods               |
+| `captureExceptions`  |  `true` | Capture server and process-level errors           |
+| `captureQuestEvents` |  `true` | Capture Quest lifecycle events                    |
+| `captureCache`       |  `true` | Instrument `sails.cache` when available           |
+| `slowQueryThreshold` |   `100` | Minimum successful query duration in milliseconds |
 
-## Data retention
+Normally, do not set `telemetryUrl` or `telemetryToken` in the app. Slipway
+injects and rotates the environment-specific values during deployment.
 
-Slipway keeps enough history for diagnosis without allowing observability data
-to grow without a bound.
+Configuration takes effect in a new app process, so redeploy after changing
+`config/slipway.js`.
 
-| Data                                              | Default  | Environment variable                           |
-| ------------------------------------------------- | -------- | ---------------------------------------------- |
-| Container CPU, memory, network, and I/O samples   | 24 hours | `SLIPWAY_CONTAINER_METRICS_RETENTION_HOURS`    |
-| Requests, exceptions, queries, and app-level data | 7 days   | `SLIPWAY_APPLICATION_TELEMETRY_RETENTION_DAYS` |
+## Storage, retention, and maintenance
 
-Retention removes at most 500 rows per table in one batch and performs at most
-20 batches per table during a maintenance run. Operators can tune those bounds
-with:
+Lookout stores its data in `db/observability.db`, separate from Slipway's main
+application database.
+
+| Data                                                     | Default retention | Setting                                        |
+| -------------------------------------------------------- | ----------------: | ---------------------------------------------- |
+| Container CPU, memory, network, and I/O samples          |          24 hours | `SLIPWAY_CONTAINER_METRICS_RETENTION_HOURS`    |
+| Requests, exceptions, queries, cache, jobs, and app logs |            7 days | `SLIPWAY_APPLICATION_TELEMETRY_RETENTION_DAYS` |
+
+The `maintain-observability` Quest job runs every five minutes. It checks disk
+health and deletes expired rows in bounded batches. Defaults are 500 rows per
+batch and at most 20 batches per table per run:
 
 ```bash
 SLIPWAY_OBSERVABILITY_PRUNE_BATCH_SIZE=500
 SLIPWAY_OBSERVABILITY_MAX_PRUNE_BATCHES=20
 ```
 
-Values must be positive. The prune batch is capped at 900 rows to stay within
-SQLite's statement parameter limit.
+The batch must be positive and is capped at 900 rows to remain within SQLite's
+statement parameter limit. If a large backlog cannot be removed in one run,
+later runs continue from the remaining oldest data.
+
+The host-health card reports the last collector and retention attempt, last
+success, retained row counts, stale state, and latest error. A job becomes
+stale after three expected intervals, which distinguishes an idle host from a
+collector that has stopped making progress.
 
 ### Existing installations
 
-On startup, Slipway creates any missing observability tables and indexes. It
-migrates legacy container samples from `db/app.db` in bounded, idempotent
-batches, verifies the copied row count, and only then removes the legacy rows.
-An interrupted migration safely resumes on the next startup.
+Slipway creates missing observability tables and indexes at lift. Older
+container samples in `db/app.db` are copied into `db/observability.db` in
+bounded, idempotent batches. Slipway verifies the copied count before deleting
+legacy rows, so an interrupted migration resumes on the next start.
 
-## What's Next?
+## Troubleshooting
 
-- Set up [sails-stash](https://docs.sailscasts.com/sails-stash) for application-level caching
-- Use [Helm](/slipway/helm) for live debugging
-- Configure [Auto-Deploy](/slipway/auto-deploy) for continuous deployment
+### Infrastructure is empty
+
+Confirm Docker is reachable and that the app or service was created by Slipway.
+The collector intentionally ignores unrelated containers.
+
+### Application tabs are empty
+
+Confirm `sails-hook-slipway` is installed in the deployed revision, then
+redeploy so the telemetry URL and token are injected. Generate a request or job
+event after the new container becomes healthy.
+
+### Query telemetry is missing
+
+Only failed queries and successful queries at or above
+`slowQueryThreshold` are recorded. Lower the threshold deliberately and
+redeploy if you need a wider sample.
+
+### Health says retention is stale
+
+Open [Bosun](/slipway/bosun), inspect the observability database and Slipway
+logs, and confirm the maintenance Quest job is running. Increasing retention
+does not fix a maintenance job that has stopped.
+
+## What's next?
+
+- Use [Helm](/slipway/helm) for Sails-aware application diagnosis.
+- Use [Dock](/slipway/dock) for direct database and cache inspection.
+- Use [Quest](/slipway/quest) for job operations and run history.

--- a/docs/slipway/quest.md
+++ b/docs/slipway/quest.md
@@ -5,7 +5,7 @@ head:
       content: https://docs.sailscasts.com/slipway-social.png
 title: Quest
 titleTemplate: Slipway
-description: Manage scheduled jobs in your Sails applications. View, run, pause, and resume jobs from the Slipway dashboard.
+description: Operate sails-hook-quest jobs from Slipway, including live state, manual runs, pause and resume controls, and bounded run history.
 prev:
   text: Content
   link: /slipway/content
@@ -17,142 +17,78 @@ editLink: true
 
 # Quest
 
-Quest is a **job scheduler dashboard** for your [sails-hook-quest](https://docs.sailscasts.com/sails-quest) powered applications. View scheduled jobs, trigger manual runs, and control job execution—all from the Slipway dashboard.
+Quest is Slipway's operational view of the jobs defined by
+[sails-hook-quest](https://docs.sailscasts.com/sails-quest). The job definition
+stays in the application repository; Slipway discovers it from the deployed
+application and provides live status, manual execution, pause and resume
+controls, and recent run history.
 
-## What is Quest?
+Use the `sails-hook-quest` documentation to design schedules and job code. Use
+this page to understand how Slipway operates those jobs after deployment.
 
-Quest provides a web-based interface for managing your scheduled jobs:
+## How the pieces connect
 
-- **View all jobs** - See every scheduled job with its schedule and status
-- **Run jobs manually** - Trigger immediate execution of any job
-- **Pause/Resume** - Control which jobs are running
-- **Monitor status** - See if jobs are currently executing
+```text
+scripts/*.js + quest config
+          │
+          ▼
+  deployed Sails app ── runtime state ──► Quest dashboard
+          │                                  │
+          └── job telemetry ────────────────► run history
+```
 
-No SSH access needed—manage your background jobs from the dashboard.
+Slipway does not copy the scheduler into its own process. It loads the target
+application in its running container to read `sails.quest`, and it executes a
+manual run with the application's normal `sails run <job>` command. Models,
+helpers, environment variables, and datastore connections are therefore the
+ones belonging to that deployment.
 
 ## Requirements
 
-Quest is available when your app uses [sails-hook-quest](https://docs.sailscasts.com/sails-quest):
+Install the hook in the target Sails application:
 
 ```bash
 npm install sails-hook-quest
 ```
 
-Slipway automatically detects `sails-hook-quest` during deployment and enables the Quest feature.
+Then deploy the application. Feature detection happens from the deployed
+source, so adding the dependency without deploying it does not enable Quest in
+an existing environment.
 
-## Accessing Quest
+For run history, also install `sails-hook-slipway`. Slipway injects its
+telemetry URL and token during deployment, and the hook reports Quest lifecycle
+events when `captureQuestEvents` is enabled. Manual runs triggered from the
+dashboard are recorded by Slipway even when no scheduled event has arrived yet.
 
-### Via Dashboard
+## Open Quest
 
-1. Go to your project in Slipway
-2. Select an environment and click the app name from the Apps list
-3. Click the ellipsis dropdown menu and select **Quest**
-4. View and manage your jobs
+Choose **Quest** from the application actions in the selected environment.
+Production uses:
 
-### Via Direct URL
-
-```
-https://your-slipway-instance.com/projects/myapp/quest
-```
-
-Or with a specific environment:
-
-```
-https://your-slipway-instance.com/projects/myapp/environments/staging/quest
+```text
+/projects/:projectSlug/quest
 ```
 
-## Job Dashboard
+Other environments include the environment slug:
 
-The Quest dashboard shows all scheduled jobs:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│ Quest                                      sails-hook-quest     │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│ cleanup-sessions                           Active    no overlap │
-│ Remove expired sessions from the database                       │
-│ ⏱ every 1 hour                                                  │
-│                                        [Run now]  [Pause]       │
-│                                                                 │
-│ send-newsletter                            Paused               │
-│ Send weekly newsletter to subscribers                           │
-│ ⏱ cron: 0 9 * * MON                                             │
-│                                        [Run now]  [Resume]      │
-│                                                                 │
-│ process-uploads                            Running              │
-│ Process pending file uploads                                    │
-│ ⏱ every 2 minutes                                               │
-│                                        [Running...]             │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
+```text
+/projects/:projectSlug/environments/:environmentSlug/quest
 ```
 
-### Job Information
+The target application must be running. When it is stopped, still deploying,
+or missing `sails-hook-quest`, the page explains which prerequisite is absent
+instead of presenting stale controls.
 
-Each job displays:
+## Define a job
 
-| Field           | Description                                  |
-| --------------- | -------------------------------------------- |
-| **Name**        | The job's friendly name or script name       |
-| **Description** | What the job does                            |
-| **Schedule**    | Cron expression or interval                  |
-| **Status**      | Active, Paused, or Running                   |
-| **No overlap**  | Badge shown if concurrent runs are prevented |
-
-### Job Status
-
-| Status      | Description                                              |
-| ----------- | -------------------------------------------------------- |
-| **Active**  | Job is scheduled and will run at its next scheduled time |
-| **Paused**  | Job won't run until resumed                              |
-| **Running** | Job is currently executing                               |
-
-## Actions
-
-### Run Now
-
-Trigger immediate execution of a job:
-
-1. Click **Run now** on any job
-2. The job starts executing in your app
-3. Status updates to "Running" while executing
-
-::: tip
-Running a job manually doesn't affect its regular schedule. The job will still run at its next scheduled time.
-:::
-
-### Pause
-
-Stop a job from running on schedule:
-
-1. Click **Pause** on an active job
-2. Status changes to "Paused"
-3. Job won't run until resumed
-
-Pausing is useful for:
-
-- Temporarily stopping resource-intensive jobs
-- Debugging job-related issues
-- Maintenance windows
-
-### Resume
-
-Re-enable a paused job:
-
-1. Click **Resume** on a paused job
-2. Status changes to "Active"
-3. Job resumes normal scheduling
-
-## Creating Jobs
-
-Jobs are defined in your Sails app's `scripts/` directory with a `quest` property:
+Jobs live in the application's `scripts/` directory. A normal Sails script
+becomes scheduled when it includes a `quest` definition:
 
 ```javascript
 // scripts/cleanup-sessions.js
 module.exports = {
-  friendlyName: 'Cleanup old sessions',
-  description: 'Remove expired sessions from the database',
+  friendlyName: 'Clean up sessions',
+  description: 'Remove sessions that have expired.',
 
   quest: {
     interval: '1 hour',
@@ -160,211 +96,156 @@ module.exports = {
   },
 
   fn: async function () {
-    const deleted = await Session.destroy({
-      lastActive: {
-        '<': new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-      }
+    const expiredBefore = Date.now() - 30 * 24 * 60 * 60 * 1000
+    const removed = await Session.destroy({
+      lastActiveAt: { '<': expiredBefore }
     }).fetch()
 
-    sails.log.info(`Cleaned up ${deleted.length} sessions`)
-    return { deletedCount: deleted.length }
+    sails.log.info(`Removed ${removed.length} expired sessions.`)
+    return { removed: removed.length }
   }
 }
 ```
 
-### Schedule Options
-
-#### Intervals (Human-Readable)
+Common schedule forms are:
 
 ```javascript
 quest: {
-  interval: '30 seconds'
   interval: '5 minutes'
-  interval: '2 hours'
-  interval: '7 days'
 }
-```
-
-#### Cron Expressions
-
-```javascript
 quest: {
-  cron: '0 2 * * *' // Daily at 2 AM
-  cron: '*/5 * * * *' // Every 5 minutes
-  cron: '0 9 * * MON' // Every Monday at 9 AM
+  cron: '0 2 * * *'
 }
-```
-
-#### One-Time Execution
-
-```javascript
 quest: {
-  timeout: '10 minutes' // Run once after 10 minutes
+  timeout: '10 minutes'
 }
 ```
 
-### Overlap Prevention
+The configured Quest timezone controls cron interpretation. Schedule parsing,
+overlap locks, retries, and startup behavior belong to `sails-hook-quest`; the
+Slipway dashboard reports the resulting runtime state without redefining those
+rules.
 
-Prevent concurrent runs of the same job:
+Scripts without a `quest` definition can still appear as manual jobs when they
+were detected in the deployment. Their schedule is shown as `manual`.
 
-```javascript
-quest: {
-  interval: '5 minutes',
-  withoutOverlapping: true  // Skip if already running
-}
-```
+## Read the dashboard
 
-## API Endpoints
+The page combines configuration, live runtime state, and recent telemetry.
 
-Quest provides REST API endpoints for programmatic control:
+| Information                        | Source                         | Meaning                                                      |
+| ---------------------------------- | ------------------------------ | ------------------------------------------------------------ |
+| Name and description               | `scripts/*.js`                 | The script identity and its human-facing metadata            |
+| Schedule and no-overlap state      | `script.quest`                 | The configured cron, interval, timeout, and overlap behavior |
+| Paused or running                  | `sails.quest` in the container | Current state of this running deployment                     |
+| Next and last run                  | Quest runtime                  | Scheduler timestamps when the hook exposes them              |
+| Success, failure, duration, output | telemetry                      | Recent completed runs retained by Slipway                    |
 
-### List Jobs
+The summary cards show completed and failed runs from the last 24 hours. An
+expanded job shows up to 20 of its most recent completed or failed runs from
+the loaded history. Slipway queries at most 500 Quest telemetry records from the
+last seven days for the environment.
 
-```bash
-GET /api/v1/projects/:projectSlug/quest/jobs
-```
+### Live refresh
 
-Response:
+The **Live** indicator means the browser has an authenticated Server-Sent
+Events connection to Slipway. Slipway sends an initial snapshot and refreshes
+the target application's job state and history every 30 seconds. The stream is
+scoped to the signed-in user's team, project, and environment.
 
-```json
-{
-  "jobs": [
-    {
-      "name": "cleanup-sessions",
-      "friendlyName": "Cleanup old sessions",
-      "description": "Remove expired sessions",
-      "schedule": "1 hour",
-      "scheduleType": "interval",
-      "paused": false,
-      "withoutOverlapping": true,
-      "isRunning": false
-    }
-  ]
-}
-```
+If the stream disconnects, the page keeps the last snapshot visible and marks
+it offline. Reconnect or use **Try again** after fixing a container or
+introspection error.
 
-### Run a Job
+When runtime introspection fails, Slipway can fall back to the scripts detected
+during deployment. Those fallback rows are intentionally conservative: they
+show the script as manual and do not pretend to know live paused or running
+state.
 
-```bash
+## Run a job now
+
+Choose **Run now** to execute the script immediately in the running app
+container. Slipway:
+
+1. resolves the current project, environment, application, and container;
+2. runs `npx sails run <job-name>` inside that container;
+3. waits for the process to exit, with a five-minute execution timeout;
+4. strips terminal color codes from captured output;
+5. returns stdout, stderr, exit code, and success state; and
+6. records a manual Quest telemetry event for history.
+
+The output panel belongs to that manual run. Closing it does not delete the
+telemetry record. A manual run also does not change the configured schedule.
+
+::: warning A manual run is real application work
+The script has the same models, helpers, credentials, and side effects it has
+when Quest runs it on schedule. There is no dry-run sandbox. Make destructive
+jobs idempotent and use `withoutOverlapping` where concurrent work would be
+unsafe.
+:::
+
+### Inputs and automation
+
+The dashboard currently runs the job without an input form. An authenticated
+client can call the run endpoint and pass `jobInputs`; each key becomes a Sails
+script argument such as `--daysOld=7`:
+
+```http
 POST /api/v1/projects/:projectSlug/quest/jobs/:name/run
-```
+Content-Type: application/json
 
-Optional body:
-
-```json
 {
-  "inputs": {
-    "daysOld": 7
+  "jobInputs": {
+    "daysOld": 7,
+    "dryRun": true
   }
 }
 ```
 
-### Pause a Job
+For a non-production environment, use:
 
-```bash
-POST /api/v1/projects/:projectSlug/quest/jobs/:name/pause
+```text
+/api/v1/projects/:projectSlug/environments/:environmentSlug/quest/jobs/:name/run
 ```
 
-### Resume a Job
+This endpoint uses the same Slipway session and team authorization as the
+dashboard. It is not an unauthenticated webhook or a substitute for a queue.
 
-```bash
-POST /api/v1/projects/:projectSlug/quest/jobs/:name/resume
-```
+## Pause and resume
 
-## Job Examples
+**Pause** and **Resume** call `sails.quest.pause(name)` and
+`sails.quest.resume(name)` against the selected running deployment. They change
+the scheduler state exposed by that application; they do not edit the script or
+commit configuration to Git.
 
-### Database Cleanup
+Treat pausing as an operational control for maintenance or diagnosis. A
+container replacement, restart, or redeployment can rebuild scheduler state
+from the application's committed Quest configuration. If a job must stay
+disabled across releases, change its application configuration and deploy that
+change.
 
-```javascript
-// scripts/cleanup-old-data.js
-module.exports = {
-  friendlyName: 'Cleanup old data',
-  description: 'Remove records older than 90 days',
+Pause and resume are dashboard form actions, not the `/api/v1/.../jobs` REST
+endpoints previously described by these docs.
 
-  quest: {
-    cron: '0 3 * * *', // Daily at 3 AM
-    withoutOverlapping: true
-  },
+## History and retention
 
-  fn: async function () {
-    const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
+Quest history is application telemetry, not a second job database. A history
+entry can contain:
 
-    await AuditLog.destroy({ createdAt: { '<': cutoff } })
-    await TempFile.destroy({ createdAt: { '<': cutoff } })
+- job name and lifecycle event;
+- manual or scheduled trigger;
+- duration and recorded time;
+- bounded stdout and stderr from a manual run; and
+- a bounded error message for failed work.
 
-    sails.log.info('Old data cleanup complete')
-  }
-}
-```
+Application telemetry is retained for seven days by default and pruned by
+Lookout maintenance. See [Lookout](/slipway/lookout) for the retention controls
+and collector health. Container logs remain useful when a failure occurred
+outside the captured run envelope.
 
-### Email Digest
+## Production job design
 
-```javascript
-// scripts/send-daily-digest.js
-module.exports = {
-  friendlyName: 'Send daily digest',
-  description: 'Send summary email to active users',
-
-  quest: {
-    cron: '0 8 * * *', // Daily at 8 AM
-    withoutOverlapping: true
-  },
-
-  fn: async function () {
-    const users = await User.find({
-      digestEnabled: true,
-      emailVerified: true
-    })
-
-    for (const user of users) {
-      await sails.helpers.mail.sendDigest(user)
-    }
-
-    return { sent: users.length }
-  }
-}
-```
-
-### Queue Processing
-
-```javascript
-// scripts/process-queue.js
-module.exports = {
-  friendlyName: 'Process job queue',
-  description: 'Process pending background jobs',
-
-  quest: {
-    interval: '30 seconds',
-    withoutOverlapping: true
-  },
-
-  fn: async function () {
-    const pending = await Job.find({
-      status: 'pending'
-    }).limit(10)
-
-    for (const job of pending) {
-      try {
-        await sails.helpers.jobs.process(job)
-        await Job.updateOne({ id: job.id }).set({ status: 'completed' })
-      } catch (err) {
-        await Job.updateOne({ id: job.id }).set({
-          status: 'failed',
-          error: err.message
-        })
-      }
-    }
-
-    return { processed: pending.length }
-  }
-}
-```
-
-## Best Practices
-
-### 1. Always Use `withoutOverlapping`
-
-For jobs that shouldn't run concurrently:
+### Prevent overlap intentionally
 
 ```javascript
 quest: {
@@ -373,90 +254,66 @@ quest: {
 }
 ```
 
-### 2. Keep Jobs Idempotent
+Use overlap protection when a second run could charge twice, send duplicate
+mail, process the same queue item, or compete for the same external resource.
 
-Jobs should be safe to run multiple times:
+### Make work idempotent
 
-```javascript
-// Good - checks before acting
-const unprocessed = await Order.find({ processed: false })
-for (const order of unprocessed) {
-  await processOrder(order)
-  await Order.updateOne({ id: order.id }).set({ processed: true })
-}
+Select a bounded set of pending records, claim or mark them atomically, and make
+retries safe. A process can stop after performing an external side effect but
+before updating the database.
 
-// Bad - might double-process
-const orders = await Order.find()
-for (const order of orders) {
-  await processOrder(order) // Might run twice!
-}
-```
+### Bound each run
 
-### 3. Add Logging
+Use query limits, batches, and checkpoints. The dashboard's five-minute wait
+for a manual invocation is not a replacement for application-level timeouts on
+HTTP calls or database operations.
 
-Log job progress for debugging:
+### Return and log useful summaries
 
-```javascript
-fn: async function () {
-  sails.log.info('Starting cleanup job')
-
-  const count = await Record.destroy({ old: true }).fetch()
-
-  sails.log.info(`Cleanup complete: ${count.length} records removed`)
-  return { removed: count.length }
-}
-```
-
-### 4. Handle Errors Gracefully
-
-Jobs should catch and log errors:
-
-```javascript
-fn: async function () {
-  try {
-    await riskyOperation()
-  } catch (err) {
-    sails.log.error('Job failed:', err)
-    // Optionally notify admins
-    await sails.helpers.mail.sendAlert({
-      subject: 'Job failed: cleanup',
-      error: err.message
-    })
-    throw err // Re-throw to mark job as failed
-  }
-}
-```
+Return counts or identifiers that help an operator understand the run, and log
+progress without emitting secrets or whole customer records.
 
 ## Troubleshooting
 
-### Jobs Not Appearing
+### Quest is unavailable
 
-If jobs don't show in the dashboard:
+1. Confirm `sails-hook-quest` is in the deployed application's dependencies.
+2. Deploy the revision that added it.
+3. Confirm you opened the correct app and environment.
+4. Confirm the application is running.
 
-1. Verify `sails-hook-quest` is in `package.json`
-2. Deploy your app (detection happens during deployment)
-3. Ensure the app is running
-4. Check that scripts have a `quest` property
+### A job is missing or shown as manual
 
-### Jobs Not Running
+Confirm the script is a top-level `.js` file in `scripts/` and can be required
+without throwing. Then inspect the app logs for errors while loading the script
+or `sails.quest`. A manual fallback row means deployment detection found the
+script but Slipway could not confirm its live schedule.
 
-If scheduled jobs aren't executing:
+### Live state is stale
 
-1. Check if the job is paused
-2. Verify the schedule syntax
-3. Check container logs for errors
-4. Ensure `autoStart: true` in quest config
+Check the **Live** indicator. If it is offline, reload after confirming that the
+Slipway instance and target container are reachable. A connected stream still
+refreshes full job state every 30 seconds, so a scheduler transition is not
+instantaneous in the browser.
 
-### Manual Run Fails
+### A manual run fails
 
-If "Run now" fails:
+Expand its output first. Then inspect the target app's logs and run the same
+script locally with `npx sails run <job-name>`. Verify required inputs and
+environment variables, and remember that Slipway stops waiting after five
+minutes.
 
-1. Check the app is running
-2. Look at container logs for errors
-3. Verify the script exists and has no syntax errors
+### History is empty
 
-## What's Next?
+Install `sails-hook-slipway`, redeploy so telemetry credentials are injected,
+and confirm `captureQuestEvents` is enabled. Scheduled history appears after a
+job emits its first lifecycle event; manual runs from Slipway are recorded
+directly.
 
-- Learn about [sails-hook-quest](https://docs.sailscasts.com/sails-quest) for setting up jobs
-- Use [Helm](/slipway/helm) for debugging
-- Set up [Auto-Deploy](/slipway/auto-deploy) for continuous deployment
+## What's next?
+
+- Configure job behavior with
+  [sails-hook-quest](https://docs.sailscasts.com/sails-quest).
+- Use [Lookout](/slipway/lookout) to inspect telemetry health and retention.
+- Use [Helm](/slipway/helm) for bounded application-aware diagnosis.


### PR DESCRIPTION
## Summary

- rewrite Quest, Dock, Lookout, and Bosun around their real runtime behavior
- expand Bridge with a complete dashboard and card contract
- document Content source, Git, frontmatter, upload, validation, and deployment boundaries
- add Helm surface-selection guidance and one exact execution/storage limits reference
- remove stale endpoints and unsafe or unsupported claims across all seven Platform guides

## Verification

- `npx prettier --write docs/slipway/helm.md docs/slipway/bridge.md docs/slipway/content.md docs/slipway/quest.md docs/slipway/dock.md docs/slipway/lookout.md docs/slipway/bosun.md`
- `npm run build`
- `git diff --check`

Closes #132