### PR TITLE
docs(durable-ui): document Scan CLI

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -820,6 +820,23 @@ function durableUiGuide() {
       ]
     },
     {
+      text: 'Scan',
+      collapsed: false,
+      items: [
+        { text: 'Overview', link: '/durable-ui/scan' },
+        { text: 'Checks', link: '/durable-ui/scan/checks' },
+        {
+          text: 'CLI Reference',
+          link: '/durable-ui/scan/cli-reference'
+        },
+        {
+          text: 'Output and JSON',
+          link: '/durable-ui/scan/output'
+        },
+        { text: 'CI and Limitations', link: '/durable-ui/scan/ci' }
+      ]
+    },
+    {
       text: 'Progress',
       collapsed: false,
       items: [

--- a/docs/.vitepress/data/projects.data.js
+++ b/docs/.vitepress/data/projects.data.js
@@ -27,7 +27,7 @@ export default {
         {
           name: 'Durable UI',
           description:
-            'State-placement utilities for progress drafts, shareable URL state, and cleanup rules that survive real users.',
+            'State-placement utilities and a CLI scanner for finding UI contracts that break under refresh, Back, sign-in, and remounts.',
           link: '/durable-ui/',
           github: 'https://github.com/sailscastshq/durable-ui',
           popular: true

--- a/docs/durable-ui/getting-started.md
+++ b/docs/durable-ui/getting-started.md
@@ -7,6 +7,18 @@ description: Start using Durable UI progress and URL primitives with Vue composa
 
 Durable UI organizes client state by durability category. Use Progress when private work should survive refreshes until the user submits. Use URL when the view itself should be shareable and bookmarkable.
 
+## Scan An Existing Project
+
+You can inspect a JavaScript or TypeScript web application without installing anything into it. From the project root, run:
+
+```sh
+npx durable-ui scan .
+```
+
+Scan reports source evidence, user impact, a browser test, and a recommended direction for every match. It does not change your files or fail the command because it found something. Read the [Scan overview](/durable-ui/scan) before automating it in CI.
+
+## Install The Runtime Primitives
+
 Install the package for the app you are building.
 
 ::: code-group

--- a/docs/durable-ui/index.md
+++ b/docs/durable-ui/index.md
@@ -2,19 +2,22 @@
 layout: home
 title: Durable UI
 titleTemplate: State placement for UI that survives real users
-description: Durable UI helps you place UI state where it belongs so interfaces survive refreshes, navigation, browser restarts, shared links, and failed submits.
+description: Durable UI helps you find fragile browser contracts and place UI state where it belongs so interfaces survive refreshes, navigation, browser restarts, shared links, and failed submits.
 hero:
   name: Durable UI
   text: State placement for UI that survives real users.
   tagline: Decide what survives refreshes, what becomes shareable, what belongs on the server, and when stale state should disappear.
   actions:
     - theme: brand
-      text: Get Started
-      link: /durable-ui/getting-started
+      text: Scan a Project
+      link: /durable-ui/scan
     - theme: alt
       text: Watch the Durable UI Course
       link: https://sailscasts.com/courses/durable-ui
 features:
+  - icon: 🔎
+    title: Scan before users find it
+    details: Run one zero-config command to surface fragile progress, navigation, dialog, storage, lifecycle, and request contracts.
   - icon: 🧭
     title: State placement
     details: Decide whether state belongs in local progress, the URL, or the server.
@@ -30,7 +33,4 @@ features:
   - icon: ⚛️
     title: Vue and React first
     details: Vue gets composables. React gets hooks. Both follow the conventions developers expect in each ecosystem.
-  - icon: 🟨
-    title: Plain JavaScript
-    details: Durable UI ships JavaScript with JSDoc for editor hints. No TypeScript source, no build step, no generated dist.
 ---

--- a/docs/durable-ui/scan.md
+++ b/docs/durable-ui/scan.md
@@ -1,0 +1,70 @@
+---
+title: Scan
+description: Run Durable UI Scan against a modern web application and turn static findings into reproducible browser tests.
+---
+
+# Durable UI Scan
+
+Durable UI Scan is a zero-configuration CLI for finding browser and state contracts that may break under refresh, Back and Forward navigation, sign-in interruptions, remounts, slow requests, or unavailable browser storage.
+
+Run it from the root of an existing application:
+
+```sh
+npx durable-ui scan .
+```
+
+It reads source files and prints possible risks with a file location, the user impact, a browser test, and a recommended implementation direction. It never edits the scanned project.
+
+::: tip Requirements
+Version `0.0.1` requires Node.js 20 or newer. `npx` downloads the published `durable-ui` package for the command; no permanent dependency is required.
+:::
+
+## Where It Works Best
+
+Scan is designed for client-facing JavaScript and TypeScript codebases, especially:
+
+- React, Vue, and Svelte applications
+- Inertia applications backed by Sails or another server framework
+- Next.js and Nuxt applications
+- applications with substantial forms, multi-step workflows, filters, dialogs, client storage, or live search
+
+It scans `.astro`, `.cjs`, `.ejs`, `.html`, `.js`, `.jsx`, `.mjs`, `.svelte`, `.ts`, `.tsx`, and `.vue` source files. React, Vue, Svelte, Inertia, Next.js, Nuxt, and Sails are named in the report when detected from `package.json` or source extensions. Other applications using the supported file types can still be scanned.
+
+## Choose The Target
+
+The target may be a project, a source directory, or one file:
+
+```sh
+# Current project
+npx durable-ui scan .
+
+# Client source only
+npx durable-ui scan ./resources/js
+
+# One component
+npx durable-ui scan ./src/pages/Checkout.vue
+```
+
+The `scan` word is optional, so `npx durable-ui ./resources/js` is equivalent. Keeping it makes the command easier to read and leaves room for future Durable UI commands.
+
+## Read A Finding
+
+Every finding answers four questions:
+
+1. Where did Scan see the signal?
+2. What can the user lose or misunderstand?
+3. How can you reproduce the contract in a browser?
+4. What implementation direction should you consider?
+
+`HIGH` and `MEDIUM` indicate stronger static signals. `REVIEW` means the correct behavior depends on the product contract—for example, whether a substantial dialog should survive refresh. These labels prioritize review; they are not quality scores or proof of a bug.
+
+Scan also prints durable signals already present, such as URL-backed state, restorable drafts, guarded storage, keyboard-aware dialogs, and cancelable requests.
+
+## Next Steps
+
+- Learn exactly what is detected in [Checks](/durable-ui/scan/checks).
+- See every option in the [CLI reference](/durable-ui/scan/cli-reference).
+- Integrate the stable report shape from [Output and JSON](/durable-ui/scan/output).
+- Understand the exit codes and static-analysis boundaries in [CI and Limitations](/durable-ui/scan/ci).
+
+For the state-placement framework behind the checks, watch the [Durable UI course](https://sailscasts.com/courses/durable-ui).

--- a/docs/durable-ui/scan/checks.md
+++ b/docs/durable-ui/scan/checks.md
@@ -1,0 +1,98 @@
+---
+title: Scan Checks
+description: The complete set of durability checks included in Durable UI Scan 0.0.1 and how to verify each finding.
+---
+
+# Scan Checks
+
+Version `0.0.1` runs eight source rules. Dialog inspection can produce two separate findings, so a report may contain nine finding types. Checks are intentionally conservative and should lead to a browser reproduction before a code change.
+
+## Progress Without A Draft
+
+`progress-without-draft` looks for a form with at least three visible or registered fields, or a multi-step signal such as `currentStep`, without a visible draft strategy.
+
+- `HIGH` for a likely multi-step workflow
+- `MEDIUM` for another substantial form
+- Verify by entering data, advancing if applicable, then refreshing and using Back and Forward.
+
+Visible uses of Durable UI draft primitives, browser storage, or common save, persist, restore, and autosave names suppress this check. A custom server autosave may not be recognizable.
+
+## View State Outside The URL
+
+`view-state-outside-url` looks for React, Vue, or Svelte state with common names such as `activeTab`, `filter`, `sort`, `page`, `query`, or `searchTerm` when no URL-state signal is visible.
+
+- `MEDIUM`
+- Verify by changing the view, copying the URL into a new tab, and using Back and Forward.
+
+This is intended for navigational state. Private edits and brief interaction state usually should not go in the URL.
+
+## Navigation Rendered As A Button
+
+`navigation-rendered-as-button` looks for a `<button>` click handler that changes destinations through a router, `navigate`, SvelteKit `goto`, or `location`.
+
+- `HIGH`
+- Verify open-in-new-tab, copy-link, keyboard activation, and Back behavior.
+
+Destination changes should normally be anchors or framework Link components. Buttons remain correct for actions on the current page.
+
+## Auth Redirect Loses Intent
+
+`auth-redirect-loses-intent` looks for navigation to a sign-in or login route without a visible return destination in the same redirect expression.
+
+- `HIGH`
+- Verify by starting at a protected deep link, signing in, and checking that the exact destination is restored.
+
+Return destinations must also be validated by the application to avoid open redirects.
+
+## Incomplete Dialog Contract
+
+`incomplete-dialog-contract` looks for a custom dialog without visible Escape dismissal or focus-entry and focus-return behavior. Native `<dialog>` elements and recognized dialog libraries are treated differently from hand-built dialog markup.
+
+- `HIGH`
+- Verify opening, dismissing, and restoring focus using only the keyboard.
+
+## Dialog State Outside The URL
+
+`dialog-state-outside-url` looks for common in-memory open-state names inside a dialog implementation when no URL state is visible.
+
+- `REVIEW`
+- Verify refresh, Back, and Forward while the dialog is open on a specific record.
+
+A brief confirmation should usually disappear. A substantial create, edit, or inspect workflow may need its open state and record identity in the URL.
+
+## Unguarded Browser Storage
+
+`unguarded-browser-storage` looks for direct `localStorage` or `sessionStorage` operations without a visible `try` and `catch` boundary.
+
+- `HIGH`
+- Verify with storage blocked and with malformed or stale stored data.
+
+Storage access, quota, and JSON parsing can fail. The screen should remain usable and have a recovery path.
+
+## Lifecycle Cleanup
+
+`event-listener-without-cleanup` looks for `addEventListener` without a visible `removeEventListener`. `interval-without-cleanup` looks for `setInterval` without a visible `clearInterval`.
+
+- `MEDIUM`
+- Verify by navigating away and back repeatedly, then confirming the handler or timer acts only once and stops after unmount.
+
+## Debounced Request Without Cancellation
+
+`debounced-request-without-cancellation` looks for a debounced or delayed request without a visible `AbortController`, signal, or cancellation token.
+
+- `MEDIUM`
+- Verify by delaying an older response, issuing a newer query, and navigating away while a request is active.
+
+The latest request should win, and a superseded response should not update a stale screen.
+
+## Positive Signals
+
+The report can also recognize and count files with:
+
+- restorable form progress through `useFormDraft` or `useWizardDraft`
+- URL-backed view state
+- guarded browser storage
+- native or Escape-aware dialogs
+- cancelable browser requests
+
+Positive signals are evidence of useful patterns, not a guarantee that every browser path is durable.

--- a/docs/durable-ui/scan/ci.md
+++ b/docs/durable-ui/scan/ci.md
@@ -1,0 +1,71 @@
+---
+title: Scan In CI And Its Limitations
+description: Automate Durable UI Scan safely and understand what the static scanner can and cannot conclude.
+---
+
+# Scan In CI And Its Limitations
+
+## Exit Codes In 0.0.1
+
+Durable UI Scan is advisory in its first release:
+
+- exit `0` when a scan completes, even when findings exist
+- exit `1` for invalid arguments, missing paths, unreadable input, or another failure to run
+
+This means you can add the command to CI to preserve a report without unexpectedly blocking a deployment. A finding is a prompt to reproduce a browser contract, not a build failure.
+
+## Save A CI Artifact
+
+Run the scanner from the checked-out project and store JSON as an artifact with the CI provider of your choice:
+
+```sh
+npx durable-ui scan . --json > durable-ui-report.json
+```
+
+For a repository containing generated or non-JavaScript environments, add directory names explicitly:
+
+```sh
+npx durable-ui scan . --ignore .venv,generated --json > durable-ui-report.json
+```
+
+Pin the package when repeatability matters:
+
+```sh
+npx durable-ui@0.0.1 scan . --json > durable-ui-report.json
+```
+
+Because the command exits `0` for findings, any custom threshold must be implemented by the consuming CI step. Treat `schemaVersion` as the compatibility boundary when parsing the report.
+
+## What Static Analysis Cannot Know
+
+Scan reads source text; it does not compile the application, execute framework code, inspect the DOM, or drive a browser. It cannot reliably determine:
+
+- whether a custom helper persists or restores state at runtime
+- whether server autosave protects a form
+- whether a dialog is intentionally ephemeral
+- whether a return destination is validated by the server
+- whether cleanup is hidden behind a framework abstraction
+- whether request ordering is enforced outside the matched file
+- whether the final experience feels correct to a keyboard, touch, or assistive-technology user
+
+The scanner favors explainable source evidence over broad guesses, so it will have both false positives and false negatives. Rename-heavy abstractions and generated code can reduce what it recognizes.
+
+## Operational Limits
+
+- Directory scans collect at most 10,000 source files by default. Change the bound with `--max-files`.
+- Supported source files larger than 1 MiB are listed in `filesSkipped` and not inspected.
+- Default ignored directories, test files, and symbolic links are not inspected.
+- The scanner reads files as UTF-8.
+- Framework detection is informational and depends on `package.json` dependencies or framework-specific source extensions.
+
+## The Verification Loop
+
+For every material finding:
+
+1. Open the referenced screen in the real application.
+2. Follow the report's browser test.
+3. Decide the intended product contract.
+4. Change the implementation only when observed behavior violates that contract.
+5. Repeat the test with refresh, Back and Forward, remounting, sign-in interruption, slow responses, or unavailable storage as relevant.
+
+The [Durable UI course](https://sailscasts.com/courses/durable-ui) teaches the decision framework behind this loop.

--- a/docs/durable-ui/scan/cli-reference.md
+++ b/docs/durable-ui/scan/cli-reference.md
@@ -1,0 +1,77 @@
+---
+title: Scan CLI Reference
+description: Every command, argument, and flag supported by Durable UI Scan 0.0.1.
+---
+
+# Scan CLI Reference
+
+## Usage
+
+```text
+durable-ui scan [path] [options]
+durable-ui [path] [options]
+```
+
+With `npx`:
+
+```sh
+npx durable-ui scan [path] [options]
+```
+
+`path` defaults to the current working directory. It may resolve to a directory or one file. Only one target is accepted.
+
+## Options
+
+| Option                    | Description                                                                                   | Default      |
+| ------------------------- | --------------------------------------------------------------------------------------------- | ------------ |
+| `--json`                  | Print machine-readable JSON. Alias for `--format json`.                                       | Off          |
+| `--format <pretty\|json>` | Select human-readable or JSON output. `--format=value` is also accepted.                      | `pretty`     |
+| `--ignore <names>`        | Add comma-separated directory names to ignore. Repeatable; `--ignore=value` is accepted.      | None added   |
+| `--max-files <number>`    | Stop collecting source files after a positive integer limit. `--max-files=value` is accepted. | `10000`      |
+| `--no-course`             | Hide the course invitation at the end of pretty output.                                       | Course shown |
+| `-h`, `--help`            | Print help and exit.                                                                          | —            |
+| `-v`, `--version`         | Print the installed scanner version and exit.                                                 | —            |
+
+## Examples
+
+```sh
+# Scan the current project
+npx durable-ui scan .
+
+# Scan only browser code
+npx durable-ui scan ./resources/js
+
+# Add generated directories to the ignore set
+npx durable-ui scan . --ignore .venv,generated
+
+# Bound a quick exploratory scan
+npx durable-ui scan . --max-files 2000
+
+# Produce clean JSON without promotional copy
+npx durable-ui scan . --json > durable-ui-report.json
+
+# Keep pretty output but omit the course invitation
+npx durable-ui scan . --no-course
+```
+
+## Built-In Directory Ignores
+
+Directory traversal ignores these names by default:
+
+```text
+.git, .next, .nuxt, .output, .svelte-kit, .turbo, .vite,
+build, coverage, dist, fixtures, node_modules, out, public,
+storybook-static, test, tests, __tests__, vendor
+```
+
+`--ignore` adds exact directory names to this set; it does not accept glob patterns. Hidden directories are scanned unless their exact name is ignored. Symbolic links and files named like `*.spec.*` or `*.test.*` are skipped.
+
+## Environment Behavior
+
+Pretty output uses color when stdout is a terminal. Set the conventional `NO_COLOR` environment variable to disable color:
+
+```sh
+NO_COLOR=1 npx durable-ui scan .
+```
+
+JSON output contains no ANSI color or course copy, so it can be parsed directly.

--- a/docs/durable-ui/scan/output.md
+++ b/docs/durable-ui/scan/output.md
@@ -1,0 +1,87 @@
+---
+title: Scan Output And JSON
+description: Understand Durable UI Scan's terminal report, JSON schema, severities, and machine-readable fields.
+---
+
+# Scan Output And JSON
+
+## Pretty Output
+
+The default report starts with the project name, number of files scanned, detected frameworks, and elapsed time. Findings are ordered by severity, then file and line.
+
+Each finding includes:
+
+- `HIGH`, `MEDIUM`, or `REVIEW` severity
+- title and source location
+- one line of source evidence when available
+- user impact
+- a browser test
+- a recommended direction
+
+When patterns are recognized, a final section counts durable signals already present. The course invitation can be hidden with `--no-course`.
+
+## JSON Output
+
+Use `--json` or `--format json`:
+
+```sh
+npx durable-ui scan . --json
+```
+
+Version `0.0.1` returns this top-level shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "scannerVersion": "0.0.1",
+  "root": "/absolute/path/to/project",
+  "frameworks": ["Vue", "Inertia", "Sails"],
+  "filesScanned": 177,
+  "filesSkipped": [],
+  "elapsedMs": 38,
+  "summary": {
+    "total": 6,
+    "high": 1,
+    "medium": 5,
+    "review": 0
+  },
+  "positiveSignals": [
+    {
+      "id": "url-state",
+      "title": "URL-backed view state",
+      "files": 12
+    }
+  ],
+  "findings": [
+    {
+      "id": "navigation-rendered-as-button",
+      "category": "Navigation",
+      "severity": "high",
+      "title": "Navigation is rendered as a button",
+      "why": "Users lose link previews, open-in-new-tab, copy-link, keyboard, and browser navigation behavior.",
+      "test": "Try to copy or open the destination in a new tab with the mouse and keyboard, then use Back; verify it behaves like a normal link.",
+      "fix": "Render destination changes as an anchor or framework Link. Keep buttons for actions on the current page.",
+      "file": "resources/js/pages/example.vue",
+      "line": 42,
+      "column": 7,
+      "evidence": "<button @click=\"router.push('/settings')\">Settings</button>"
+    }
+  ]
+}
+```
+
+The example values illustrate the contract; the report for your project will differ.
+
+## Field Notes
+
+- `schemaVersion` versions the JSON contract independently of the package.
+- `scannerVersion` is the installed `durable-ui` package version.
+- `root` is the resolved absolute scan root. For a single-file target, it is the file's parent directory.
+- `frameworks` contains recognized frameworks in a stable display order.
+- `filesScanned` counts readable source files actually inspected.
+- `filesSkipped` lists supported source files skipped because they exceed 1 MiB. Ignored directories, test files, symbolic links, and files beyond `--max-files` are not listed here.
+- `summary` counts findings by severity.
+- `positiveSignals` contains only signals found in at least one file.
+- `findings` is sorted by severity, file, and line.
+
+JSON is written to stdout. Argument, path, and scan errors are written to stderr, which keeps successful JSON output parseable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ hero:
   tagline: Documentation for Sails.js, The Boring JavaScript Stack, and related tools.
   actions:
     - theme: brand
-      text: Watch a Course
-      link: https://sailscasts.com
+      text: Watch the Durable UI Course
+      link: https://sailscasts.com/courses/durable-ui
     - theme: alt
       text: The Boring Stack
       link: /boring-stack/
@@ -23,7 +23,7 @@ features:
     details: Server-centric full-stack guides built around Sails, Inertia, Tailwind CSS, and Vue, React, or Svelte.
   - icon: 🛠️
     title: Developer Tools
-    details: Hooks, CLI tools, and supporting packages for Sails applications.
+    details: Hooks, CLI tools like Durable UI Scan, and supporting packages for resilient Sails applications.
   - icon: 🖖
     title: Open Source
     details: Documentation for the open-source libraries published through Sailscasts.


### PR DESCRIPTION
## Summary

- make Durable UI Scan the primary Durable UI docs entry point
- document supported codebases, every 0.0.1 check and CLI flag, report output, JSON schema, CI behavior, and limitations
- point the main docs homepage to the Durable UI course and keep Durable UI current in the open-source catalog

## Verification

- `npm run lint`
- `npm run build`
- verified all five generated Scan routes

Supports sailscastshq/durable-ui#6.