### PR TITLE
docs: add live Klean UI component documentation

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -54,6 +54,7 @@ export default {
       '/sentry-sails/': SentrySailsGuide(),
       '/pellicule/': pelliculeGuide(),
       '/durable-ui/': durableUiGuide(),
+      '/klean-ui/': kleanUiGuide(),
       '/sails-ai/': sailsAiGuide(),
       '/sails-flare/': sailsFlareGuide()
     },
@@ -85,6 +86,41 @@ function nav() {
     { text: 'Open Source', link: '/open-source' },
     { text: 'Courses', link: 'https://sailscasts.com/courses' },
     { text: 'Blog', link: 'https://blog.sailscasts.com' }
+  ]
+}
+
+function kleanUiGuide() {
+  return [
+    {
+      text: 'Getting Started',
+      collapsed: false,
+      items: [
+        { text: 'Introduction', link: '/klean-ui/' },
+        { text: 'Installation', link: '/klean-ui/installation' }
+      ]
+    },
+    {
+      text: 'Foundations',
+      collapsed: false,
+      items: [
+        { text: 'Doctrine', link: '/klean-ui/doctrine' },
+        { text: 'Durable UI', link: '/klean-ui/durable-ui' },
+        { text: 'Theming', link: '/klean-ui/theming' }
+      ]
+    },
+    {
+      text: 'Components',
+      collapsed: false,
+      items: [
+        { text: 'Overview', link: '/klean-ui/components/' },
+        { text: 'Button', link: '/klean-ui/components/button' }
+      ]
+    },
+    {
+      text: 'Reference',
+      collapsed: false,
+      items: [{ text: 'CLI', link: '/klean-ui/cli' }]
+    }
   ]
 }
 

--- a/docs/.vitepress/data/projects.data.js
+++ b/docs/.vitepress/data/projects.data.js
@@ -33,6 +33,14 @@ export default {
           popular: true
         },
         {
+          name: 'Klean UI',
+          description:
+            "Kelvin's Lean UI: accessible, durable, source-owned components for Vue, React, and Svelte with Tailwind as the visual API.",
+          link: '/klean-ui/',
+          github: 'https://github.com/sailscastshq/klean-ui',
+          popular: true
+        },
+        {
           name: 'Sails AI',
           description:
             'Multi-provider AI hook for Sails.js with a clean adapter pattern. Chat, stream, and reason with any LLM.',

--- a/docs/.vitepress/theme/components/CopyCode.vue
+++ b/docs/.vitepress/theme/components/CopyCode.vue
@@ -1,0 +1,147 @@
+<script setup>
+import { useClipboard } from '../composables/useClipboard.js'
+
+const props = defineProps({
+  code: {
+    type: String,
+    required: true
+  },
+  label: {
+    type: String,
+    default: 'Code'
+  }
+})
+
+const { copied, copyFailed, copy } = useClipboard()
+</script>
+
+<template>
+  <figure class="copy-code">
+    <figcaption>{{ label }}</figcaption>
+    <pre tabindex="0"><code>{{ code }}</code></pre>
+    <button
+      type="button"
+      class="copy-code__button"
+      :aria-label="copied ? 'Copied to clipboard' : `Copy ${label}`"
+      @click="copy(code)"
+    >
+      <svg
+        v-if="!copied"
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+      >
+        <rect x="9" y="9" width="11" height="11" rx="2" />
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+      </svg>
+      <svg
+        v-else
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+      >
+        <path d="m5 12 4 4L19 6" />
+      </svg>
+      <span>{{ copied ? 'Copied' : 'Copy' }}</span>
+    </button>
+    <p class="copy-code__status" role="status" aria-live="polite">
+      {{
+        copied
+          ? `${label} copied to clipboard.`
+          : copyFailed
+            ? `Could not copy ${label.toLowerCase()}.`
+            : ''
+      }}
+    </p>
+  </figure>
+</template>
+
+<style scoped>
+.copy-code {
+  position: relative;
+  margin: 1rem 0 2rem;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.75rem;
+  background: #111;
+  color: #f5f5f5;
+}
+
+.copy-code figcaption {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgb(255 255 255 / 12%);
+  color: #a3a3a3;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.75rem;
+}
+
+.copy-code pre {
+  margin: 0;
+  overflow-x: auto;
+  padding: 1.15rem 4.75rem 1.15rem 1rem;
+  background: transparent;
+  color: inherit;
+  font-size: 0.8125rem;
+  line-height: 1.65;
+}
+
+.copy-code code {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.copy-code__button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: inline-flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.4rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: #262626;
+  padding: 0 0.75rem;
+  color: #f5f5f5;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.copy-code__button:hover {
+  background: #404040;
+}
+
+.copy-code__button:focus-visible {
+  outline: 2px solid #a3a3a3;
+  outline-offset: 2px;
+}
+
+.copy-code__button svg {
+  width: 1rem;
+  height: 1rem;
+  stroke-width: 1.8;
+}
+
+.copy-code__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-code__button {
+    transition: none;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/KleanInstallation.vue
+++ b/docs/.vitepress/theme/components/KleanInstallation.vue
@@ -1,0 +1,351 @@
+<script setup>
+import { nextTick, ref } from 'vue'
+import CopyCode from './CopyCode.vue'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  source: {
+    type: String,
+    required: true
+  },
+  filename: {
+    type: String,
+    default: 'Button.vue'
+  },
+  destination: {
+    type: String,
+    default: 'assets/js/components/ui/button/Button.vue'
+  }
+})
+
+const methods = [
+  { id: 'command', label: 'Command' },
+  { id: 'manual', label: 'Manual' }
+]
+
+const packageManagers = [
+  { id: 'npm', label: 'npm', command: 'npx klean-ui add button' },
+  { id: 'pnpm', label: 'pnpm', command: 'pnpm dlx klean-ui add button' },
+  { id: 'yarn', label: 'yarn', command: 'yarn dlx klean-ui add button' },
+  { id: 'bun', label: 'bun', command: 'bunx klean-ui add button' }
+]
+
+const activeMethod = ref('command')
+const activePackageManager = ref('npm')
+const methodRefs = ref([])
+const packageManagerRefs = ref([])
+
+function methodTabId(method) {
+  return `${props.id}-${method}-tab`
+}
+
+function methodPanelId(method) {
+  return `${props.id}-${method}-panel`
+}
+
+function packageManagerTabId(packageManager) {
+  return `${props.id}-${packageManager}-tab`
+}
+
+function packageManagerPanelId(packageManager) {
+  return `${props.id}-${packageManager}-panel`
+}
+
+async function selectTab(value, refs, options, focusTab) {
+  if (!focusTab) return
+
+  await nextTick()
+  refs.value[options.findIndex((option) => option.id === value)]?.focus()
+}
+
+function handleTabKeydown(event, index, options, activate) {
+  let nextIndex
+
+  if (event.key === 'ArrowRight') nextIndex = (index + 1) % options.length
+  else if (event.key === 'ArrowLeft')
+    nextIndex = (index - 1 + options.length) % options.length
+  else if (event.key === 'Home') nextIndex = 0
+  else if (event.key === 'End') nextIndex = options.length - 1
+  else return
+
+  event.preventDefault()
+  activate(options[nextIndex].id, true)
+}
+
+function selectMethod(method, focusTab = false) {
+  activeMethod.value = method
+  selectTab(method, methodRefs, methods, focusTab)
+}
+
+function selectPackageManager(packageManager, focusTab = false) {
+  activePackageManager.value = packageManager
+  selectTab(packageManager, packageManagerRefs, packageManagers, focusTab)
+}
+</script>
+
+<template>
+  <div class="klean-installation">
+    <div
+      class="klean-installation__methods"
+      role="tablist"
+      aria-label="Installation method"
+    >
+      <button
+        v-for="(method, index) in methods"
+        :id="methodTabId(method.id)"
+        :key="method.id"
+        :ref="(element) => (methodRefs[index] = element)"
+        type="button"
+        role="tab"
+        :aria-selected="activeMethod === method.id"
+        :aria-controls="methodPanelId(method.id)"
+        :tabindex="activeMethod === method.id ? 0 : -1"
+        @click="selectMethod(method.id)"
+        @keydown="handleTabKeydown($event, index, methods, selectMethod)"
+      >
+        {{ method.label }}
+      </button>
+    </div>
+
+    <section
+      v-if="activeMethod === 'command'"
+      :id="methodPanelId('command')"
+      role="tabpanel"
+      :aria-labelledby="methodTabId('command')"
+      tabindex="0"
+      class="klean-installation__panel"
+    >
+      <p>
+        Run one command from a Boring Stack application. Klean detects the
+        framework and conventional destination, then adds the framework-native
+        source and its direct dependencies.
+      </p>
+
+      <div
+        class="klean-installation__packages"
+        role="tablist"
+        aria-label="Package manager"
+      >
+        <button
+          v-for="(packageManager, index) in packageManagers"
+          :id="packageManagerTabId(packageManager.id)"
+          :key="packageManager.id"
+          :ref="(element) => (packageManagerRefs[index] = element)"
+          type="button"
+          role="tab"
+          :aria-selected="activePackageManager === packageManager.id"
+          :aria-controls="packageManagerPanelId(packageManager.id)"
+          :tabindex="activePackageManager === packageManager.id ? 0 : -1"
+          @click="selectPackageManager(packageManager.id)"
+          @keydown="
+            handleTabKeydown(
+              $event,
+              index,
+              packageManagers,
+              selectPackageManager
+            )
+          "
+        >
+          {{ packageManager.label }}
+        </button>
+      </div>
+
+      <div
+        v-for="packageManager in packageManagers"
+        v-show="activePackageManager === packageManager.id"
+        :id="packageManagerPanelId(packageManager.id)"
+        :key="packageManager.id"
+        role="tabpanel"
+        :aria-labelledby="packageManagerTabId(packageManager.id)"
+        tabindex="0"
+      >
+        <CopyCode :code="packageManager.command" label="Terminal" />
+      </div>
+
+      <ul class="klean-installation__summary">
+        <li>No initializer or configuration file</li>
+        <li>No framework, alias, or theme questions</li>
+        <li>No Klean runtime dependency</li>
+      </ul>
+    </section>
+
+    <section
+      v-else
+      :id="methodPanelId('manual')"
+      role="tabpanel"
+      :aria-labelledby="methodTabId('manual')"
+      tabindex="0"
+      class="klean-installation__panel"
+    >
+      <ol class="klean-installation__steps">
+        <li>
+          <h3>Install the direct dependency</h3>
+          <CopyCode code="npm install tailwind-merge" label="Terminal" />
+        </li>
+        <li>
+          <h3>Copy the component source</h3>
+          <CopyCode :code="source" :label="filename" />
+        </li>
+        <li>
+          <h3>Save it at the conventional path</h3>
+          <CopyCode :code="destination" label="Destination" />
+        </li>
+      </ol>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.klean-installation {
+  margin: 1.25rem 0 2.75rem;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.875rem;
+  background: var(--vp-c-bg);
+}
+
+.klean-installation__methods {
+  display: flex;
+  min-height: 3.25rem;
+  align-items: stretch;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  padding: 0 0.75rem;
+}
+
+.klean-installation__methods button,
+.klean-installation__packages button {
+  position: relative;
+  border: 0;
+  background: transparent;
+  color: var(--vp-c-text-2);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.klean-installation__methods button {
+  min-width: 5.25rem;
+  padding: 0 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.klean-installation__methods button::after {
+  position: absolute;
+  right: 0.75rem;
+  bottom: -1px;
+  left: 0.75rem;
+  height: 2px;
+  background: var(--vp-c-text-1);
+  content: '';
+  transform: scaleX(0);
+  transition: transform 140ms ease;
+}
+
+.klean-installation__methods button[aria-selected='true'] {
+  color: var(--vp-c-text-1);
+}
+
+.klean-installation__methods button[aria-selected='true']::after {
+  transform: scaleX(1);
+}
+
+.klean-installation__panel {
+  padding: 1.5rem;
+  outline: none;
+}
+
+.klean-installation__panel:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--vp-c-text-3);
+}
+
+.klean-installation__panel > p {
+  max-width: 42rem;
+  margin: 0 0 1.25rem;
+  color: var(--vp-c-text-2);
+  line-height: 1.7;
+}
+
+.klean-installation__packages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.klean-installation__packages button {
+  min-height: 2.5rem;
+  border-radius: 0.5rem;
+  padding: 0 0.8rem;
+  font-size: 0.75rem;
+}
+
+.klean-installation__packages button:hover {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+}
+
+.klean-installation__packages button[aria-selected='true'] {
+  background: var(--vp-c-bg-mute);
+  color: var(--vp-c-text-1);
+}
+
+.klean-installation__methods button:focus-visible,
+.klean-installation__packages button:focus-visible {
+  outline: 2px solid var(--vp-c-text-2);
+  outline-offset: 2px;
+}
+
+.klean-installation__summary {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  color: var(--vp-c-text-2);
+  font-size: 0.875rem;
+  list-style: none;
+}
+
+.klean-installation__summary li::before {
+  margin-right: 0.55rem;
+  color: var(--vp-c-text-1);
+  content: '✓';
+}
+
+.klean-installation__steps {
+  display: grid;
+  gap: 2rem;
+  margin: 0;
+  padding-left: 1.4rem;
+}
+
+.klean-installation__steps h3 {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0.95rem;
+}
+
+.klean-installation :deep(.copy-code) {
+  margin-bottom: 0;
+}
+
+@media (max-width: 520px) {
+  .klean-installation__panel {
+    padding: 1rem;
+  }
+
+  .klean-installation__methods {
+    padding: 0 0.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .klean-installation__methods button::after {
+    transition: none;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/KleanPreview.vue
+++ b/docs/.vitepress/theme/components/KleanPreview.vue
@@ -1,0 +1,441 @@
+<script setup>
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useClipboard } from '../composables/useClipboard.js'
+import previewStyles from '../klean.css?inline'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  source: {
+    type: String,
+    required: true
+  },
+  filename: {
+    type: String,
+    default: 'Button.vue'
+  }
+})
+
+const panels = [
+  { id: 'preview', label: 'Preview' },
+  { id: 'source', label: 'Source' }
+]
+
+const activePanel = ref('preview')
+const tabRefs = ref([])
+const previewHost = ref()
+const previewTarget = ref()
+const { copied, copyFailed, copy } = useClipboard()
+
+let themeObserver
+
+function syncPreviewTheme() {
+  previewTarget.value?.classList.toggle(
+    'dark',
+    document.documentElement.classList.contains('dark')
+  )
+}
+
+onMounted(() => {
+  const shadowRoot = previewHost.value.attachShadow({ mode: 'open' })
+  const style = document.createElement('style')
+  const stage = document.createElement('div')
+
+  style.textContent = `${previewStyles}\n
+    :host { display: block; }
+
+    .klean-preview__stage {
+      box-sizing: border-box;
+      display: flex;
+      min-height: 19rem;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      padding: 2rem;
+    }
+
+    @media (max-width: 480px) {
+      .klean-preview__stage {
+        min-height: 15rem;
+        padding: 1.25rem;
+      }
+    }
+  `
+  stage.className = 'klean-preview__stage'
+  shadowRoot.append(style, stage)
+  previewTarget.value = stage
+  syncPreviewTheme()
+
+  themeObserver = new MutationObserver(syncPreviewTheme)
+  themeObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class']
+  })
+})
+
+onBeforeUnmount(() => {
+  themeObserver?.disconnect()
+})
+
+function panelId(panel) {
+  return `${props.id}-${panel}`
+}
+
+function tabId(panel) {
+  return `${props.id}-${panel}-tab`
+}
+
+async function selectPanel(panel, focusTab = false) {
+  activePanel.value = panel
+
+  if (!focusTab) return
+
+  await nextTick()
+  tabRefs.value[panels.findIndex((item) => item.id === panel)]?.focus()
+}
+
+function handleTabKeydown(event, index) {
+  let nextIndex
+
+  if (event.key === 'ArrowRight') nextIndex = (index + 1) % panels.length
+  else if (event.key === 'ArrowLeft')
+    nextIndex = (index - 1 + panels.length) % panels.length
+  else if (event.key === 'Home') nextIndex = 0
+  else if (event.key === 'End') nextIndex = panels.length - 1
+  else return
+
+  event.preventDefault()
+  selectPanel(panels[nextIndex].id, true)
+}
+</script>
+
+<template>
+  <figure class="klean-preview">
+    <header class="klean-preview__toolbar">
+      <div role="tablist" aria-label="Component example view">
+        <button
+          v-for="(panel, index) in panels"
+          :id="tabId(panel.id)"
+          :key="panel.id"
+          :ref="(element) => (tabRefs[index] = element)"
+          type="button"
+          role="tab"
+          :aria-selected="activePanel === panel.id"
+          :aria-controls="panelId(panel.id)"
+          :tabindex="activePanel === panel.id ? 0 : -1"
+          @click="selectPanel(panel.id)"
+          @keydown="handleTabKeydown($event, index)"
+        >
+          {{ panel.label }}
+        </button>
+      </div>
+
+      <button
+        v-if="activePanel === 'source'"
+        type="button"
+        class="klean-preview__copy"
+        :aria-label="
+          copied ? 'Source copied to clipboard' : 'Copy component source'
+        "
+        @click="copy(source)"
+      >
+        <svg
+          v-if="!copied"
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+        >
+          <rect x="9" y="9" width="11" height="11" rx="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+        <svg
+          v-else
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+        >
+          <path d="m5 12 4 4L19 6" />
+        </svg>
+        <span>{{ copied ? 'Copied' : 'Copy source' }}</span>
+      </button>
+      <span v-else class="klean-preview__filename">{{ filename }}</span>
+    </header>
+
+    <Transition name="klean-panel" mode="out-in">
+      <section
+        v-if="activePanel === 'preview'"
+        :id="panelId('preview')"
+        key="preview"
+        role="tabpanel"
+        :aria-labelledby="tabId('preview')"
+        tabindex="0"
+        class="klean-preview__panel"
+      >
+        <div ref="previewHost" class="klean-preview__canvas"></div>
+        <Teleport v-if="previewTarget" :to="previewTarget">
+          <slot name="preview" />
+        </Teleport>
+      </section>
+      <section
+        v-else
+        :id="panelId('source')"
+        key="source"
+        role="tabpanel"
+        :aria-labelledby="tabId('source')"
+        tabindex="0"
+        class="klean-preview__panel klean-preview__source"
+      >
+        <p>{{ filename }}</p>
+        <div v-if="$slots.source" class="klean-preview__highlighted">
+          <slot name="source" />
+        </div>
+        <pre v-else tabindex="0"><code>{{ source }}</code></pre>
+      </section>
+    </Transition>
+
+    <figcaption v-if="$slots.caption">
+      <slot name="caption" />
+    </figcaption>
+
+    <p class="klean-preview__status" role="status" aria-live="polite">
+      {{
+        copied
+          ? `${filename} copied to clipboard.`
+          : copyFailed
+            ? 'Could not copy the source.'
+            : ''
+      }}
+    </p>
+  </figure>
+</template>
+
+<style scoped>
+.klean-preview {
+  margin: 1.5rem 0 2.75rem;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.875rem;
+  background: var(--vp-c-bg);
+}
+
+.klean-preview__toolbar {
+  display: flex;
+  min-height: 3.25rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  padding: 0 0.5rem 0 0.75rem;
+}
+
+.klean-preview__toolbar [role='tablist'] {
+  display: flex;
+  align-self: stretch;
+}
+
+.klean-preview__toolbar [role='tab'] {
+  position: relative;
+  min-width: 4.5rem;
+  border: 0;
+  background: transparent;
+  padding: 0 0.75rem;
+  color: var(--vp-c-text-2);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.klean-preview__toolbar [role='tab']::after {
+  position: absolute;
+  right: 0.75rem;
+  bottom: -1px;
+  left: 0.75rem;
+  height: 2px;
+  background: var(--vp-c-text-1);
+  content: '';
+  transform: scaleX(0);
+  transition: transform 140ms ease;
+}
+
+.klean-preview__toolbar [role='tab'][aria-selected='true'] {
+  color: var(--vp-c-text-1);
+}
+
+.klean-preview__toolbar [role='tab'][aria-selected='true']::after {
+  transform: scaleX(1);
+}
+
+.klean-preview__toolbar [role='tab']:focus-visible,
+.klean-preview__copy:focus-visible {
+  outline: 2px solid var(--vp-c-text-2);
+  outline-offset: 2px;
+}
+
+.klean-preview__filename {
+  padding-right: 0.75rem;
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.75rem;
+}
+
+.klean-preview__copy {
+  display: inline-flex;
+  min-height: 2.5rem;
+  align-items: center;
+  gap: 0.4rem;
+  border: 0;
+  border-radius: 0.5rem;
+  background: var(--vp-c-bg-soft);
+  padding: 0 0.7rem;
+  color: var(--vp-c-text-1);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.klean-preview__copy:hover {
+  background: var(--vp-c-bg-mute);
+}
+
+.klean-preview__copy svg {
+  width: 1rem;
+  height: 1rem;
+  stroke-width: 1.8;
+}
+
+.klean-preview__panel {
+  margin: 0;
+  outline: none;
+}
+
+.klean-preview__panel:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--vp-c-text-3);
+}
+
+.klean-preview__canvas {
+  min-height: 19rem;
+  background-color: var(--vp-c-bg-soft);
+  background-image: radial-gradient(
+    circle,
+    var(--vp-c-divider) 0.7px,
+    transparent 0.7px
+  );
+  background-size: 18px 18px;
+}
+
+.klean-preview__source {
+  min-height: 19rem;
+  background: var(--vp-code-block-bg);
+  color: var(--vp-code-block-color);
+}
+
+.klean-preview__source > p {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.75rem;
+}
+
+.klean-preview__source :deep(div[class*='language-']) {
+  margin: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.klean-preview__source :deep(.copy),
+.klean-preview__source :deep(.lang) {
+  display: none;
+}
+
+.klean-preview__source :deep(pre) {
+  max-height: 34rem;
+  margin: 0;
+  overflow: auto;
+  padding: 1.25rem;
+  background: transparent;
+  color: inherit;
+  font-size: 0.78rem;
+  line-height: 1.65;
+}
+
+.klean-preview__source :deep(code) {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.klean-preview figcaption {
+  padding: 0.8rem 1rem;
+  border-top: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  font-size: 0.8125rem;
+  line-height: 1.55;
+}
+
+.klean-preview__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.klean-panel-enter-active,
+.klean-panel-leave-active {
+  transition:
+    opacity 100ms ease,
+    transform 100ms ease;
+}
+
+.klean-panel-enter-from,
+.klean-panel-leave-to {
+  opacity: 0;
+  transform: translateY(2px);
+}
+
+@media (max-width: 480px) {
+  .klean-preview__toolbar {
+    gap: 0.25rem;
+  }
+
+  .klean-preview__toolbar [role='tab'] {
+    min-width: 4rem;
+    padding: 0 0.5rem;
+  }
+
+  .klean-preview__filename {
+    display: none;
+  }
+
+  .klean-preview__copy span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .klean-preview__canvas {
+    min-height: 15rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .klean-preview__toolbar [role='tab']::after,
+  .klean-panel-enter-active,
+  .klean-panel-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/klean/Button.vue
+++ b/docs/.vitepress/theme/components/klean/Button.vue
@@ -1,0 +1,107 @@
+<script setup>
+import { computed, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const props = defineProps({
+  /**
+   * The rendered element. Pass an Inertia Link component directly when the
+   * destination should retain navigation semantics.
+   */
+  as: {
+    type: [String, Object, Function],
+    default: 'button',
+    validator: (value) =>
+      typeof value !== 'string' || ['button', 'a'].includes(value)
+  },
+  /** Native button type. Ignored when `as` does not render a button. */
+  type: {
+    type: String,
+    default: 'button',
+    validator: (value) => ['button', 'submit', 'reset'].includes(value)
+  },
+  /**
+   * Uses the native disabled attribute for buttons and accessible disabled
+   * link semantics for anchors or component links.
+   */
+  disabled: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const attrs = useAttrs()
+
+const baseClasses = [
+  'inline-flex min-h-11 min-w-11 cursor-pointer select-none items-center justify-center gap-2 rounded-md no-underline',
+  'bg-gray-950 px-4 py-2 text-sm font-medium text-nowrap text-white',
+  'transition-colors duration-150 ease-out',
+  'hover:bg-gray-800 active:bg-gray-700',
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:focus-visible:outline-gray-400',
+  'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+  'dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100 dark:active:bg-gray-200',
+  'motion-reduce:transition-none'
+]
+
+const isNativeButton = computed(() => props.as === 'button')
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    tabindex: _tabindex,
+    'aria-disabled': _ariaDisabled,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+
+  return rest
+})
+
+const buttonClasses = computed(() => twMerge(baseClasses, attrs.class))
+
+const managedAriaDisabled = computed(() => {
+  if (isNativeButton.value) return undefined
+  if (props.disabled) return 'true'
+  return attrs['aria-disabled']
+})
+
+const managedTabindex = computed(() => {
+  if (!isNativeButton.value && props.disabled) return -1
+  return attrs.tabindex
+})
+
+function guardDisabledClick(event) {
+  if (!props.disabled || isNativeButton.value) return
+
+  event.preventDefault()
+  event.stopImmediatePropagation()
+}
+
+function guardDisabledKeydown(event) {
+  if (!['Enter', ' '].includes(event.key)) return
+
+  guardDisabledClick(event)
+}
+</script>
+
+<template>
+  <component
+    :is="as"
+    v-bind="forwardedAttrs"
+    :type="isNativeButton ? type : undefined"
+    :disabled="isNativeButton ? disabled : undefined"
+    :aria-disabled="managedAriaDisabled"
+    :tabindex="managedTabindex"
+    :data-disabled="disabled ? '' : undefined"
+    data-slot="button"
+    :class="buttonClasses"
+    @click.capture="guardDisabledClick"
+    @keydown.capture="guardDisabledKeydown"
+  >
+    <slot />
+  </component>
+</template>

--- a/docs/.vitepress/theme/composables/useClipboard.js
+++ b/docs/.vitepress/theme/composables/useClipboard.js
@@ -1,0 +1,33 @@
+import { onBeforeUnmount, ref } from 'vue'
+
+export function useClipboard() {
+  const copied = ref(false)
+  const copyFailed = ref(false)
+  let resetTimer
+
+  async function copy(text) {
+    copied.value = false
+    copyFailed.value = false
+
+    try {
+      await navigator.clipboard.writeText(text)
+      copied.value = true
+      clearTimeout(resetTimer)
+      resetTimer = setTimeout(() => {
+        copied.value = false
+      }, 2000)
+    } catch {
+      copyFailed.value = true
+    }
+  }
+
+  onBeforeUnmount(() => {
+    clearTimeout(resetTimer)
+  })
+
+  return {
+    copied,
+    copyFailed,
+    copy
+  }
+}

--- a/docs/.vitepress/theme/klean.css
+++ b/docs/.vitepress/theme/klean.css
@@ -1,0 +1,6 @@
+@import 'tailwindcss';
+
+@source './components/klean';
+@source '../../klean-ui';
+
+@custom-variant dark (&:where(.dark, .dark *));

--- a/docs/klean-ui/cli.md
+++ b/docs/klean-ui/cli.md
@@ -1,0 +1,104 @@
+---
+title: CLI
+titleTemplate: Klean UI
+description: The zero-configuration Klean UI source installer command and its framework, path, dependency, and conflict rules.
+outline: [2, 3]
+---
+
+# CLI
+
+The Klean CLI is a source installer for conventional Boring Stack applications:
+
+```bash
+npx klean-ui add button
+```
+
+It has one job: place the right framework-native source in the right application path safely.
+
+## How `npx klean-ui add` works
+
+The published `klean-ui` npm package exposes a `klean-ui` executable. `npx` resolves and runs that executable for the command; it does not add Klean as an application runtime dependency.
+
+The CLI performs a deterministic pipeline:
+
+1. **Locate the application root.** Walk upward to the Sails `package.json`.
+2. **Detect the framework.** Inspect dependencies and the conventional frontend entry for reliable Vue, React, or Svelte evidence.
+3. **Resolve conventions.** Use `assets/js/components/ui` and, when needed, `assets/css/app.css`.
+4. **Resolve the registry item.** Read Button's manifest from the registry bundled with that CLI version.
+5. **Build a mutation plan.** Select only the detected framework's file and any direct dependencies it imports.
+6. **Check safety.** Compare an existing destination before any write.
+7. **Apply atomically where practical.** Create missing directories, copy source, add missing dependencies, and avoid partial state.
+8. **Report the result.** Print the detected framework, resolved paths, added files, dependencies, skips, or conflicts.
+
+Bundling versioned registry metadata with the CLI keeps one invocation deterministic: the executable and the source it installs come from the same package version.
+
+## Detection
+
+Klean does not ask questions that the project can answer.
+
+| Evidence                                        | Resolution                     |
+| ----------------------------------------------- | ------------------------------ |
+| Sails package and conventional app shape        | Application root               |
+| Framework dependency plus matching entry source | Vue, React, or Svelte          |
+| Boring Stack directory conventions              | Component and stylesheet paths |
+| Registry item metadata                          | Files and direct dependencies  |
+
+When evidence conflicts or is incomplete, the command exits with the evidence it found and the relevant explicit override. It does not guess silently.
+
+## Command surface
+
+```bash
+# Add a component
+npx klean-ui add button
+
+# Inspect the full plan without writing
+npx klean-ui add button --dry-run
+
+# Use a nonstandard component destination
+npx klean-ui add button --components-dir resources/js/ui
+
+# Override a stylesheet path for an item that needs CSS
+npx klean-ui add button --css resources/css/app.css
+```
+
+Exceptional paths are flags, not permanent consumer configuration.
+
+## Example output
+
+```text
+Klean UI detected a Boring Stack application.
+
+  Framework    React
+  Components   assets/js/components/ui
+  Styles       assets/css/app.css
+
+✓ Added button/Button.jsx
+✓ Added tailwind-merge
+```
+
+Vue installs `Button.vue`; React installs `Button.jsx`; Svelte installs `Button.svelte`. Only one framework implementation lands in the application.
+
+## Conflict and re-run rules
+
+- Re-running against unchanged installed source is a no-op.
+- A locally edited destination is never silently overwritten.
+- Conflicts show a useful diff or require an explicit overwrite decision.
+- `--dry-run` prints files, dependencies, and mutations without writing.
+- A partial failure returns a non-zero exit code and rolls back where practical.
+- Missing destination directories are created safely.
+
+Source ownership begins at installation, so an update command cannot assume the local file still matches upstream.
+
+## What the CLI does not create
+
+The installer does not create:
+
+- `klean-ui.json` or another project manifest;
+- an `init` result;
+- a generated `cn.js` or shared class helper;
+- a theme provider, preset, or token file;
+- a Klean component runtime;
+- a framework selection prompt;
+- telemetry or an account requirement.
+
+Registry manifests are maintainer metadata inside the published package. They describe files and dependencies without becoming configuration that every consuming application must keep.

--- a/docs/klean-ui/components/button.md
+++ b/docs/klean-ui/components/button.md
@@ -1,0 +1,140 @@
+---
+title: Button
+titleTemplate: Klean UI
+description: A native-first Klean UI action primitive with behavioral props and Tailwind as its visual API.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
+import buttonSource from '../../.vitepress/theme/components/klean/Button.vue?raw'
+import basicUsage from '../snippets/button/usage.vue?raw'
+import semanticUsage from '../snippets/button/semantics.vue?raw'
+import productRecipes from '../snippets/button/products.vue?raw'
+</script>
+
+# Button
+
+Button is a native-first action primitive. It owns truthful element selection, safe button type, disabled semantics, attribute forwarding, a stable `data-slot`, and conflict-aware class composition. Your application owns loading state, navigation decisions, business language, and the visual recipe.
+
+There are intentionally no `variant`, `size`, `color`, `tone`, `radius`, `elevated`, or `loading` props.
+
+<KleanPreview id="button-source" :source="buttonSource" filename="Button.vue">
+  <template #preview>
+    <KleanButton>Continue</KleanButton>
+    <KleanButton disabled>Processing</KleanButton>
+    <KleanButton
+      as="a"
+      href="/klean-ui/components/button#semantic-elements"
+      class="bg-white text-gray-950 ring-1 ring-inset ring-gray-300 hover:bg-gray-100 dark:bg-gray-900 dark:text-white dark:ring-gray-700 dark:hover:bg-gray-800"
+    >
+      Button as a link
+    </KleanButton>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/Button.vue
+
+  </template>
+  <template #caption>
+    Switch to Source to inspect or copy the file rendered by this documentation
+    preview. The installer selects Vue, React, or Svelte source while preserving
+    the same contract.
+  </template>
+</KleanPreview>
+
+## Installation
+
+The standard Boring Stack path requires no `init`, `klean-ui.json`, alias prompt, or generated `cn.js`. The installer detects the framework and conventional source paths.
+
+<KleanInstallation id="button-installation" :source="buttonSource" />
+
+## Usage
+
+<CopyCode :code="basicUsage" label="usage.vue" />
+
+Visual styling stays in the framework's ordinary class API. If the same product treatment repeats, create an application-owned component such as `PrimaryButton.vue` using Button as its semantic base.
+
+## API
+
+| Input        | Default    | Purpose                                                                              |
+| ------------ | ---------- | ------------------------------------------------------------------------------------ |
+| `as`         | `'button'` | Render a native `button`, native `a`, or framework component such as Inertia `Link`. |
+| `type`       | `'button'` | Native button behavior: `button`, `submit`, or `reset`. Ignored for non-buttons.     |
+| `disabled`   | `false`    | Native disabled behavior for buttons and accessible disabled semantics for links.    |
+| `class`      | —          | The visual API. Caller Tailwind classes merge last.                                  |
+| default slot | —          | Label, decorative icon, spinner, or other accessible content.                        |
+
+## Semantic elements
+
+Appearance does not decide semantics. Use one truthful interactive element:
+
+- `<button>` for actions, local state, dialogs, and form submission;
+- `<a>` for external navigation, downloads, OAuth, or full-page requests;
+- the Boring Stack `Link` for internal Inertia navigation.
+
+Do not wrap a Button inside an anchor. Render Button **as** the anchor or Link.
+
+<KleanPreview id="button-semantics" :source="semanticUsage" filename="semantic-usage.vue">
+  <template #preview>
+    <KleanButton type="button">Open dialog</KleanButton>
+    <KleanButton type="submit">Save changes</KleanButton>
+    <KleanButton as="a" href="https://sailsjs.com">Read Sails docs</KleanButton>
+    <KleanButton
+      as="a"
+      href="/klean-ui/"
+      class="bg-white text-gray-950 ring-1 ring-inset ring-gray-300 hover:bg-gray-100 dark:bg-gray-900 dark:text-white dark:ring-gray-700 dark:hover:bg-gray-800"
+    >
+      View Klean UI
+    </KleanButton>
+  </template>
+  <template #source>
+
+<<< ../snippets/button/semantics.vue
+
+  </template>
+  <template #caption>
+    The last preview uses a native anchor because this documentation site does
+    not run inside an Inertia application. In a Boring Stack app, pass its Link
+    component directly.
+  </template>
+</KleanPreview>
+
+## Product recipes
+
+Klean's neutral default stays motionless and uses tonal feedback. Hagfish deliberately adds an offset-shadow press; Slipway keeps its dense operational controls quiet. Those opinions are explicit Tailwind classes, not Klean variants.
+
+<KleanPreview id="button-product-recipes" :source="productRecipes" filename="product-buttons.vue">
+  <template #preview>
+    <KleanButton
+      class="border-2 border-black bg-black px-6 text-white hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-white hover:text-black hover:shadow-[4px_4px_0_0_#000] active:translate-x-1 active:translate-y-1 active:shadow-none dark:border-white dark:bg-white dark:text-black dark:hover:bg-transparent dark:hover:text-white dark:hover:shadow-[4px_4px_0_0_#fff]"
+    >
+      Send invoice
+    </KleanButton>
+    <KleanButton class="min-h-9 min-w-0 rounded-md px-3 py-1.5 text-sm">
+      Deploy
+    </KleanButton>
+  </template>
+  <template #source>
+
+<<< ../snippets/button/products.vue
+
+  </template>
+  <template #caption>
+    Every class shown here is built into Tailwind or written as an explicit
+    arbitrary value. There are no hidden Klean theme utilities.
+  </template>
+</KleanPreview>
+
+## Accessibility contract
+
+- The default is a real `<button type="button">`.
+- Submit and reset behavior remain native.
+- Keyboard focus is visible without relying on color alone.
+- Icon-only usage needs an accessible name such as `aria-label`.
+- Disabled links leave the tab order and cannot activate.
+- Processing indicators are decorative when the visible label already describes the state.
+- Base interaction is motionless, and transitions are removed for reduced-motion preferences.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -1,0 +1,32 @@
+---
+title: Components
+titleTemplate: Klean UI
+description: Accessible, source-owned Klean UI components with neutral defaults and Tailwind as the visual API.
+outline: [2, 3]
+---
+
+# Components
+
+Klean components provide semantic markup, accessible behavior, durable interaction, and neutral defaults. Install the framework-native source, then style it with ordinary Tailwind.
+
+Components do not share a visual variant API. Each page shows the behavioral contract, live preview, exact source, installation command, semantic recipes, and accessibility requirements.
+
+## Available components
+
+### [Button](/klean-ui/components/button)
+
+A native-first action primitive that can render a truthful button, anchor, or Boring Stack Link. It handles safe type defaults, disabled semantics, attribute forwarding, and caller-owned Tailwind classes.
+
+## What belongs in the catalog
+
+A component graduates when it has:
+
+- the same semantic and accessibility outcomes in Vue, React, and Svelte;
+- framework-native, readable source;
+- keyboard and focus proof where relevant;
+- source-application evidence from Hagfish, Slipway, or another Boring Stack app;
+- safe installation, re-installation, and dependency metadata;
+- a neutral default that does not fight product styling;
+- documented Durable UI behavior where state or interaction must recover.
+
+The catalog grows by proving contracts, not by maximizing component count.

--- a/docs/klean-ui/doctrine.md
+++ b/docs/klean-ui/doctrine.md
@@ -1,0 +1,146 @@
+---
+title: Doctrine
+titleTemplate: Klean UI
+description: The design and engineering rules that make Klean UI lean, accessible, durable, and source-owned.
+outline: [2, 3]
+---
+
+# Doctrine
+
+Klean UI means Kelvin's Lean UI. “Lean” is a boundary: Klean owns excellent markup and reusable behavior, then gets out of the application's way.
+
+> Own the source. Keep the markup. Style it with Tailwind.
+
+Vue, React, and Svelte share the same outcomes without sharing a lowest-common-denominator runtime. Each component is native to its framework and recognizable to developers who already know that framework.
+
+## The non-negotiables
+
+1. **The application owns the source.** Klean copies readable files; it does not retain runtime ownership.
+2. **Conventions are the configuration.** A standard Boring Stack app needs no initializer, manifest, alias questionnaire, or provider hierarchy.
+3. **HTML comes first.** Native elements and browser behavior are the starting contract.
+4. **Tailwind is the visual API.** Visual decisions belong in `class` or `className`.
+5. **There are no visual variants.** Klean does not ship `variant`, `size`, `tone`, `color`, `radius`, or elevation props.
+6. **Behavior earns props.** A prop must express semantics or interaction that native attributes, slots, and classes cannot express clearly.
+7. **Accessibility is a release gate.** Keyboard, focus, naming, state, contrast, and reduced-motion behavior are correctness.
+8. **Application classes win.** Neutral defaults stay easy to replace and caller classes merge last.
+9. **Anatomy stays obvious.** Slots, parts, state, and rendered elements remain visible in the copied source.
+10. **Durability is part of correctness.** Useful state survives, navigation context is shareable, focus recovers, and failed optimistic work rolls back.
+
+## What Klean owns
+
+Klean owns:
+
+- sound semantic markup;
+- accessible behavior and state;
+- Durable UI components and state utilities;
+- neutral, usable defaults;
+- stable slots and `data-*` hooks;
+- safe native attribute forwarding;
+- readable framework-native source;
+- Boring Stack conventions and recipes.
+
+The application owns:
+
+- brand color, typography, density, radius, and shadow;
+- business language and request state;
+- product concepts such as `PrimaryButton` or `DeleteProjectButton`;
+- server interaction and navigation decisions;
+- the final composition of primitives into product UI.
+
+That boundary lets Hagfish, Slipway, and future applications share behavior without being forced into one visual personality.
+
+## Use the platform
+
+An action begins as `<button>`. Navigation remains `<a>` or the Boring Stack Link. A field uses a real `<label>`. Related choices use `<fieldset>` and `<legend>`. Headings describe document structure rather than font size.
+
+Native HTML provides browser behavior before JavaScript enhancement, accepts native attributes without a parallel Klean vocabulary, and keeps the source legible. Custom interaction is justified only when the platform cannot satisfy the complete contract.
+
+## Tailwind is the visual API
+
+Do not hide visual choices behind props:
+
+```vue
+<!-- Not Klean -->
+<Button variant="danger" size="large" radius="full">
+  Delete project
+</Button>
+```
+
+Write the treatment directly:
+
+```vue
+<Button
+  class="min-h-11 rounded-md bg-red-700 px-5 font-semibold text-white hover:bg-red-800"
+>
+  Delete project
+</Button>
+```
+
+This is not an escape hatch around the API. It is the visual API.
+
+When the same treatment expresses a recurring product concept, create an application-owned component:
+
+```vue
+<!-- assets/js/components/PrimaryButton.vue -->
+<script setup>
+import Button from './ui/button/Button.vue'
+</script>
+
+<template>
+  <Button class="bg-emerald-700 text-white hover:bg-emerald-800">
+    <slot />
+  </Button>
+</template>
+```
+
+Klean does not generate a public `cn.js`. Use each framework's ordinary conditional class syntax. If copied component internals need conflict-aware merging so caller utilities win, that implementation remains inside the source.
+
+## Motion belongs to the product
+
+Base components do not bounce, scale, lift, or depress. Their default feedback is tonal and their focus is visible. Hagfish may add its offset-shadow press with explicit Tailwind classes; Slipway may stay still. Neither treatment becomes a universal Button variant.
+
+## Accessibility is the release gate
+
+A component is unfinished until the relevant contract is proven:
+
+- truthful native element or equivalent semantics;
+- accessible name and required description;
+- complete keyboard operation and predictable tab order;
+- visible focus in light, dark, and high-contrast contexts;
+- state communicated programmatically, not by color alone;
+- disabled behavior that cannot activate or trap focus;
+- correct focus entry, containment, restoration, and dismissal for layered UI;
+- errors associated with their controls;
+- usable touch targets and responsive behavior;
+- nonessential motion removed under `prefers-reduced-motion`.
+
+ARIA supplements correct HTML. It does not repair an avoidable semantic mistake.
+
+## Durable UI is the interaction doctrine
+
+Klean is the canonical source-owned implementation of [Durable UI](/klean-ui/durable-ui). State belongs in the smallest durable home: local state for ephemeral interaction, browser storage for browser-only preferences, the URL for shareable navigation state, and the server for authoritative or cross-device data.
+
+Durability also covers interaction recovery: predictable dismissal, focus restoration, stale request cancellation, optimistic rollback, draft recovery, scroll restoration, and feedback that survives navigation.
+
+## The dependency ladder
+
+Klean chooses the smallest layer that can prove the complete behavior:
+
+1. native HTML;
+2. small, readable framework behavior;
+3. a focused unstyled primitive when keyboard navigation, focus management, dismissal, or positioning becomes substantial.
+
+Button needs no headless interaction dependency. A future Combobox, Menu, Select, Tooltip, or Dialog may justify one. Dependencies are selected per component, remain visible in the installed source and registry metadata, and never become an automatic platform beneath everything.
+
+## The test
+
+Before adding a Klean API, ask:
+
+- Is this already native HTML?
+- Is this ordinary framework composition?
+- Is this a Tailwind class?
+- Is this a repeated product concept that belongs in the application?
+- Does this prop change real behavior or only choose CSS?
+- Can a developer understand the installed source in one careful pass?
+
+If the platform, framework, Tailwind, or application already owns the idea, Klean should not invent another configuration language for it.

--- a/docs/klean-ui/durable-ui.md
+++ b/docs/klean-ui/durable-ui.md
@@ -1,0 +1,65 @@
+---
+title: Durable UI
+titleTemplate: Klean UI
+description: How Klean UI implements resilient state, focus, navigation, and async interaction patterns.
+outline: [2, 3]
+---
+
+# Durable UI
+
+Klean UI is the canonical source-owned implementation of Durable UI for The Boring JavaScript Stack. Components should not merely look correct in a screenshot; useful state, navigation context, focus, and in-progress work should survive the real conditions of an application.
+
+Vue, React, and Svelte preserve the same outcomes with framework-native source.
+
+## Two kinds of resilience
+
+**State resilience** puts state in the right durable home so preferences survive, useful views are shareable, and work can recover.
+
+**Interaction resilience** makes overlays dismiss predictably, restores focus, cancels stale work, rolls failed optimistic changes back, and keeps feedback perceivable through navigation.
+
+## Where state belongs
+
+| State                              | Conventional home         | Examples                                          |
+| ---------------------------------- | ------------------------- | ------------------------------------------------- |
+| Ephemeral interaction              | Local component state     | open disclosure, active drag, transient hover     |
+| Browser-only preference            | Versioned browser storage | density, dismissed coach mark, sidebar preference |
+| Shareable navigation context       | URL query or path         | filters, search, sort, selected tab, pagination   |
+| Recoverable local work             | Expiring draft storage    | long form, multi-step progress                    |
+| Authoritative or cross-device data | Server                    | account settings, permissions, billing state      |
+
+Sensitive or server-owned data does not belong in browser storage. A durable value also needs a lifecycle: namespace, schema version, expiry where appropriate, migration or invalidation, and a clear success path.
+
+## The Klean durability surface
+
+Klean components, state utilities, and blocks cover:
+
+- SSR-safe, namespaced, versioned storage with cross-tab synchronization;
+- typed URL state with clean defaults and deliberate push/replace history;
+- expiring form drafts with restore, discard, dirty-state honesty, and clear-on-success behavior;
+- multi-step recovery with schema evolution and intentional navigation;
+- Escape, outside-click, and backdrop dismissal with listener cleanup and scroll locking;
+- focus entry, containment, return, and recovery after destructive list changes;
+- optimistic toggles and list changes only when rollback is safe;
+- window and container scroll restoration plus asynchronous hash navigation;
+- accessible toast queues with deduplication, hover pause, manual dismissal, and Inertia flash integration;
+- debounced client or server search with URL synchronization and stale-request cancellation.
+
+## Durable does not mean global
+
+Zero configuration does not mean every pattern runs globally without being invoked. A toast queue still needs a host in the application layout. A controlled Dialog still needs open state. A draft needs an intentional key and lifecycle.
+
+Those are semantic integration points. Klean supplies one opinionated source implementation and safe conventions without requiring a provider hierarchy, registry manifest, state library, or parallel configuration language.
+
+## Accessibility and recovery
+
+Durability is observable:
+
+- Back and Forward restore the view a URL represents.
+- Reloading does not destroy explicitly recoverable work.
+- Closing a layered surface returns focus to a sensible place.
+- Removing a focused row moves focus to a nearby stable target.
+- A rejected optimistic update restores both data and announcement state.
+- A stale search response cannot replace a newer result.
+- Navigation does not make a success or error message disappear before it can be perceived.
+
+Each Klean component page documents the durability behaviors that apply. Button has a small contract; Dialog, Toast, Combobox, forms, and state utilities will carry more.

--- a/docs/klean-ui/index.md
+++ b/docs/klean-ui/index.md
@@ -1,0 +1,70 @@
+---
+title: Klean UI
+titleTemplate: Sailscasts
+description: Kelvin's Lean UI — accessible, durable, source-owned components for Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import KleanButton from '../.vitepress/theme/components/klean/Button.vue'
+import KleanInstallation from '../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../.vitepress/theme/components/KleanPreview.vue'
+import buttonSource from '../.vitepress/theme/components/klean/Button.vue?raw'
+import quickUsage from './snippets/introduction/usage.vue?raw'
+</script>
+
+# Klean UI
+
+Klean UI means **Kelvin's Lean UI**. It is the source-owned component system for The Boring JavaScript Stack: accessible markup, Durable UI behavior, neutral defaults, and Tailwind left directly in your hands.
+
+Vue, React, and Svelte are equal product targets. Each implementation uses its framework's native conventions while preserving the same semantics, states, anatomy, accessibility outcomes, and source-ownership model.
+
+<KleanPreview id="klean-introduction" :source="quickUsage" filename="usage.vue">
+  <template #preview>
+    <KleanButton>Continue</KleanButton>
+    <KleanButton
+      as="a"
+      href="/klean-ui/components/button"
+      class="bg-white text-gray-950 ring-1 ring-inset ring-gray-300 hover:bg-gray-100 dark:bg-gray-900 dark:text-white dark:ring-gray-700 dark:hover:bg-gray-800"
+    >
+      Read Button docs
+    </KleanButton>
+  </template>
+  <template #source>
+
+<<< ./snippets/introduction/usage.vue
+
+  </template>
+  <template #caption>
+    One behavioral contract, styled with ordinary Tailwind. VitePress renders
+    the source shown on the Button page; the installer selects framework-native
+    Vue, React, or Svelte source for the application.
+  </template>
+</KleanPreview>
+
+## Installation
+
+Add a component with one command. Klean infers the framework and conventional Boring Stack paths; the files it adds become application source.
+
+<KleanInstallation id="klean-installation" :source="buttonSource" />
+
+## The contract
+
+- **Own the source.** Components land in the application as readable files.
+- **Use the platform.** Actions are buttons; navigation is an anchor or the Boring Stack Link.
+- **Style with Tailwind.** There are no visual `variant`, `size`, `tone`, or `radius` props.
+- **Prefer conventions.** A standard Boring Stack app needs no initializer, manifest, alias questionnaire, or public `cn.js`.
+- **Treat accessibility as correctness.** Keyboard behavior, focus, naming, state, and reduced motion are release requirements.
+- **Implement Durable UI.** Useful state survives, navigation remains shareable, focus recovers, and failed work rolls back.
+
+## Start with Button
+
+Button is the first documented component, not the definition of the library. Its API is intentionally small: choose the truthful element, pass behavioral state, and write the product's design in `class`.
+
+[Explore Button →](/klean-ui/components/button)
+
+## Source-owned, not runtime-owned
+
+Klean takes the useful part of the shadcn model—discoverable examples and source ownership—then removes the required initialization ceremony, visual variant matrix, public class helper, and hidden theme prerequisites.
+
+Read the [Doctrine](/klean-ui/doctrine) for the boundaries behind those choices, or the [CLI reference](/klean-ui/cli) for the complete installer contract.

--- a/docs/klean-ui/installation.md
+++ b/docs/klean-ui/installation.md
@@ -1,0 +1,75 @@
+---
+title: Installation
+titleTemplate: Klean UI
+description: Add framework-native Klean UI source to a Boring Stack application with one convention-first command.
+outline: [2, 3]
+---
+
+<script setup>
+import KleanInstallation from '../.vitepress/theme/components/KleanInstallation.vue'
+import buttonSource from '../.vitepress/theme/components/klean/Button.vue?raw'
+</script>
+
+# Installation
+
+Klean installs readable component source into your application. There is no setup wizard, `init` command, `klean-ui.json`, provider, or Klean runtime to retain.
+
+<KleanInstallation id="installation-page" :source="buttonSource" />
+
+## What the command does
+
+`npx klean-ui add button` runs the published Klean CLI for this invocation. The CLI:
+
+1. confirms that the current directory is a Sails application;
+2. detects Vue, React, or Svelte from `package.json` and the conventional application entry;
+3. resolves the conventional component and stylesheet paths;
+4. selects the matching framework-native registry source;
+5. checks for an existing or locally edited destination;
+6. copies the component and adds only the direct dependencies it imports;
+7. reports every file and dependency it changed.
+
+The CLI is a delivery tool. The installed component does not import a Klean runtime, and the application owns the copied file.
+
+## Conventional paths
+
+For a Boring Stack application, the framework determines the file—not a prompt:
+
+```text
+assets/js/components/ui/button/
+  Button.vue       Vue
+  Button.jsx       React
+  Button.svelte    Svelte
+```
+
+Only the detected framework's file is added. `assets/js/components/ui` is the component root, and `assets/css/app.css` is the stylesheet convention when a component genuinely needs CSS.
+
+## Zero configuration
+
+The standard path has no questions because the application already contains the answers:
+
+- Sails identifies the application shape;
+- installed framework packages and the application entry identify the framework;
+- Boring Stack directories identify component and stylesheet destinations;
+- the registry item declares its own files and direct dependencies.
+
+Ambiguous evidence is an error with an explanation. Klean does not guess silently or turn uncertainty into an interactive questionnaire.
+
+## Nonstandard applications
+
+Configuration is an escape hatch expressed at the point of use:
+
+```bash
+npx klean-ui add button --components-dir resources/js/ui
+```
+
+Use explicit flags for exceptional paths. Klean does not create a permanent project manifest just because one directory differs.
+
+## Safe re-runs
+
+Adding the same unchanged source is idempotent. If the destination was edited, Klean stops and shows the conflict instead of overwriting application-owned work. Use `--dry-run` to inspect the framework, paths, files, dependencies, and planned mutations before writing:
+
+```bash
+npx klean-ui add button --dry-run
+```
+
+Read the [CLI reference](/klean-ui/cli) for the complete command contract.

--- a/docs/klean-ui/snippets/button/products.vue
+++ b/docs/klean-ui/snippets/button/products.vue
@@ -1,0 +1,17 @@
+<script setup>
+import Button from '@/components/ui/button/Button.vue'
+</script>
+
+<template>
+  <!-- Hagfish owns this expressive motion. -->
+  <Button
+    class="border-2 border-black bg-black px-6 text-white hover:bg-white hover:text-black hover:shadow-[4px_4px_0_0_#000] active:translate-x-1 active:translate-y-1 active:shadow-none"
+  >
+    Send invoice
+  </Button>
+
+  <!-- Slipway stays compact and motionless. -->
+  <Button class="min-h-9 min-w-0 rounded-md px-3 py-1.5 text-sm">
+    Deploy
+  </Button>
+</template>

--- a/docs/klean-ui/snippets/button/semantics.vue
+++ b/docs/klean-ui/snippets/button/semantics.vue
@@ -1,0 +1,11 @@
+<script setup>
+import { Link } from '@inertiajs/vue3'
+import Button from '@/components/ui/button/Button.vue'
+</script>
+
+<template>
+  <Button type="button">Open dialog</Button>
+  <Button type="submit">Save changes</Button>
+  <Button as="a" href="https://sailsjs.com">Read Sails docs</Button>
+  <Button :as="Link" href="/projects">View projects</Button>
+</template>

--- a/docs/klean-ui/snippets/button/usage.vue
+++ b/docs/klean-ui/snippets/button/usage.vue
@@ -1,0 +1,7 @@
+<script setup>
+import Button from '@/components/ui/button/Button.vue'
+</script>
+
+<template>
+  <Button type="submit">Save changes</Button>
+</template>

--- a/docs/klean-ui/snippets/introduction/usage.vue
+++ b/docs/klean-ui/snippets/introduction/usage.vue
@@ -1,0 +1,7 @@
+<script setup>
+import Button from '@/components/ui/button/Button.vue'
+</script>
+
+<template>
+  <Button>Continue</Button>
+</template>

--- a/docs/klean-ui/theming.md
+++ b/docs/klean-ui/theming.md
@@ -1,0 +1,105 @@
+---
+title: Theming
+titleTemplate: Klean UI
+description: Theme Klean UI with application-owned CSS and Tailwind instead of providers, presets, or component variants.
+outline: [2, 3]
+---
+
+# Theming
+
+The application's CSS is the theme. Klean has no `ThemeProvider`, theme object, preset code, named theme catalog, or theme section in a configuration file.
+
+Neutral component defaults work without global Klean tokens. Products apply their visual language with ordinary Tailwind, and the copied source remains replaceable.
+
+## Three levels of styling
+
+### One local treatment: use classes
+
+```vue
+<Button class="bg-emerald-700 text-white hover:bg-emerald-800">
+  Approve invoice
+</Button>
+```
+
+### One repeated product concept: create a component
+
+```vue
+<!-- assets/js/components/PrimaryButton.vue -->
+<script setup>
+import Button from './ui/button/Button.vue'
+</script>
+
+<template>
+  <Button
+    class="min-h-11 bg-emerald-700 px-5 font-semibold text-white hover:bg-emerald-800"
+  >
+    <slot />
+  </Button>
+</template>
+```
+
+This is the normal replacement for `variant="primary"`. The product concept receives a product name and stays inside the product.
+
+### One shared value: use Tailwind's theme
+
+```css
+@import 'tailwindcss';
+
+@theme {
+  --color-brand: oklch(0.49 0.16 154);
+  --color-on-brand: oklch(0.985 0 0);
+}
+```
+
+```vue
+<Button class="bg-brand text-on-brand hover:bg-brand/90">
+  Approve invoice
+</Button>
+```
+
+The token creates Tailwind utilities. It does not create component variants.
+
+## Optional semantic foundations
+
+Applications with coordinated modes or white-label branding can define a short set of application-owned roles such as `canvas`, `ink`, `surface`, `muted`, `line`, and `focus`. Product signals should have paired foregrounds such as `brand` / `on-brand`.
+
+Avoid component-specific tokens such as `--button-primary-hover-background`. They recreate a variant matrix in CSS and make the primitive harder to replace.
+
+## Light and dark
+
+An application that follows the operating system can use Tailwind's ordinary `dark:` utilities. A manual switcher can expose one resolved mode on the root:
+
+```html
+<html data-mode="dark"></html>
+```
+
+```css
+@custom-variant dark (&:where([data-mode="dark"], [data-mode="dark"] *));
+```
+
+If the stored preference is `system`, application-owned code resolves the media query and writes `light` or `dark` before paint. A server-readable cookie is the right convention when SSR must avoid a flash.
+
+## Accessibility invariants
+
+Every product mode must preserve:
+
+- text, icon, boundary, and focus contrast;
+- states communicated by more than color;
+- readable disabled content;
+- reduced-motion behavior independently of theme;
+- native control rendering through the correct `color-scheme`;
+- useful forced-colors behavior.
+
+Klean does not guess contrast at runtime. Applications choose and test deliberate foreground/background pairs.
+
+## The decision rule
+
+| Question                                        | Use                              |
+| ----------------------------------------------- | -------------------------------- |
+| Is this unique here?                            | Direct Tailwind classes          |
+| Is this a repeated product concept?             | Application-owned component      |
+| Is this value shared across unrelated surfaces? | Tailwind `@theme` variable       |
+| Is this light/dark user state?                  | CSS plus one root mode attribute |
+| Does this change behavior?                      | A behavioral prop                |
+
+Do not tokenize a value merely because it exists.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,22 @@
 {
   "name": "sailscasts-docs",
-  "version": "1.20.7",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sailscasts-docs",
-      "version": "1.20.7",
+      "version": "1.21.0",
       "devDependencies": {
         "@commitlint/cli": "^20.1.0",
         "@commitlint/config-conventional": "^20.0.0",
+        "@tailwindcss/postcss": "^4.3.3",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.3",
+        "postcss": "^8.5.25",
         "prettier": "^3.6.2",
+        "tailwind-merge": "^3.6.0",
+        "tailwindcss": "^4.3.3",
         "vitepress": "^1.6.4",
         "vue": "^3.4.27"
       },
@@ -276,6 +280,19 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -668,6 +685,380 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.53",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.53.tgz",
@@ -685,6 +1076,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -692,10 +1115,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
-      "integrity": "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
@@ -707,9 +1161,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz",
-      "integrity": "sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
@@ -721,9 +1175,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz",
-      "integrity": "sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
@@ -735,9 +1189,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz",
-      "integrity": "sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
@@ -749,9 +1203,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz",
-      "integrity": "sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
@@ -763,9 +1217,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz",
-      "integrity": "sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
@@ -777,13 +1231,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz",
-      "integrity": "sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -791,13 +1248,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz",
-      "integrity": "sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -805,13 +1265,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz",
-      "integrity": "sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -819,13 +1282,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz",
-      "integrity": "sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,13 +1299,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz",
-      "integrity": "sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -847,13 +1333,33 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz",
-      "integrity": "sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -861,13 +1367,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz",
-      "integrity": "sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -875,13 +1384,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz",
-      "integrity": "sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,13 +1401,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz",
-      "integrity": "sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -903,13 +1418,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
-      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,9 +1435,26 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz",
-      "integrity": "sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
       "cpu": [
         "x64"
       ],
@@ -927,13 +1462,13 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
+        "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz",
-      "integrity": "sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
       "cpu": [
         "arm64"
       ],
@@ -945,9 +1480,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz",
-      "integrity": "sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
@@ -959,9 +1494,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz",
-      "integrity": "sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
@@ -973,9 +1508,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz",
-      "integrity": "sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
       "cpu": [
         "x64"
       ],
@@ -987,9 +1522,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz",
-      "integrity": "sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
@@ -1087,6 +1622,289 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
+      }
+    },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz",
@@ -1098,9 +1916,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1880,6 +2698,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -1921,6 +2749,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -1952,6 +2794,45 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -2114,6 +2995,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
@@ -2305,9 +3193,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2373,6 +3261,279 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lines-and-columns": {
@@ -2524,25 +3685,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2750,9 +3896,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -2911,9 +4057,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2931,7 +4077,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2975,21 +4121,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/regex": {
@@ -3072,6 +4203,52 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -3259,6 +4436,38 @@
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/text-extensions": {
       "version": "2.4.0",
@@ -3449,6 +4658,66 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitepress": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
@@ -3489,380 +4758,6 @@
         "postcss": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vitepress/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
@@ -3942,156 +4837,6 @@
           "optional": true
         },
         "universal-cookie": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitepress/node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/vitepress/node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
-      }
-    },
-    "node_modules/vitepress/node_modules/rollup": {
-      "version": "4.52.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
-      "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.3",
-        "@rollup/rollup-android-arm64": "4.52.3",
-        "@rollup/rollup-darwin-arm64": "4.52.3",
-        "@rollup/rollup-darwin-x64": "4.52.3",
-        "@rollup/rollup-freebsd-arm64": "4.52.3",
-        "@rollup/rollup-freebsd-x64": "4.52.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.3",
-        "@rollup/rollup-linux-arm64-musl": "4.52.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.3",
-        "@rollup/rollup-linux-x64-gnu": "4.52.3",
-        "@rollup/rollup-linux-x64-musl": "4.52.3",
-        "@rollup/rollup-openharmony-arm64": "4.52.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.3",
-        "@rollup/rollup-win32-x64-gnu": "4.52.3",
-        "@rollup/rollup-win32-x64-msvc": "4.52.3",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/vitepress/node_modules/vite": {
-      "version": "5.4.20",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
-      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,13 @@
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
+    "@tailwindcss/postcss": "^4.3.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.3",
+    "postcss": "^8.5.25",
     "prettier": "^3.6.2",
+    "tailwind-merge": "^3.6.0",
+    "tailwindcss": "^4.3.3",
     "vitepress": "^1.6.4",
     "vue": "^3.4.27"
   },

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {}
+  }
+}


### PR DESCRIPTION
## Summary

- add Klean UI to the open-source catalog and documentation navigation
- add framework-neutral introduction, doctrine, Durable UI, theming, installation, CLI, and component pages
- render the Button as a real button, native anchor, and Boring Stack navigation recipe
- isolate previews from VitePress prose styles with a Shadow DOM boundary
- highlight source with VitePress's build-time Shiki pipeline and provide accessible copy feedback
- keep recipes in ordinary Tailwind classes with no visual variant API or hidden theme utilities

## Merge dependency

The documentation describes the intended zero-configuration `npx klean-ui add button` contract. The actual installer and registry are tracked in [sailscastshq/klean-ui#5](https://github.com/sailscastshq/klean-ui/issues/5). Keep this PR in draft until that command is implemented, published, and verified against these docs.

## Validation

- `npm run lint`
- `npm run build`
- browser verification in light and dark themes
- native anchor navigation and keyboard-accessible preview/source tabs

Closes #136