### PR TITLE
docs: document Klean UI Popover

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -115,7 +115,8 @@ function kleanUiGuide() {
         { text: 'Overview', link: '/klean-ui/components/' },
         { text: 'Button', link: '/klean-ui/components/button' },
         { text: 'Input', link: '/klean-ui/components/input' },
-        { text: 'Textarea', link: '/klean-ui/components/textarea' }
+        { text: 'Textarea', link: '/klean-ui/components/textarea' },
+        { text: 'Popover', link: '/klean-ui/components/popover' }
       ]
     },
     {

--- a/docs/.vitepress/theme/components/KleanInstallation.vue
+++ b/docs/.vitepress/theme/components/KleanInstallation.vue
@@ -26,6 +26,10 @@ const props = defineProps({
   files: {
     type: Array,
     default: undefined
+  },
+  dependencies: {
+    type: Array,
+    default: () => ['tailwind-merge']
   }
 })
 
@@ -67,6 +71,10 @@ const sourceFiles = computed(() =>
           source: props.source
         }
       ]
+)
+
+const dependencyCommand = computed(
+  () => `npm install ${props.dependencies.join(' ')}`
 )
 
 const activeMethod = ref('command')
@@ -218,8 +226,8 @@ function selectPackageManager(packageManager, focusTab = false) {
     >
       <ol class="klean-installation__steps">
         <li>
-          <h3>Install the direct dependency</h3>
-          <CopyCode code="npm install tailwind-merge" label="Terminal" />
+          <h3>Install direct dependencies</h3>
+          <CopyCode :code="dependencyCommand" label="Terminal" />
         </li>
         <li v-for="file in sourceFiles" :key="file.destination">
           <h3>Copy {{ file.filename }}</h3>

--- a/docs/.vitepress/theme/components/klean/popover/Popover.vue
+++ b/docs/.vitepress/theme/components/klean/popover/Popover.vue
@@ -1,0 +1,325 @@
+<script setup>
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset as floatingOffset,
+  shift
+} from '@floating-ui/dom'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  useId,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Matches the native button's `popovertarget`. */
+  id: { type: String, default: undefined },
+  /** Framework-native controlled state. Omit for native uncontrolled use. */
+  open: { type: Boolean, default: undefined },
+  /** Initial state when `open` is not controlled. */
+  defaultOpen: { type: Boolean, default: false },
+  /** Preferred logical placement. Collision handling may flip it. */
+  placement: {
+    type: String,
+    default: 'bottom-start',
+    validator: (value) =>
+      [
+        'top',
+        'top-start',
+        'top-end',
+        'right',
+        'right-start',
+        'right-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'left',
+        'left-start',
+        'left-end'
+      ].includes(value)
+  },
+  /** Space in pixels between the invoker and floating surface. */
+  offset: { type: Number, default: 8 }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const generatedId = useId()
+const content = ref()
+const activeInvoker = ref()
+const internalOpen = ref(props.defaultOpen)
+const nativePopover = ref(false)
+const resolvedPlacement = ref(props.placement)
+const positionStyle = ref({ position: 'fixed', left: '0px', top: '0px' })
+let cleanupPosition = () => {}
+
+const isControlled = computed(() => props.open !== undefined)
+const isOpen = computed(() =>
+  isControlled.value ? props.open : internalOpen.value
+)
+const contentId = computed(
+  () =>
+    props.id ?? `klean-popover-${generatedId.replace(/[^a-zA-Z0-9_-]/g, '')}`
+)
+const contentAttrs = computed(() => {
+  const {
+    class: _class,
+    style: _style,
+    hidden: _hidden,
+    popover: _popover,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+const contentClasses = computed(() =>
+  twMerge(
+    [
+      'z-50 m-0 w-max max-w-[calc(100vw-1rem)] rounded-md border border-gray-200 bg-white p-4 text-gray-950 shadow-lg outline-none',
+      'dark:border-gray-700 dark:bg-gray-950 dark:text-white'
+    ],
+    attrs.class
+  )
+)
+
+function invokers() {
+  const root = content.value?.getRootNode?.() ?? document
+
+  return [...(root.querySelectorAll?.('[popovertarget]') ?? [])].filter(
+    (element) => element.getAttribute('popovertarget') === contentId.value
+  )
+}
+
+function eventPath(event) {
+  return event.composedPath?.() ?? [event.target]
+}
+
+function resolveInvoker(candidate) {
+  if (candidate?.getAttribute?.('popovertarget') === contentId.value) {
+    activeInvoker.value = candidate
+  }
+
+  if (!activeInvoker.value?.isConnected) {
+    activeInvoker.value = invokers()[0]
+  }
+
+  return activeInvoker.value
+}
+
+function syncInvokerAria() {
+  for (const invoker of invokers()) {
+    invoker.setAttribute('aria-controls', contentId.value)
+    invoker.setAttribute('aria-expanded', String(isOpen.value))
+  }
+}
+
+function popoverIsShowing() {
+  if (!content.value || !nativePopover.value) return false
+
+  try {
+    return content.value.matches(':popover-open')
+  } catch {
+    return false
+  }
+}
+
+function syncNativePopover() {
+  if (!content.value || !nativePopover.value) return
+
+  const showing = popoverIsShowing()
+
+  try {
+    if (isOpen.value && !showing) {
+      content.value.showPopover({ source: resolveInvoker() })
+    } else if (!isOpen.value && showing) {
+      content.value.hidePopover()
+    }
+  } catch {
+    // A rapid native toggle can briefly make the requested state redundant.
+  }
+}
+
+function setOpen(nextOpen, { restoreFocus = false } = {}) {
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+
+  nextTick(() => {
+    syncInvokerAria()
+    syncNativePopover()
+
+    const invoker = resolveInvoker()
+    if (!nextOpen && restoreFocus && invoker?.isConnected) {
+      invoker.focus({ preventScroll: true })
+    }
+  })
+}
+
+function close() {
+  setOpen(false, { restoreFocus: true })
+}
+
+function open() {
+  setOpen(true)
+}
+
+function handleNativeToggle(event) {
+  const nextOpen = event.newState === 'open'
+  const shouldRestoreFocus =
+    !nextOpen && event.source?.getAttribute?.('popovertargetaction') === 'hide'
+  if (nextOpen) resolveInvoker(event.source)
+  if (nextOpen === isOpen.value) return
+
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+  syncInvokerAria()
+
+  if (isControlled.value) nextTick(syncNativePopover)
+
+  if (shouldRestoreFocus) {
+    nextTick(() => {
+      const invoker = resolveInvoker()
+      if (invoker?.isConnected) invoker.focus({ preventScroll: true })
+    })
+  }
+}
+
+function matchingInvokerFromEvent(event) {
+  const candidate = eventPath(event).find(
+    (element) => element?.getAttribute?.('popovertarget') === contentId.value
+  )
+  return candidate?.getAttribute('popovertarget') === contentId.value
+    ? candidate
+    : undefined
+}
+
+function handleFallbackInvokerClick(event) {
+  const invoker = matchingInvokerFromEvent(event)
+  if (!invoker) return
+
+  resolveInvoker(invoker)
+  const action = invoker.getAttribute('popovertargetaction') ?? 'toggle'
+
+  if (action === 'show') setOpen(true)
+  else if (action === 'hide') setOpen(false, { restoreFocus: true })
+  else setOpen(!isOpen.value)
+}
+
+function handleOutsidePointer(event) {
+  const path = eventPath(event)
+
+  if (
+    path.includes(content.value) ||
+    invokers().some(
+      (invoker) => path.includes(invoker) || invoker.contains(event.target)
+    )
+  ) {
+    return
+  }
+
+  setOpen(false)
+}
+
+function handleEscape(event) {
+  if (event.key !== 'Escape') return
+
+  if (nativePopover.value) {
+    const openPopovers = [...document.querySelectorAll(':popover-open')]
+    if (openPopovers.at(-1) !== content.value) return
+  }
+
+  event.preventDefault()
+  setOpen(false, { restoreFocus: true })
+}
+
+async function updatePosition() {
+  const invoker = resolveInvoker()
+  if (!isOpen.value || !invoker || !content.value) return
+
+  const { x, y, placement } = await computePosition(invoker, content.value, {
+    placement: props.placement,
+    strategy: 'fixed',
+    middleware: [floatingOffset(props.offset), flip(), shift({ padding: 8 })]
+  })
+
+  resolvedPlacement.value = placement
+  positionStyle.value = {
+    position: 'fixed',
+    left: `${x}px`,
+    top: `${y}px`
+  }
+}
+
+function stopOpenEffects() {
+  cleanupPosition()
+  cleanupPosition = () => {}
+  document.removeEventListener('pointerdown', handleOutsidePointer, true)
+  document.removeEventListener('keydown', handleEscape)
+}
+
+async function syncOpenEffects() {
+  stopOpenEffects()
+  await nextTick()
+  syncInvokerAria()
+  syncNativePopover()
+
+  const invoker = resolveInvoker()
+  if (!isOpen.value || !invoker || !content.value) return
+
+  cleanupPosition = autoUpdate(invoker, content.value, updatePosition)
+
+  document.addEventListener('keydown', handleEscape)
+  document.addEventListener('pointerdown', handleOutsidePointer, true)
+}
+
+watch(() => [isOpen.value, props.placement, props.offset], syncOpenEffects, {
+  flush: 'post'
+})
+
+onMounted(() => {
+  nativePopover.value =
+    typeof content.value?.showPopover === 'function' &&
+    typeof content.value?.hidePopover === 'function'
+  resolveInvoker()
+  syncInvokerAria()
+
+  if (!nativePopover.value) {
+    document.addEventListener('click', handleFallbackInvokerClick)
+  }
+
+  syncOpenEffects()
+})
+
+onBeforeUnmount(() => {
+  stopOpenEffects()
+  document.removeEventListener('click', handleFallbackInvokerClick)
+})
+
+defineExpose({ content, close, open })
+</script>
+
+<template>
+  <div
+    ref="content"
+    v-bind="contentAttrs"
+    :id="contentId"
+    popover="auto"
+    :hidden="!nativePopover && !isOpen"
+    data-slot="popover-content"
+    :data-state="isOpen ? 'open' : 'closed'"
+    :data-placement="resolvedPlacement"
+    :class="contentClasses"
+    :style="[positionStyle, attrs.style]"
+    @toggle="handleNativeToggle"
+  >
+    <slot :open="isOpen" :close="close" />
+  </div>
+</template>

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -25,6 +25,10 @@ A styled native input that forwards native attributes and framework-native value
 
 A styled native textarea whose durable presentation grows from its current value and responsive width. Caller Tailwind can take ownership of height and resizing without a component prop.
 
+### [Popover](/klean-ui/components/popover)
+
+A native-first non-modal floating surface with light dismissal, focus return, collision-aware positioning, and ordinary semantic content. A real button invokes it through the browser's `popovertarget` relationship.
+
 ## What belongs in the catalog
 
 A component graduates when it has:

--- a/docs/klean-ui/components/popover.md
+++ b/docs/klean-ui/components/popover.md
@@ -1,0 +1,244 @@
+---
+title: Popover
+titleTemplate: Klean UI
+description: A native-first Klean UI floating surface with durable dismissal, focus return, and collision-aware positioning.
+outline: [2, 3]
+---
+
+<script setup>
+import { ref } from 'vue'
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
+import KleanPopover from '../../.vitepress/theme/components/klean/popover/Popover.vue'
+import popoverSource from '../../.vitepress/theme/components/klean/popover/Popover.vue?raw'
+import usageSource from '../snippets/popover/usage.vue?raw'
+import observedSource from '../snippets/popover/observed.vue?raw'
+import productSource from '../snippets/popover/products.vue?raw'
+
+const observedOpen = ref(false)
+</script>
+
+# Popover
+
+Popover is Klean UI's non-modal floating surface. The browser owns top-layer display, the native `popovertarget` relationship, light dismissal, and Escape behavior. Klean fills the remaining gaps: collision-aware placement, an older-browser fallback, reliable focus return, and framework-native observable state.
+
+The application owns the truthful content and every visual decision. There is no `PopoverTrigger`, `asChild`, `triggerClass`, visual variant, provider, or theme object.
+
+<KleanPreview id="popover-source" :source="popoverSource" filename="Popover.vue">
+  <template #preview>
+    <KleanButton popovertarget="docs-filters-popover">
+      Filters
+      <svg
+        aria-hidden="true"
+        class="size-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path d="m7 10 5 5 5-5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </KleanButton>
+    <KleanPopover id="docs-filters-popover" class="w-72">
+      <section aria-labelledby="docs-filters-title">
+        <h2 id="docs-filters-title" class="font-semibold">Visible records</h2>
+        <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400">
+          Choose which records appear in this view.
+        </p>
+        <label class="mt-4 flex items-center gap-3 text-sm">
+          <input type="checkbox" checked class="size-4 accent-gray-950" />
+          Active projects
+        </label>
+        <KleanButton
+          popovertarget="docs-filters-popover"
+          popovertargetaction="hide"
+          class="mt-5 w-full"
+        >
+          Done
+        </KleanButton>
+      </section>
+    </KleanPopover>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/popover/Popover.vue
+
+  </template>
+  <template #caption>
+    This preview runs inside an isolated Shadow DOM root. The native relationship,
+    Tailwind source, top-layer rendering, dismissal, and collision handling remain
+    intact.
+  </template>
+</KleanPreview>
+
+## Installation
+
+Run the same command in Vue, React, or Svelte. Klean detects the framework and conventional destination, writes one source file, and installs its direct dependencies.
+
+<KleanInstallation
+  id="popover-installation"
+  component="popover"
+  :source="popoverSource"
+  filename="Popover.vue"
+  destination="assets/js/components/ui/popover/Popover.vue"
+  :dependencies="['@floating-ui/dom', 'tailwind-merge']"
+/>
+
+`@floating-ui/dom` performs geometry only: logical placement, collision flipping, viewport shifting, and position updates. It is not a component runtime or styling system.
+
+## Usage
+
+<CopyCode :code="usageSource" label="usage.vue" />
+
+`popovertarget` and `id` are native HTML. A native button works too:
+
+```html
+<button type="button" popovertarget="filters">Filters</button>
+```
+
+Use a real button because opening interface content is an action. An anchor remains navigation and should not become a Popover invoker merely because it can be styled like a button.
+
+## API
+
+| Input                  | Default        | Purpose                                                                                  |
+| ---------------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| `id`                   | generated      | Native target identifier. Supply a stable value when a button invokes the Popover.       |
+| `placement`            | `bottom-start` | Preferred logical placement. It may flip or shift to remain visible.                     |
+| `offset`               | `8`            | Pixel distance between the invoker and surface.                                          |
+| framework open binding | uncontrolled   | Observe or control visibility only when application behavior genuinely needs it.         |
+| `defaultOpen`          | `false`        | Initial uncontrolled state, useful for composition and testing.                          |
+| `class` / `className`  | —              | Ordinary Tailwind classes merged last on the surface.                                    |
+| default content        | —              | Ordinary semantic application markup with framework-native access to `open` and `close`. |
+
+Vue uses `v-model:open`, React uses `open` with `onOpenChange`, and Svelte uses `bind:open`. The native uncontrolled relationship remains the default in every framework.
+
+Placement and offset describe geometry, not appearance. Popover has no `variant`, `tone`, `size`, `radius`, `elevation`, or animation props.
+
+## Closing the surface
+
+Prefer the native close action when a button only dismisses the surface:
+
+```vue
+<Button popovertarget="filters" popovertargetaction="hide">Done</Button>
+```
+
+Use the framework-native `close` value when an application action already runs code:
+
+```vue
+<Popover id="filters" v-slot="{ close }">
+  <Button @click="applyFilters(); close()">Apply</Button>
+</Popover>
+```
+
+Escape and explicit dismissal return focus to the connected invoker. Outside pointer dismissal leaves focus with the element the person selected instead of moving it unexpectedly.
+
+## Observable, never persisted
+
+Most Popovers need no application state. Observe visibility only when another part of the interface truly responds to it.
+
+<KleanPreview id="popover-observed" :source="observedSource" filename="observed.vue">
+  <template #preview>
+    <div class="grid justify-items-start gap-3">
+      <KleanButton popovertarget="docs-observed-popover">
+        Inspect filters
+      </KleanButton>
+      <KleanPopover
+        id="docs-observed-popover"
+        v-model:open="observedOpen"
+        class="w-64"
+      >
+        <p class="text-sm leading-6">
+          Observe visibility only when another part of the application needs it.
+        </p>
+      </KleanPopover>
+      <p aria-live="polite" class="text-sm text-gray-600 dark:text-gray-400">
+        Popover is {{ observedOpen ? 'open' : 'closed' }}.
+      </p>
+    </div>
+  </template>
+  <template #caption>
+    Open state is ephemeral. Never write it to local storage, session storage,
+    cookies, server data, or the URL. Persist a meaningful filter selection when
+    required—not the temporary surface visibility.
+  </template>
+</KleanPreview>
+
+## Popover is not every overlay
+
+- **Popover** is a generic non-modal surface. It leaves content in ordinary document tab order and assigns no role.
+- **Menu** composes this foundation with `menu` and `menuitem` semantics, arrow keys, Home/End, and typeahead.
+- **Dialog** is modal. It uses native dialog behavior, labeling, focus containment, and an inert background.
+- **Tooltip** describes a control on hover or focus and follows a different trigger and dismissal contract.
+
+Do not add `role="menu"` merely because a Popover contains several links or buttons. A list, navigation region, form, heading, or group of ordinary buttons is usually more truthful.
+
+## Product recipes
+
+Hagfish's share surface and Slipway's operational filters need the same interaction behavior but intentionally different visual language. Their Tailwind stays visible at the call site.
+
+<KleanPreview id="popover-products" :source="productSource" filename="product-popovers.vue">
+  <template #preview>
+    <div class="grid w-full max-w-2xl gap-8 sm:grid-cols-2">
+      <div class="bg-[#f4f0e8] p-6">
+        <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-600">
+          Hagfish / share
+        </p>
+        <KleanButton
+          popovertarget="docs-share-invoice"
+          class="rounded-none border-2 border-black bg-black text-white hover:bg-white hover:text-black"
+        >
+          Share invoice
+        </KleanButton>
+        <KleanPopover
+          id="docs-share-invoice"
+          class="w-80 rounded-none border-2 border-black p-5 shadow-[6px_6px_0_0_#000]"
+        >
+          <h2 class="font-semibold">Public invoice link</h2>
+          <p class="mt-2 break-all font-mono text-xs text-gray-600">
+            https://example.com/i/INV-1042
+          </p>
+        </KleanPopover>
+      </div>
+      <div class="dark bg-gray-950 p-6 text-white">
+        <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-400">
+          Slipway / filter
+        </p>
+        <KleanButton
+          popovertarget="docs-environment"
+          class="min-h-9 min-w-0 bg-gray-800 px-3 py-1.5 text-sm hover:bg-gray-700"
+        >
+          Environment
+        </KleanButton>
+        <KleanPopover
+          id="docs-environment"
+          class="w-64 border-gray-700 bg-gray-900 p-3 text-white shadow-xl"
+        >
+          <h2 class="px-2 py-1 text-xs font-medium uppercase tracking-wide text-gray-400">
+            Environment
+          </h2>
+          <label class="mt-2 flex items-center gap-3 rounded px-2 py-2 text-sm">
+            <input type="checkbox" checked class="size-4" /> Production
+          </label>
+        </KleanPopover>
+      </div>
+    </div>
+
+  </template>
+  <template #caption>
+    Every visual choice is ordinary Tailwind. There are no Klean variants or
+    hidden theme utilities.
+  </template>
+</KleanPreview>
+
+## Accessibility and Durable UI contract
+
+- The invoker is a real button with native keyboard activation.
+- `aria-controls` and `aria-expanded` stay synchronized automatically.
+- Escape and light dismissal work without trapping focus or locking page scroll.
+- Explicit and keyboard dismissal restore focus only when the invoker still exists.
+- Global listeners and position observers exist only while the surface is open and are cleaned up on unmount.
+- Popover assigns no Menu or Dialog role; the application's semantic content remains visible in its markup.
+- Open state is ephemeral. Meaningful state inside the surface follows the [Durable UI contract](/klean-ui/durable-ui).
+- Visual treatment follows the application-owned [theming convention](/klean-ui/theming).

--- a/docs/klean-ui/snippets/popover/observed.vue
+++ b/docs/klean-ui/snippets/popover/observed.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref } from 'vue'
+import Button from '~/components/ui/button/Button.vue'
+import Popover from '~/components/ui/popover/Popover.vue'
+
+const filtersOpen = ref(false)
+</script>
+
+<template>
+  <Button popovertarget="observed-filters">Inspect filters</Button>
+  <Popover id="observed-filters" v-model:open="filtersOpen" class="w-64">
+    <p class="text-sm leading-6">
+      Observe visibility only when another part of the application needs it.
+    </p>
+  </Popover>
+
+  <p aria-live="polite" class="text-sm text-gray-600">
+    Popover is {{ filtersOpen ? 'open' : 'closed' }}.
+  </p>
+</template>

--- a/docs/klean-ui/snippets/popover/products.vue
+++ b/docs/klean-ui/snippets/popover/products.vue
@@ -1,0 +1,47 @@
+<script setup>
+import Button from '~/components/ui/button/Button.vue'
+import Popover from '~/components/ui/popover/Popover.vue'
+</script>
+
+<template>
+  <div>
+    <Button
+      popovertarget="share-invoice"
+      class="rounded-none border-2 border-black bg-black text-white hover:bg-white hover:text-black"
+    >
+      Share invoice
+    </Button>
+    <Popover
+      id="share-invoice"
+      class="w-80 rounded-none border-2 border-black p-5 shadow-[6px_6px_0_0_#000]"
+    >
+      <h2 id="share-title" class="font-semibold">Public invoice link</h2>
+      <p class="mt-2 break-all font-mono text-xs text-gray-600">
+        https://example.com/i/INV-1042
+      </p>
+    </Popover>
+  </div>
+
+  <div class="dark bg-gray-950 p-6 text-white">
+    <Button
+      popovertarget="environment"
+      class="min-h-9 min-w-0 bg-gray-800 px-3 py-1.5 text-sm hover:bg-gray-700"
+    >
+      Environment
+    </Button>
+    <Popover
+      id="environment"
+      class="w-64 border-gray-700 bg-gray-900 p-3 text-white shadow-xl"
+    >
+      <h2
+        id="env-title"
+        class="px-2 py-1 text-xs font-medium uppercase tracking-wide text-gray-400"
+      >
+        Environment
+      </h2>
+      <label class="mt-2 flex items-center gap-3 rounded px-2 py-2 text-sm">
+        <input type="checkbox" checked class="size-4" /> Production
+      </label>
+    </Popover>
+  </div>
+</template>

--- a/docs/klean-ui/snippets/popover/usage.vue
+++ b/docs/klean-ui/snippets/popover/usage.vue
@@ -1,0 +1,21 @@
+<script setup>
+import Button from '~/components/ui/button/Button.vue'
+import Popover from '~/components/ui/popover/Popover.vue'
+</script>
+
+<template>
+  <Button popovertarget="filters">Filters</Button>
+
+  <Popover id="filters" class="w-72">
+    <section aria-labelledby="filters-title">
+      <h2 id="filters-title" class="font-semibold">Visible records</h2>
+      <p class="mt-1 text-sm text-gray-600">
+        Choose which records appear in this view.
+      </p>
+      <label class="mt-4 flex items-center gap-3 text-sm">
+        <input type="checkbox" checked class="size-4 accent-gray-950" />
+        Active projects
+      </label>
+    </section>
+  </Popover>
+</template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.1.0",
         "@commitlint/config-conventional": "^20.0.0",
+        "@floating-ui/dom": "^1.8.0",
         "@tailwindcss/postcss": "^4.3.3",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.3",
@@ -1058,6 +1059,34 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.53",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
+    "@floating-ui/dom": "^1.8.0",
     "@tailwindcss/postcss": "^4.3.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.3",


### PR DESCRIPTION
## Summary

- add Popover to the Klean UI Components section on docs.sailscasts.com
- render an isolated live preview with complete copyable source
- document zero-config installation, native HTML usage, the framework-neutral API, product recipes, accessibility, and the Durable UI contract
- teach the shared installation block to show component-specific direct dependencies

## Verification

- `npm run lint`
- `npm run build`
- live browser checks in dark mode and at 390px, with no page overflow or console warnings
- verified source and manual installation tabs

Related to sailscastshq/klean-ui#20
Closes #147
