### PR TITLE
docs: add Klean UI form foundation

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -113,7 +113,8 @@ function kleanUiGuide() {
       collapsed: false,
       items: [
         { text: 'Overview', link: '/klean-ui/components/' },
-        { text: 'Button', link: '/klean-ui/components/button' }
+        { text: 'Button', link: '/klean-ui/components/button' },
+        { text: 'Field', link: '/klean-ui/components/field' }
       ]
     },
     {

--- a/docs/.vitepress/theme/components/KleanInstallation.vue
+++ b/docs/.vitepress/theme/components/KleanInstallation.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { nextTick, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import CopyCode from './CopyCode.vue'
 
 const props = defineProps({
@@ -11,6 +11,10 @@ const props = defineProps({
     type: String,
     required: true
   },
+  component: {
+    type: String,
+    default: 'button'
+  },
   filename: {
     type: String,
     default: 'Button.vue'
@@ -18,6 +22,10 @@ const props = defineProps({
   destination: {
     type: String,
     default: 'assets/js/components/ui/button/Button.vue'
+  },
+  files: {
+    type: Array,
+    default: undefined
   }
 })
 
@@ -26,12 +34,40 @@ const methods = [
   { id: 'manual', label: 'Manual' }
 ]
 
-const packageManagers = [
-  { id: 'npm', label: 'npm', command: 'npx klean-ui add button' },
-  { id: 'pnpm', label: 'pnpm', command: 'pnpm dlx klean-ui add button' },
-  { id: 'yarn', label: 'yarn', command: 'yarn dlx klean-ui add button' },
-  { id: 'bun', label: 'bun', command: 'bunx klean-ui add button' }
-]
+const packageManagers = computed(() => [
+  {
+    id: 'npm',
+    label: 'npm',
+    command: `npx klean-ui add ${props.component}`
+  },
+  {
+    id: 'pnpm',
+    label: 'pnpm',
+    command: `pnpm dlx klean-ui add ${props.component}`
+  },
+  {
+    id: 'yarn',
+    label: 'yarn',
+    command: `yarn dlx klean-ui add ${props.component}`
+  },
+  {
+    id: 'bun',
+    label: 'bun',
+    command: `bunx klean-ui add ${props.component}`
+  }
+])
+
+const sourceFiles = computed(() =>
+  props.files?.length
+    ? props.files
+    : [
+        {
+          filename: props.filename,
+          destination: props.destination,
+          source: props.source
+        }
+      ]
+)
 
 const activeMethod = ref('command')
 const activePackageManager = ref('npm')
@@ -82,7 +118,7 @@ function selectMethod(method, focusTab = false) {
 
 function selectPackageManager(packageManager, focusTab = false) {
   activePackageManager.value = packageManager
-  selectTab(packageManager, packageManagerRefs, packageManagers, focusTab)
+  selectTab(packageManager, packageManagerRefs, packageManagers.value, focusTab)
 }
 </script>
 
@@ -185,13 +221,10 @@ function selectPackageManager(packageManager, focusTab = false) {
           <h3>Install the direct dependency</h3>
           <CopyCode code="npm install tailwind-merge" label="Terminal" />
         </li>
-        <li>
-          <h3>Copy the component source</h3>
-          <CopyCode :code="source" :label="filename" />
-        </li>
-        <li>
-          <h3>Save it at the conventional path</h3>
-          <CopyCode :code="destination" label="Destination" />
+        <li v-for="file in sourceFiles" :key="file.destination">
+          <h3>Copy {{ file.filename }}</h3>
+          <CopyCode :code="file.source" :label="file.filename" />
+          <CopyCode :code="file.destination" label="Destination" />
         </li>
       </ol>
     </section>

--- a/docs/.vitepress/theme/components/klean/field/Field.vue
+++ b/docs/.vitepress/theme/components/klean/field/Field.vue
@@ -1,0 +1,92 @@
+<script setup>
+import { computed, provide, useAttrs, useId } from 'vue'
+import { twMerge } from 'tailwind-merge'
+import { FIELD_CONTEXT_KEY } from './field-context.js'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** The native control ID shared by Label, Input, and Textarea. */
+  id: { type: String, default: undefined },
+  /** The native control name inherited by Input or Textarea. */
+  name: { type: String, default: undefined },
+  /** The visible native label for the control. */
+  label: { type: [String, Number], required: true },
+  /** Optional help text connected to the control. */
+  description: { type: [String, Number], default: undefined },
+  /** Optional server or application error connected to the control. */
+  error: { type: [String, Number], default: undefined },
+  /** Exposes the server-owned validation state to the field primitives. */
+  invalid: { type: Boolean, default: undefined },
+  /** Disables the field's native control. */
+  disabled: { type: Boolean, default: false },
+  /** Marks the field's native control as required. */
+  required: { type: Boolean, default: false }
+})
+
+const attrs = useAttrs()
+const generatedId = useId()
+const controlId = computed(() => props.id ?? generatedId)
+const descriptionId = computed(() => `${controlId.value}-description`)
+const errorId = computed(() => `${controlId.value}-error`)
+const resolvedInvalid = computed(() => props.invalid ?? Boolean(props.error))
+const describedBy = computed(
+  () =>
+    [
+      props.description !== undefined ? descriptionId.value : undefined,
+      props.error !== undefined ? errorId.value : undefined
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined
+)
+
+provide(FIELD_CONTEXT_KEY, {
+  controlId,
+  name: computed(() => props.name),
+  invalid: resolvedInvalid,
+  disabled: computed(() => props.disabled),
+  required: computed(() => props.required),
+  describedBy
+})
+
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+</script>
+
+<template>
+  <div
+    v-bind="forwardedAttrs"
+    data-slot="field"
+    :data-invalid="resolvedInvalid ? '' : undefined"
+    :data-disabled="disabled ? '' : undefined"
+    :class="twMerge('grid gap-2', attrs.class)"
+  >
+    <label
+      :for="controlId"
+      data-slot="label"
+      :data-disabled="disabled ? '' : undefined"
+      class="block text-sm font-medium leading-6 text-gray-950 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60 dark:text-white"
+    >
+      {{ label }}
+    </label>
+    <slot />
+    <p
+      v-if="description !== undefined"
+      :id="descriptionId"
+      data-slot="field-description"
+      class="text-sm leading-6 text-gray-600 dark:text-gray-400"
+    >
+      {{ description }}
+    </p>
+    <p
+      v-if="error !== undefined"
+      :id="errorId"
+      data-slot="field-error"
+      class="text-sm leading-6 text-red-700 dark:text-red-400"
+    >
+      {{ error }}
+    </p>
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/klean/field/field-context.js
+++ b/docs/.vitepress/theme/components/klean/field/field-context.js
@@ -1,0 +1,15 @@
+import { inject } from 'vue'
+
+export const FIELD_CONTEXT_KEY = Symbol.for('klean-ui.field')
+
+export function useFieldContext() {
+  return inject(FIELD_CONTEXT_KEY, null)
+}
+
+export function mergeDescribedBy(...values) {
+  const ids = values
+    .flatMap((value) => (value ? String(value).trim().split(/\s+/) : []))
+    .filter(Boolean)
+
+  return [...new Set(ids)].join(' ') || undefined
+}

--- a/docs/.vitepress/theme/components/klean/input/Input.vue
+++ b/docs/.vitepress/theme/components/klean/input/Input.vue
@@ -1,0 +1,106 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+import { mergeDescribedBy, useFieldContext } from '../field/field-context.js'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  modelValue: { type: [String, Number], default: undefined },
+  id: { type: String, default: undefined },
+  name: { type: String, default: undefined },
+  type: { type: String, default: 'text' },
+  disabled: { type: Boolean, default: undefined },
+  required: { type: Boolean, default: undefined }
+})
+const emit = defineEmits(['update:modelValue'])
+const attrs = useAttrs()
+const field = useFieldContext()
+const element = ref()
+let composing = false
+
+const resolvedId = computed(() => field?.controlId.value ?? props.id)
+const resolvedName = computed(() => props.name ?? field?.name.value)
+const resolvedDisabled = computed(
+  () => props.disabled ?? field?.disabled.value ?? false
+)
+const resolvedRequired = computed(
+  () => props.required ?? field?.required.value ?? false
+)
+const resolvedInvalid = computed(
+  () => attrs['aria-invalid'] ?? (field?.invalid.value ? 'true' : undefined)
+)
+const resolvedDescribedBy = computed(() =>
+  mergeDescribedBy(attrs['aria-describedby'], field?.describedBy.value)
+)
+const resolvedValue = computed(() => props.modelValue ?? attrs.value)
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    value: _value,
+    'aria-invalid': _ariaInvalid,
+    'aria-describedby': _ariaDescribedBy,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function updateValue(event) {
+  if (composing) return
+  const value = ['number', 'range'].includes(props.type)
+    ? event.target.value === ''
+      ? ''
+      : event.target.valueAsNumber
+    : event.target.value
+  emit('update:modelValue', value)
+}
+
+function finishComposition(event) {
+  composing = false
+  updateValue(event)
+}
+
+defineExpose({
+  element,
+  focus: (options) => element.value?.focus(options)
+})
+</script>
+
+<template>
+  <input
+    ref="element"
+    v-bind="forwardedAttrs"
+    :id="resolvedId"
+    :name="resolvedName"
+    :type="type"
+    :value="resolvedValue"
+    :disabled="resolvedDisabled"
+    :required="resolvedRequired"
+    :aria-invalid="resolvedInvalid"
+    :aria-describedby="resolvedDescribedBy"
+    :data-invalid="
+      resolvedInvalid === 'true' || resolvedInvalid === true ? '' : undefined
+    "
+    :data-disabled="resolvedDisabled ? '' : undefined"
+    data-slot="input"
+    :class="
+      twMerge(
+        [
+          'block min-h-11 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-base text-gray-950 shadow-sm outline-none transition-colors duration-150',
+          'placeholder:text-gray-500 hover:border-gray-400',
+          'focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950',
+          'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500',
+          'aria-invalid:border-red-600 aria-invalid:focus-visible:outline-red-600',
+          'dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-400 dark:hover:border-gray-600 dark:focus-visible:border-white dark:focus-visible:outline-white dark:disabled:bg-gray-900 dark:disabled:text-gray-500 dark:aria-invalid:border-red-500 dark:aria-invalid:focus-visible:outline-red-500',
+          'motion-reduce:transition-none'
+        ],
+        attrs.class
+      )
+    "
+    @compositionstart="composing = true"
+    @compositionend="finishComposition"
+    @input="updateValue"
+  />
+</template>

--- a/docs/.vitepress/theme/components/klean/label/Label.vue
+++ b/docs/.vitepress/theme/components/klean/label/Label.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { computed, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+import { useFieldContext } from '../field/field-context.js'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  for: { type: String, default: undefined }
+})
+const attrs = useAttrs()
+const field = useFieldContext()
+const resolvedFor = computed(() => field?.controlId.value ?? props.for)
+
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+</script>
+
+<template>
+  <label
+    v-bind="forwardedAttrs"
+    :for="resolvedFor"
+    data-slot="label"
+    :data-disabled="field?.disabled.value ? '' : undefined"
+    :class="
+      twMerge(
+        'block text-sm font-medium leading-6 text-gray-950 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </label>
+</template>

--- a/docs/.vitepress/theme/components/klean/textarea/Textarea.vue
+++ b/docs/.vitepress/theme/components/klean/textarea/Textarea.vue
@@ -1,0 +1,139 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+import { mergeDescribedBy, useFieldContext } from '../field/field-context.js'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  modelValue: { type: [String, Number], default: undefined },
+  id: { type: String, default: undefined },
+  name: { type: String, default: undefined },
+  disabled: { type: Boolean, default: undefined },
+  required: { type: Boolean, default: undefined }
+})
+const emit = defineEmits(['update:modelValue'])
+const attrs = useAttrs()
+const field = useFieldContext()
+const element = ref()
+let composing = false
+let resizeObserver
+
+const resolvedId = computed(() => field?.controlId.value ?? props.id)
+const resolvedName = computed(() => props.name ?? field?.name.value)
+const resolvedDisabled = computed(
+  () => props.disabled ?? field?.disabled.value ?? false
+)
+const resolvedRequired = computed(
+  () => props.required ?? field?.required.value ?? false
+)
+const resolvedInvalid = computed(
+  () => attrs['aria-invalid'] ?? (field?.invalid.value ? 'true' : undefined)
+)
+const resolvedDescribedBy = computed(() =>
+  mergeDescribedBy(attrs['aria-describedby'], field?.describedBy.value)
+)
+const resolvedValue = computed(() => props.modelValue ?? attrs.value)
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    value: _value,
+    'aria-invalid': _ariaInvalid,
+    'aria-describedby': _ariaDescribedBy,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function updateValue(event) {
+  if (composing) return
+  resizeToContent()
+  emit('update:modelValue', event.target.value)
+}
+
+function finishComposition(event) {
+  composing = false
+  updateValue(event)
+}
+
+function resizeToContent() {
+  if (!element.value) return
+
+  element.value.style.removeProperty('--klean-textarea-height')
+  element.value.style.setProperty(
+    '--klean-textarea-height',
+    `${element.value.scrollHeight}px`
+  )
+}
+
+onMounted(() => {
+  resizeToContent()
+
+  if (typeof ResizeObserver === 'undefined') return
+  let width = element.value.offsetWidth
+  resizeObserver = new ResizeObserver(([entry]) => {
+    if (entry.contentRect.width === width) return
+    width = entry.contentRect.width
+    resizeToContent()
+  })
+  resizeObserver.observe(element.value)
+})
+onBeforeUnmount(() => resizeObserver?.disconnect())
+
+watch(resolvedValue, async () => {
+  await nextTick()
+  resizeToContent()
+})
+
+defineExpose({
+  element,
+  focus: (options) => element.value?.focus(options),
+  resize: resizeToContent
+})
+</script>
+
+<template>
+  <textarea
+    ref="element"
+    v-bind="forwardedAttrs"
+    :id="resolvedId"
+    :name="resolvedName"
+    :value="resolvedValue"
+    :disabled="resolvedDisabled"
+    :required="resolvedRequired"
+    :aria-invalid="resolvedInvalid"
+    :aria-describedby="resolvedDescribedBy"
+    :data-invalid="
+      resolvedInvalid === 'true' || resolvedInvalid === true ? '' : undefined
+    "
+    :data-disabled="resolvedDisabled ? '' : undefined"
+    data-slot="textarea"
+    :class="
+      twMerge(
+        [
+          'block h-[var(--klean-textarea-height)] min-h-28 w-full resize-none overflow-y-hidden rounded-md border border-gray-300 bg-white px-3 py-2 text-base text-gray-950 shadow-sm outline-none transition-colors duration-150',
+          'placeholder:text-gray-500 hover:border-gray-400',
+          'focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950',
+          'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500',
+          'aria-invalid:border-red-600 aria-invalid:focus-visible:outline-red-600',
+          'dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-400 dark:hover:border-gray-600 dark:focus-visible:border-white dark:focus-visible:outline-white dark:disabled:bg-gray-900 dark:disabled:text-gray-500 dark:aria-invalid:border-red-500 dark:aria-invalid:focus-visible:outline-red-500',
+          'motion-reduce:transition-none'
+        ],
+        attrs.class
+      )
+    "
+    @compositionstart="composing = true"
+    @compositionend="finishComposition"
+    @input="updateValue"
+  />
+</template>

--- a/docs/klean-ui/cli.md
+++ b/docs/klean-ui/cli.md
@@ -11,6 +11,7 @@ The Klean CLI is a source installer for conventional Boring Stack applications:
 
 ```bash
 npx klean-ui add button
+npx klean-ui add field
 ```
 
 It has one job: place the right framework-native source in the right application path safely.
@@ -24,13 +25,15 @@ The CLI performs a deterministic pipeline:
 1. **Locate the application root.** Walk upward to the Sails `package.json`.
 2. **Detect the framework.** Inspect dependencies and the conventional frontend entry for reliable Vue, React, or Svelte evidence.
 3. **Resolve conventions.** Use `assets/js/components/ui` and, when needed, `assets/css/app.css`.
-4. **Resolve the registry item.** Read Button's manifest from the registry bundled with that CLI version.
-5. **Build a mutation plan.** Select only the detected framework's file and any direct dependencies it imports.
-6. **Check safety.** Compare an existing destination before any write.
-7. **Apply atomically where practical.** Create missing directories, copy source, add missing dependencies, and avoid partial state.
+4. **Resolve the registry item.** Read the requested manifest and its prerequisites from the registry bundled with that CLI version.
+5. **Build a mutation plan.** Select only the detected framework's files and any direct dependencies they import.
+6. **Check safety.** Compare every existing destination before any write.
+7. **Apply atomically where practical.** Create missing directories, copy all planned source, add missing dependencies, and avoid partial state.
 8. **Report the result.** Print the detected framework, resolved paths, added files, dependencies, skips, or conflicts.
 
 Bundling versioned registry metadata with the CLI keeps one invocation deterministic: the executable and the source it installs come from the same package version.
+
+Button contains one source file. Field expands to its complete native form foundation in dependency order. One conflicting target blocks that complete transaction before mutation.
 
 ## Detection
 

--- a/docs/klean-ui/components/field.md
+++ b/docs/klean-ui/components/field.md
@@ -1,0 +1,185 @@
+---
+title: Field
+titleTemplate: Klean UI
+description: A native Klean UI form foundation that wires labels, controls, descriptions, and errors together by convention.
+outline: [2, 3]
+---
+
+<script setup>
+import { computed, ref } from 'vue'
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
+import KleanField from '../../.vitepress/theme/components/klean/field/Field.vue'
+import KleanInput from '../../.vitepress/theme/components/klean/input/Input.vue'
+import KleanTextarea from '../../.vitepress/theme/components/klean/textarea/Textarea.vue'
+import fieldContextSource from '../../.vitepress/theme/components/klean/field/field-context.js?raw'
+import fieldSource from '../../.vitepress/theme/components/klean/field/Field.vue?raw'
+import inputSource from '../../.vitepress/theme/components/klean/input/Input.vue?raw'
+import labelSource from '../../.vitepress/theme/components/klean/label/Label.vue?raw'
+import textareaSource from '../../.vitepress/theme/components/klean/textarea/Textarea.vue?raw'
+import usageSource from '../snippets/field/usage.vue?raw'
+
+const email = ref('kelvin@')
+const note = ref('')
+const submitted = ref(false)
+const emailInvalid = computed(
+  () => submitted.value && !/^\S+@\S+\.\S+$/.test(email.value)
+)
+
+const fieldFiles = [
+  {
+    filename: 'field-context.js',
+    destination: 'assets/js/components/ui/field/field-context.js',
+    source: fieldContextSource
+  },
+  {
+    filename: 'Label.vue',
+    destination: 'assets/js/components/ui/label/Label.vue',
+    source: labelSource
+  },
+  {
+    filename: 'Input.vue',
+    destination: 'assets/js/components/ui/input/Input.vue',
+    source: inputSource
+  },
+  {
+    filename: 'Textarea.vue',
+    destination: 'assets/js/components/ui/textarea/Textarea.vue',
+    source: textareaSource
+  },
+  {
+    filename: 'Field.vue',
+    destination: 'assets/js/components/ui/field/Field.vue',
+    source: fieldSource
+  }
+]
+</script>
+
+# Field
+
+Field is Klean UI's native form convention. One component renders the real label and messages, generates their IDs before render, and shares the native control relationship. Input and Textarea remain real controls. Label, Input, and Textarea also remain independent primitives for forms that do not use Field.
+
+There are intentionally no `variant`, `size`, `tone`, `orientation`, floating-label, validation-rule, or theme props.
+
+<KleanPreview id="field-usage" :source="usageSource" filename="usage.vue">
+  <template #preview>
+    <form
+      class="grid w-full max-w-md gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-950"
+      novalidate
+      @submit.prevent="submitted = true"
+    >
+      <KleanField
+        name="email"
+        label="Email address"
+        description="We only use this for account messages."
+        :error="emailInvalid ? 'Enter a complete email address.' : undefined"
+        required
+      >
+        <KleanInput v-model="email" type="email" autocomplete="email" />
+      </KleanField>
+      <KleanField name="note" label="Internal note">
+        <KleanTextarea v-model="note" rows="3" placeholder="Optional context…" />
+      </KleanField>
+      <KleanButton type="submit">Check form</KleanButton>
+    </form>
+
+  </template>
+  <template #source>
+
+<<< ../snippets/field/usage.vue
+
+  </template>
+  <template #caption>
+    Submit once to reveal the server-style error state. Editing, validation, and
+    submission remain application concerns; Field owns only the relationship.
+  </template>
+</KleanPreview>
+
+## Installation
+
+Run one command. Klean detects Vue, React, or Svelte and installs Field, Label, Input, Textarea, and their small framework context in dependency order. There is no initializer, configuration file, alias prompt, or provider.
+
+<KleanInstallation
+  id="field-installation"
+  component="field"
+  :source="fieldSource"
+  filename="Field.vue"
+  :files="fieldFiles"
+/>
+
+The command is transactional. One conflicting destination stops the complete install before mutation; a later dependency failure restores every controlled file and removes atomic-write temporary files.
+
+## Usage
+
+<CopyCode :code="usageSource" label="usage.vue" />
+
+Set an explicit control ID on Field when you need one. Inside Field, the convention owns that relationship so you do not repeat matching `id` and `for` values across children.
+
+Label, Input, and Textarea also work independently with ordinary native attributes:
+
+```vue
+<Label for="search">Search</Label>
+<Input id="search" name="query" autocomplete="off" />
+```
+
+## API
+
+| Primitive  | Behavioral inputs                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------------- |
+| `Field`    | `id`, `name`, `label`, `description`, `error`, `invalid`, `disabled`, `required`, native attrs |
+| `Label`    | native `for` when standalone, native attrs, default slot                                       |
+| `Input`    | native input attrs, framework-native value binding, caller class                               |
+| `Textarea` | native textarea attrs, framework-native binding, caller class                                  |
+
+The generated relationships append caller-provided `aria-describedby` IDs rather than erasing them. Input and Textarea expose their native elements for imperative focus when recovery requires it.
+
+## Validation ownership
+
+The server and application own validation. Klean does not hide rules, touched state, formatting, debouncing, or submission inside the primitive.
+
+- validate after blur or submit rather than punishing untouched fields;
+- clear stale errors as soon as editing makes them obsolete;
+- keep `aria-invalid` synchronized through Field's `invalid` input;
+- use one form-level error summary when a failed submission needs announcement and recovery;
+- do not turn every inline error into an assertive live region.
+
+## Durable behavior
+
+These primitives implement [Durable UI](/klean-ui/durable-ui) without creating a second form store. The application restores authoritative server data, URL state, or a local draft through the framework's normal value binding. Field reconstructs its native label, invalid state, description, and error relationships from those current inputs. Clearing an error removes its stale `aria-describedby` ID immediately.
+
+Textarea derives its height from the current value on mount and after every value or responsive-width change. A restored draft therefore restores its presentation without Klean writing another localStorage record. Input and Textarea expose their native elements for explicit focus recovery after a failed submission.
+
+## Styling and density
+
+The defaults are neutral, monochrome, touch-safe, and visibly focusable. Input uses a 16px font to avoid mobile zoom. Textarea grows from its current value instead of showing the native resize handle, and recalculates when restored content or responsive width changes. Caller `h-*`, `max-h-*`, `overflow-y-auto`, or `resize-y` classes can take ownership without an `autoGrow` prop. Everything else is ordinary caller Tailwind:
+
+```vue
+<Input class="min-h-9 rounded-none border-2 py-1 text-sm shadow-none" />
+```
+
+Field exposes stable `data-slot` anatomy when its internal label or messages need application-owned styling:
+
+```vue
+<Field
+  label="Email"
+  :error="form.errors.email"
+  class="[&_[data-slot=label]]:sr-only [&_[data-slot=field-error]]:text-amber-700"
+>
+  <Input v-model="form.email" type="email" />
+</Field>
+```
+
+If the dense treatment repeats, create an application-owned component such as `DenseInput.vue`. Klean does not turn that product decision into a `size` prop or theme configuration.
+
+## Accessibility contract
+
+- Every control has a real associated Label.
+- Description and error IDs are deduplicated and connected with `aria-describedby`.
+- Caller ARIA and native attributes survive composition.
+- Disabled and required behavior stays native.
+- Error styling never replaces `aria-invalid`.
+- Field's error text is descriptive, not a separate live-region announcement.
+- Focus remains visible in light and dark contexts.
+- Motion-reduction preferences remove decorative transitions.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -17,6 +17,10 @@ Components do not share a visual variant API. Each page shows the behavioral con
 
 A native-first action primitive that can render a truthful button, anchor, or Boring Stack Link. It handles safe type defaults, disabled semantics, attribute forwarding, and caller-owned Tailwind classes.
 
+### [Field](/klean-ui/components/field)
+
+The native form foundation: Field, Label, Input, and Textarea. Field renders the common label and messages itself, generating accessible relationships by convention while validation, values, and every visual recipe remain application-owned.
+
 ## What belongs in the catalog
 
 A component graduates when it has:

--- a/docs/klean-ui/installation.md
+++ b/docs/klean-ui/installation.md
@@ -30,6 +30,8 @@ Klean installs readable component source into your application. There is no setu
 
 The CLI is a delivery tool. The installed component does not import a Klean runtime, and the application owns the copied file.
 
+Registry items may include prerequisites and more than one source file. For example, `npx klean-ui add field` installs Field, Label, Input, Textarea, and their small framework-native context as one transaction.
+
 ## Conventional paths
 
 For a Boring Stack application, the framework determines the file—not a prompt:

--- a/docs/klean-ui/snippets/field/usage.vue
+++ b/docs/klean-ui/snippets/field/usage.vue
@@ -1,0 +1,16 @@
+<script setup>
+import Field from '@/components/ui/field/Field.vue'
+import Input from '@/components/ui/input/Input.vue'
+</script>
+
+<template>
+  <Field
+    name="email"
+    label="Email address"
+    description="We only use this for account messages."
+    :error="form.errors.email"
+    required
+  >
+    <Input v-model="form.email" type="email" autocomplete="email" />
+  </Field>
+</template>


### PR DESCRIPTION
## Summary
- add Field under the Klean UI Components section
- render the live Vue source in an isolated VitePress preview with copyable usage and component files
- document the zero-configuration multi-file install, clean Field API, accessibility contract, styling anatomy, and Durable UI behavior

## Verification
- npm run build
- live VitePress preview at /klean-ui/components/field

Closes #140