### PR TITLE
Document stable Klean form relationships

### DIFF
--- a/docs/klean-ui/components/input.md
+++ b/docs/klean-ui/components/input.md
@@ -46,22 +46,17 @@ Klean deliberately does not supply Field, Label, description, or error component
           type="email"
           autocomplete="email"
           required
-          :aria-invalid="emailInvalid || undefined"
-          :aria-describedby="
-            emailInvalid
-              ? 'input-demo-help input-demo-error'
-              : 'input-demo-help'
-          "
+          :aria-invalid="emailInvalid"
+          aria-describedby="input-demo-help input-demo-error"
         />
         <p id="input-demo-help" class="text-sm text-gray-600 dark:text-gray-400">
           We only use this for account messages.
         </p>
         <p
-          v-if="emailInvalid"
           id="input-demo-error"
-          class="text-sm text-red-700 dark:text-red-400"
+          class="empty:hidden text-sm text-red-700 dark:text-red-400"
         >
-          Enter a complete email address.
+          {{ emailInvalid ? 'Enter a complete email address.' : '' }}
         </p>
       </div>
       <KleanButton type="submit">Check form</KleanButton>
@@ -94,9 +89,9 @@ One command installs one framework-native source file. There is no initializer, 
 
 <CopyCode :code="usageSource" label="usage.vue" />
 
-The application owns the visible label, deterministic IDs, help and error elements, validation timing, and submitted value. When both help and error are visible, `aria-describedby` names both IDs. Removing the error removes its stale ID at the same time.
+The application owns the visible label, deterministic IDs, help and error elements, validation timing, and submitted value. Help and error nodes keep stable IDs, so `aria-describedby` never needs conditional string building. `aria-invalid="false"` is valid, and `empty:hidden` collapses an empty error. When an error appears, the existing relationship becomes useful automatically.
 
-This explicit repetition is smaller and clearer than a Field configuration language. Extract an application-owned form composition only when your product repeats the same complete markup and policy.
+This explicit repetition is smaller and clearer than a Field configuration language or accessibility helper. Extract an application-owned form composition only when your product repeats the same complete markup and policy.
 
 ## API
 
@@ -119,7 +114,8 @@ If that dense treatment is a recurring product concept, create an application-ow
 - Every input needs a visible associated label unless the application has a justified accessible-name alternative.
 - Help and error text connect through `aria-describedby`.
 - Invalid state uses `aria-invalid`; color is never the only signal.
+- Stable empty errors remain unannounced until they contain useful text.
 - Native required and disabled behavior stays native.
 - Focus remains visible in light, dark, and high-contrast contexts.
 - Validation waits for blur or submission instead of punishing untouched input.
-- A failed submission that needs announcement uses one application-owned error summary and focus recovery.
+- A failed submission that needs announcement uses one application-owned error summary and focus recovery, not `role="alert"` on every inline error.

--- a/docs/klean-ui/components/textarea.md
+++ b/docs/klean-ui/components/textarea.md
@@ -17,6 +17,7 @@ import usageSource from '../snippets/textarea/usage.vue?raw'
 const note = ref(
   'This value represents a draft restored by the application.\n\nTextarea derives its height from the value already rendered.'
 )
+const noteError = ref('')
 </script>
 
 # Textarea
@@ -34,10 +35,17 @@ Textarea is a styled native control with one durable behavior: its presentation 
         v-model="note"
         name="note"
         rows="3"
-        aria-describedby="textarea-demo-help"
+        :aria-invalid="Boolean(noteError)"
+        aria-describedby="textarea-demo-help textarea-demo-error"
       />
       <p id="textarea-demo-help" class="text-sm text-gray-600 dark:text-gray-400">
         Edit the restored draft and watch the control follow its content.
+      </p>
+      <p
+        id="textarea-demo-error"
+        class="empty:hidden text-sm text-red-700 dark:text-red-400"
+      >
+        {{ noteError }}
       </p>
     </div>
   </template>
@@ -66,7 +74,7 @@ Textarea is a styled native control with one durable behavior: its presentation 
 
 <CopyCode :code="usageSource" label="usage.vue" />
 
-The surrounding label, help, error, IDs, validation, and value source remain ordinary application markup. There is no Field context or `autoGrow` switch.
+The surrounding label, help, error, IDs, validation, and value source remain ordinary application markup. Keep help and error nodes stable, bind `aria-invalid` to the boolean error state, and hide an empty error with `empty:hidden`. There is no Field context, accessibility helper, or `autoGrow` switch.
 
 ## Durable resizing
 
@@ -87,6 +95,7 @@ Textarea accepts native textarea attributes, framework-native value binding, and
 ## Accessibility contract
 
 - Use a real associated label and connect help or error text explicitly.
+- Keep description IDs stable instead of rebuilding them when an error changes.
 - Keep the native `name`, `required`, `disabled`, and form behavior.
 - Apply `aria-invalid` with useful visible error text.
 - Do not use placeholder text as the label.

--- a/docs/klean-ui/snippets/input/usage.vue
+++ b/docs/klean-ui/snippets/input/usage.vue
@@ -12,13 +12,11 @@ import Input from '@/components/ui/input/Input.vue'
       type="email"
       autocomplete="email"
       required
-      :aria-invalid="!!form.errors.email"
-      :aria-describedby="
-        form.errors.email ? 'email-help email-error' : 'email-help'
-      "
+      :aria-invalid="Boolean(form.errors.email)"
+      aria-describedby="email-help email-error"
     />
     <p id="email-help">We only use this for account messages.</p>
-    <p v-if="form.errors.email" id="email-error">
+    <p id="email-error" class="empty:hidden text-sm text-red-700">
       {{ form.errors.email }}
     </p>
   </div>

--- a/docs/klean-ui/snippets/textarea/usage.vue
+++ b/docs/klean-ui/snippets/textarea/usage.vue
@@ -10,8 +10,12 @@ import Textarea from '@/components/ui/textarea/Textarea.vue'
       v-model="form.note"
       name="note"
       rows="3"
-      aria-describedby="note-help"
+      :aria-invalid="Boolean(form.errors.note)"
+      aria-describedby="note-help note-error"
     />
     <p id="note-help">Plain text, up to 2,000 characters.</p>
+    <p id="note-error" class="empty:hidden text-sm text-red-700">
+      {{ form.errors.note }}
+    </p>
   </div>
 </template>


### PR DESCRIPTION
Closes #144

Updates the canonical Input and Textarea pages and copyable snippets to use stable native accessibility relationships without a helper abstraction.