### PR TITLE
Document Klean UI Menu

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -116,7 +116,8 @@ function kleanUiGuide() {
         { text: 'Button', link: '/klean-ui/components/button' },
         { text: 'Input', link: '/klean-ui/components/input' },
         { text: 'Textarea', link: '/klean-ui/components/textarea' },
-        { text: 'Popover', link: '/klean-ui/components/popover' }
+        { text: 'Popover', link: '/klean-ui/components/popover' },
+        { text: 'Menu', link: '/klean-ui/components/menu' }
       ]
     },
     {

--- a/docs/.vitepress/theme/components/klean/menu/Menu.vue
+++ b/docs/.vitepress/theme/components/klean/menu/Menu.vue
@@ -1,0 +1,364 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+import Popover from '../popover/Popover.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Matches the native button's `popovertarget`. */
+  id: { type: String, default: undefined },
+  /** Framework-native controlled state. Omit for native uncontrolled use. */
+  open: { type: Boolean, default: undefined },
+  /** Initial state when `open` is not controlled. */
+  defaultOpen: { type: Boolean, default: false },
+  /** Preferred logical placement. Collision handling may flip it. */
+  placement: { type: String, default: 'bottom-start' },
+  /** Space in pixels between the invoker and menu. */
+  offset: { type: Number, default: 8 }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const popover = ref()
+const internalOpen = ref(props.defaultOpen)
+const activeInvoker = ref()
+const isControlled = computed(() => props.open !== undefined)
+const isOpen = computed(() =>
+  isControlled.value ? props.open : internalOpen.value
+)
+const menuAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    tabindex: _tabindex,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+const menuClasses = computed(() => twMerge('min-w-40 p-1', attrs.class))
+
+let interactionRoot
+let itemObserver
+let pendingFocus = 'first'
+let restoreOnClose = false
+let typeahead = ''
+let typeaheadTimer
+
+function contentElement() {
+  const exposed = popover.value?.content
+  return exposed?.value ?? exposed
+}
+
+function eventPath(event) {
+  return event.composedPath?.() ?? [event.target]
+}
+
+function invokers() {
+  const content = contentElement()
+  const root = content?.getRootNode?.() ?? document
+
+  return [...(root.querySelectorAll?.('[popovertarget]') ?? [])].filter(
+    (element) => element.getAttribute('popovertarget') === content?.id
+  )
+}
+
+function syncInvokerSemantics() {
+  for (const invoker of invokers()) {
+    invoker.setAttribute('aria-haspopup', 'menu')
+  }
+}
+
+function matchingInvoker(event) {
+  const id = contentElement()?.id
+  return eventPath(event).find(
+    (element) => element?.getAttribute?.('popovertarget') === id
+  )
+}
+
+function rememberInvoker(event) {
+  const invoker = matchingInvoker(event)
+  if (invoker) activeInvoker.value = invoker
+}
+
+function restoreInvokerFocus() {
+  const invoker = activeInvoker.value?.isConnected
+    ? activeInvoker.value
+    : invokers()[0]
+  invoker?.focus?.({ preventScroll: true })
+}
+
+function itemRole(element) {
+  return ['menuitem', 'menuitemcheckbox', 'menuitemradio'].includes(
+    element.getAttribute('role')
+  )
+}
+
+function menuItems() {
+  const content = contentElement()
+  if (!content) return []
+
+  for (const element of content.querySelectorAll('button, a[href]')) {
+    if (!element.hasAttribute('role')) element.setAttribute('role', 'menuitem')
+  }
+
+  const items = [
+    ...content.querySelectorAll(
+      '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+    )
+  ].filter((element) => element.closest('[role="menu"]') === content)
+
+  for (const item of items) item.tabIndex = -1
+  return items
+}
+
+function itemIsDisabled(item) {
+  return (
+    item.matches(':disabled') ||
+    item.getAttribute('aria-disabled') === 'true' ||
+    item.hidden ||
+    item.closest('[hidden]') !== null
+  )
+}
+
+function enabledItems() {
+  return menuItems().filter((item) => !itemIsDisabled(item))
+}
+
+function focusedElement() {
+  return (
+    contentElement()?.getRootNode?.().activeElement ?? document.activeElement
+  )
+}
+
+function focusItem(item) {
+  if (!item) return
+  for (const candidate of menuItems()) candidate.tabIndex = -1
+  item.tabIndex = 0
+  item.focus({ preventScroll: true })
+}
+
+function focusEdge(edge = 'first') {
+  const items = enabledItems()
+  const item = edge === 'last' ? items.at(-1) : items[0]
+  if (item) focusItem(item)
+  else contentElement()?.focus({ preventScroll: true })
+}
+
+function clearTypeahead() {
+  typeahead = ''
+  clearTimeout(typeaheadTimer)
+  typeaheadTimer = undefined
+}
+
+function normalizedText(item) {
+  return (item.getAttribute('aria-label') ?? item.textContent ?? '')
+    .trim()
+    .toLocaleLowerCase()
+}
+
+function handleTypeahead(event) {
+  if (
+    event.key.length !== 1 ||
+    event.key === ' ' ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  clearTimeout(typeaheadTimer)
+  typeahead += event.key.toLocaleLowerCase()
+  typeaheadTimer = setTimeout(clearTypeahead, 500)
+
+  const items = enabledItems()
+  if (!items.length) return true
+  const current = items.indexOf(focusedElement())
+  const ordered = [...items.slice(current + 1), ...items.slice(0, current + 1)]
+  let match = ordered.find((item) => normalizedText(item).startsWith(typeahead))
+
+  if (!match && new Set(typeahead).size === 1) {
+    typeahead = typeahead.at(-1)
+    match = ordered.find((item) => normalizedText(item).startsWith(typeahead))
+  }
+
+  if (match) focusItem(match)
+  return true
+}
+
+function requestOpen(nextOpen) {
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+}
+
+function openMenu(edge = 'first') {
+  pendingFocus = edge
+  if (isOpen.value) focusEdge(edge)
+  else requestOpen(true)
+}
+
+function closeMenu({ restoreFocus = false } = {}) {
+  restoreOnClose ||= restoreFocus
+  if (isOpen.value) requestOpen(false)
+  else if (restoreOnClose) {
+    restoreOnClose = false
+    nextTick(restoreInvokerFocus)
+  }
+}
+
+function handlePopoverOpen(nextOpen) {
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+}
+
+function handleInvokerKeydown(event) {
+  const invoker = matchingInvoker(event)
+  if (!invoker || invoker.matches(':disabled')) return
+  activeInvoker.value = invoker
+
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(event.key === 'ArrowUp' ? 'last' : 'first')
+  }
+}
+
+function itemFromEvent(event) {
+  const content = contentElement()
+  return eventPath(event).find(
+    (element) =>
+      element?.nodeType === Node.ELEMENT_NODE &&
+      itemRole(element) &&
+      element.closest?.('[role="menu"]') === content
+  )
+}
+
+function handleClick(event) {
+  const item = itemFromEvent(event)
+  if (!item) return
+
+  if (itemIsDisabled(item)) {
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    return
+  }
+
+  closeMenu({ restoreFocus: true })
+}
+
+function handleKeydown(event) {
+  const items = enabledItems()
+  const currentIndex = items.indexOf(focusedElement())
+  let nextIndex
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    closeMenu({ restoreFocus: true })
+    return
+  }
+
+  if (event.key === 'Tab') {
+    clearTypeahead()
+    closeMenu()
+    return
+  }
+
+  if (event.key === 'ArrowDown') {
+    nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+  } else if (event.key === 'ArrowUp') {
+    nextIndex =
+      currentIndex < 0
+        ? items.length - 1
+        : (currentIndex - 1 + items.length) % items.length
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = items.length - 1
+  } else if (handleTypeahead(event)) {
+    return
+  } else {
+    return
+  }
+
+  if (!items.length) return
+  event.preventDefault()
+  focusItem(items[nextIndex])
+}
+
+watch(
+  isOpen,
+  async (nextOpen) => {
+    await nextTick()
+    syncInvokerSemantics()
+
+    if (nextOpen) {
+      focusEdge(pendingFocus)
+      pendingFocus = 'first'
+      return
+    }
+
+    clearTypeahead()
+    menuItems()
+    if (restoreOnClose) restoreInvokerFocus()
+    restoreOnClose = false
+  },
+  { flush: 'post' }
+)
+
+onMounted(async () => {
+  await nextTick()
+  const content = contentElement()
+  interactionRoot = content?.getRootNode?.() ?? document
+  interactionRoot.addEventListener('keydown', handleInvokerKeydown)
+  interactionRoot.addEventListener('click', rememberInvoker, true)
+  syncInvokerSemantics()
+  menuItems()
+
+  if (typeof MutationObserver !== 'undefined' && content) {
+    itemObserver = new MutationObserver(menuItems)
+    itemObserver.observe(content, { childList: true, subtree: true })
+  }
+
+  if (isOpen.value) focusEdge(pendingFocus)
+})
+
+onBeforeUnmount(() => {
+  clearTypeahead()
+  itemObserver?.disconnect()
+  interactionRoot?.removeEventListener('keydown', handleInvokerKeydown)
+  interactionRoot?.removeEventListener('click', rememberInvoker, true)
+})
+
+defineExpose({ close: closeMenu, open: openMenu })
+</script>
+
+<template>
+  <Popover
+    ref="popover"
+    v-bind="menuAttrs"
+    :id="id"
+    :open="isOpen"
+    :placement="placement"
+    :offset="offset"
+    role="menu"
+    tabindex="-1"
+    data-slot="menu"
+    :class="menuClasses"
+    @update:open="handlePopoverOpen"
+    @click.capture="handleClick"
+    @keydown="handleKeydown"
+  >
+    <slot :open="isOpen" :close="closeMenu" />
+  </Popover>
+</template>

--- a/docs/.vitepress/theme/components/klean/popover/Popover.vue
+++ b/docs/.vitepress/theme/components/klean/popover/Popover.vue
@@ -90,6 +90,7 @@ const contentClasses = computed(() =>
     attrs.class
   )
 )
+const dataSlot = computed(() => attrs['data-slot'] ?? 'popover-content')
 
 function invokers() {
   const root = content.value?.getRootNode?.() ?? document
@@ -313,7 +314,7 @@ defineExpose({ content, close, open })
     :id="contentId"
     popover="auto"
     :hidden="!nativePopover && !isOpen"
-    data-slot="popover-content"
+    :data-slot="dataSlot"
     :data-state="isOpen ? 'open' : 'closed'"
     :data-placement="resolvedPlacement"
     :class="contentClasses"

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -29,6 +29,10 @@ A styled native textarea whose durable presentation grows from its current value
 
 A native-first non-modal floating surface with light dismissal, focus return, collision-aware positioning, and ordinary semantic content. A real button invokes it through the browser's `popovertarget` relationship.
 
+### [Menu](/klean-ui/components/menu)
+
+An accessible list of truthful button actions and link destinations built on Klean Popover. It adds roving focus, Arrow keys, Home/End, typeahead, disabled-item behavior, selection, and durable focus return while caller Tailwind owns the product treatment.
+
 ## What belongs in the catalog
 
 A component graduates when it has:

--- a/docs/klean-ui/components/menu.md
+++ b/docs/klean-ui/components/menu.md
@@ -1,0 +1,277 @@
+---
+title: Menu
+titleTemplate: Klean UI
+description: A native-Popover Klean UI menu with truthful buttons and links, roving focus, typeahead, and caller-owned Tailwind.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
+import KleanMenu from '../../.vitepress/theme/components/klean/menu/Menu.vue'
+import menuSource from '../../.vitepress/theme/components/klean/menu/Menu.vue?raw'
+import popoverSource from '../../.vitepress/theme/components/klean/popover/Popover.vue?raw'
+import reactMenuSource from '../sources/menu/Menu.jsx?raw'
+import svelteMenuSource from '../sources/menu/Menu.svelte?raw'
+import vueUsage from '../snippets/menu/usage.vue?raw'
+import reactUsage from '../snippets/menu/usage.jsx?raw'
+import svelteUsage from '../snippets/menu/usage.svelte?raw'
+import productSource from '../snippets/menu/products.vue?raw'
+
+const vueFiles = [
+  {
+    filename: 'Popover.vue',
+    destination: 'assets/js/components/ui/popover/Popover.vue',
+    source: popoverSource
+  },
+  {
+    filename: 'Menu.vue',
+    destination: 'assets/js/components/ui/menu/Menu.vue',
+    source: menuSource
+  }
+]
+</script>
+
+# Menu
+
+Menu is an accessible list of actions and navigation destinations. It composes Klean [Popover](/klean-ui/components/popover), so the browser still owns native top-layer display and light dismissal. Menu adds the missing composite behavior: `menu` and `menuitem` semantics, one roving focus stop, Arrow keys, Home/End, printable-key typeahead, disabled-item handling, selection, and reliable cleanup.
+
+The application supplies real buttons and links plus ordinary Tailwind. There is no `MenuTrigger`, `MenuItem`, item-data schema, `asChild`, visual variant, provider, or theme object.
+
+<KleanPreview id="menu-source" :source="menuSource" filename="Menu.vue">
+  <template #preview>
+    <KleanButton popovertarget="docs-project-actions">
+      Actions
+      <svg
+        aria-hidden="true"
+        class="size-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path d="m7 10 5 5 5-5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </KleanButton>
+    <KleanMenu
+      id="docs-project-actions"
+      aria-label="Project actions"
+      class="w-60"
+    >
+      <button
+        type="button"
+        class="flex w-full rounded px-3 py-2 text-left text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 focus:text-gray-950 dark:text-gray-200 dark:hover:bg-white/10 dark:focus:bg-white/10"
+      >
+        Edit project
+      </button>
+      <a
+        href="#truthful-items"
+        class="flex w-full rounded px-3 py-2 text-sm text-gray-700 no-underline outline-none hover:bg-gray-100 focus:bg-gray-100 focus:text-gray-950 dark:text-gray-200 dark:hover:bg-white/10 dark:focus:bg-white/10"
+      >
+        View deployments
+      </a>
+      <button
+        type="button"
+        disabled
+        class="flex w-full cursor-not-allowed rounded px-3 py-2 text-left text-sm text-gray-400 outline-none"
+      >
+        Archive project
+      </button>
+      <button
+        type="button"
+        class="flex w-full rounded px-3 py-2 text-left text-sm text-red-700 outline-none hover:bg-red-50 focus:bg-red-50 focus:text-red-800 dark:text-red-400 dark:hover:bg-red-500/10 dark:focus:bg-red-500/10"
+      >
+        Delete project
+      </button>
+    </KleanMenu>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/menu/Menu.vue
+
+  </template>
+  <template #caption>
+    This preview runs inside an isolated Shadow DOM root. Click Actions, then try
+    Arrow Up/Down, Home/End, typing “d”, and Escape. The children remain real
+    buttons and an anchor.
+  </template>
+</KleanPreview>
+
+## Installation
+
+Run the same command in Vue, React, or Svelte. Klean detects the framework and conventional destination, then installs Popover first when it is missing.
+
+<KleanInstallation
+  id="menu-installation"
+  component="menu"
+  :source="menuSource"
+  filename="Menu.vue"
+  destination="assets/js/components/ui/menu/Menu.vue"
+  :files="vueFiles"
+  :dependencies="['@floating-ui/dom', 'tailwind-merge']"
+/>
+
+The dependency is source-level, not configuration: `Menu` imports its sibling `Popover`. The registry resolves that prerequisite before Menu and installs only the direct packages their readable source imports. No initializer, `klean-ui.json`, public `cn.js`, alias prompt, or Klean runtime appears.
+
+## Usage
+
+### Vue
+
+<CopyCode :code="vueUsage" label="ProjectActions.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="ProjectActions.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="ProjectActions.svelte" />
+
+The framework syntax changes; the HTML contract does not. A real button uses native `popovertarget`. Native button and anchor children become menu items automatically, so developers do not repeat roles or tab indices.
+
+## Truthful items
+
+Use a native button when selection performs an action:
+
+```vue
+<button type="button" class="..." @click="redeploy">Redeploy</button>
+```
+
+Use an anchor for navigation. The Boring Stack Link renders an anchor too, so it works without an adapter:
+
+```vue
+<Link href="/projects/42/settings" class="...">Project settings</Link>
+```
+
+Menu does not accept an item array because an array forces the component to guess whether each record is a button, anchor, download, or framework Link. Authorization, conditional visibility, event handlers, and destinations remain obvious in application markup.
+
+### Disabled items
+
+A disabled action uses the native `disabled` attribute and is skipped during keyboard navigation. A navigation item that must remain visible can use `aria-disabled="true"`; Menu prevents activation and skips it. Prefer hiding unauthorized items in application logic instead of teaching Menu about permissions.
+
+```vue
+<button
+  type="button"
+  disabled
+  class="disabled:cursor-not-allowed disabled:opacity-40"
+>
+  Stop provisioning
+</button>
+```
+
+## API
+
+| Input                  | Default        | Purpose                                                                          |
+| ---------------------- | -------------- | -------------------------------------------------------------------------------- |
+| `id`                   | generated      | Native target identifier. Supply a stable value when a button invokes the Menu.  |
+| `placement`            | `bottom-start` | Preferred logical placement. It may flip or shift to remain visible.             |
+| `offset`               | `8`            | Pixel distance between the invoker and menu.                                     |
+| framework open binding | uncontrolled   | Observe or control visibility only when application behavior genuinely needs it. |
+| `defaultOpen`          | `false`        | Initial uncontrolled visibility, mainly useful for examples and tests.           |
+| `class` / `className`  | —              | Ordinary Tailwind classes merged last on the menu surface.                       |
+| default content        | —              | Native buttons, anchors, or framework links.                                     |
+
+Vue uses `v-model:open`, React uses `open` with `onOpenChange`, and Svelte uses `bind:open`. Placement and offset are geometry, not appearance. Menu has no `variant`, `tone`, `size`, `inset`, `destructive`, animation, or theme props.
+
+## Keyboard and focus
+
+- Click, Enter, or Space on the real trigger opens and focuses the first enabled item.
+- Arrow Down on the trigger opens at the first enabled item; Arrow Up opens at the last.
+- Arrow Down and Arrow Up wrap between enabled items.
+- Home and End move to the first and last enabled items.
+- Printable characters use a short buffered typeahead against visible text or `aria-label`.
+- Enter and Space activation remain native to the real button or anchor, avoiding double firing.
+- Escape closes and restores focus to the invoker.
+- Selection closes and restores focus; link navigation may then move to the destination.
+- Tab closes without pulling focus backward.
+- Outside interaction closes without stealing focus from the selected target.
+
+The vertical key contract is the same in right-to-left documents. Menu adds no animation, so reduced-motion users get a stable surface by default. Product motion, if useful, belongs in caller Tailwind and must use `motion-safe:` or an equivalent fallback.
+
+## Menu is not every floating list
+
+- **Menu** is a composite widget of actions and destinations with arrow navigation and typeahead.
+- **Popover** holds ordinary forms, filters, help, or previews and keeps normal Tab order.
+- **Select** chooses one value and has selected-option behavior.
+- **Combobox** combines text input, filtering, and an option popup.
+- **Dialog** is modal, contains focus, and makes the background inert.
+
+Website navigation remains a semantic `nav` and list of links with ordinary Tab behavior. Do not add Menu roles merely because navigation appears in a floating surface.
+
+## Product recipes
+
+Slipway needs compact operational actions; Hagfish needs a stronger border and offset shadow. Those are caller recipes, not Klean themes.
+
+<KleanPreview id="menu-products" :source="productSource" filename="product-menus.vue">
+  <template #preview>
+    <div class="grid w-full max-w-2xl gap-8 sm:grid-cols-2">
+      <div class="bg-[#f4f0e8] p-6">
+        <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-600">
+          Hagfish / invoice
+        </p>
+        <KleanButton
+          popovertarget="docs-invoice-actions"
+          class="rounded-none border-2 border-black bg-black text-white hover:bg-white hover:text-black"
+        >
+          Invoice actions
+        </KleanButton>
+        <KleanMenu
+          id="docs-invoice-actions"
+          aria-label="Invoice actions"
+          class="w-64 rounded-none border-2 border-black p-2 shadow-[6px_6px_0_0_#000]"
+        >
+          <a href="#product-recipes" class="flex w-full border-2 border-transparent px-3 py-2 text-sm font-medium text-black no-underline outline-none hover:border-black focus:border-black">Preview invoice</a>
+          <button type="button" class="flex w-full border-2 border-transparent px-3 py-2 text-left text-sm font-medium text-red-700 outline-none hover:border-red-700 focus:border-red-700">Void invoice</button>
+        </KleanMenu>
+      </div>
+      <div class="dark bg-gray-950 p-6 text-white">
+        <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-400">
+          Slipway / deploy
+        </p>
+        <KleanButton
+          popovertarget="docs-deploy-actions"
+          class="min-h-9 min-w-0 bg-gray-800 px-3 py-1.5 text-sm hover:bg-gray-700"
+        >
+          Actions
+        </KleanButton>
+        <KleanMenu
+          id="docs-deploy-actions"
+          aria-label="Deployment actions"
+          class="w-52 border-gray-700 bg-gray-900 p-1 text-white shadow-xl"
+        >
+          <button type="button" class="flex w-full rounded px-2 py-2 text-left text-sm text-gray-200 outline-none hover:bg-white/10 focus:bg-white/10">Redeploy</button>
+          <a href="#product-recipes" class="flex w-full rounded px-2 py-2 text-sm text-gray-200 no-underline outline-none hover:bg-white/10 focus:bg-white/10">View logs</a>
+          <button type="button" disabled class="flex w-full cursor-not-allowed rounded px-2 py-2 text-left text-sm text-gray-500 outline-none">Stop provisioning</button>
+        </KleanMenu>
+      </div>
+    </div>
+  </template>
+  <template #caption>
+    Every visual choice is visible Tailwind at the call site. The same Menu
+    behavior carries both products without a variant or theme selector.
+  </template>
+</KleanPreview>
+
+## Complete framework source
+
+The preview Source tab contains the complete Vue component. The equivalent framework-native React and Svelte sources are copyable here; both import their local Klean Popover and preserve the same behavior contract.
+
+### React source
+
+<CopyCode :code="reactMenuSource" label="Menu.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteMenuSource" label="Menu.svelte" />
+
+## Accessibility and Durable UI contract
+
+- The invoker remains a real button and automatically receives `aria-haspopup="menu"`, `aria-controls`, and synchronized `aria-expanded`.
+- Button and anchor children keep their truthful native activation while Menu supplies composite roles and roving focus.
+- Disabled items cannot activate and never become the active roving focus stop.
+- Escape and selection restore focus only when the invoker still exists; Tab and outside interaction do not steal focus.
+- Shadow DOM, RTL, dynamic items, listener cleanup, observer cleanup, and typeahead-timer cleanup are part of the tested contract.
+- Menu open state is ephemeral and is never written to storage, cookies, server data, or the URL.
+- Meaningful state selected from a menu follows the [Durable UI contract](/klean-ui/durable-ui); appearance follows the application-owned [theming convention](/klean-ui/theming).

--- a/docs/klean-ui/installation.md
+++ b/docs/klean-ui/installation.md
@@ -30,7 +30,7 @@ Klean installs readable component source into your application. There is no setu
 
 The CLI is a delivery tool. The installed component does not import a Klean runtime, and the application owns the copied file.
 
-Registry items may include prerequisites and more than one source file for future compound interactions. Button, Input, and Textarea are deliberately self-contained today: adding one installs one component source file.
+Registry items may include prerequisites and more than one source file. Button, Input, and Textarea are deliberately self-contained. Popover installs its focused geometry dependencies, and `npx klean-ui add menu` resolves Popover first before writing Menu. The full plan stays visible with `--dry-run`; prerequisite handling adds no configuration step.
 
 ## Conventional paths
 

--- a/docs/klean-ui/snippets/menu/products.vue
+++ b/docs/klean-ui/snippets/menu/products.vue
@@ -1,0 +1,73 @@
+<script setup>
+import Button from '~/components/ui/button/Button.vue'
+import Menu from '~/components/ui/menu/Menu.vue'
+</script>
+
+<template>
+  <div class="bg-[#f4f0e8] p-6">
+    <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-600">
+      Hagfish / invoice
+    </p>
+    <Button
+      popovertarget="invoice-actions"
+      class="rounded-none border-2 border-black bg-black text-white hover:bg-white hover:text-black"
+    >
+      Invoice actions
+    </Button>
+    <Menu
+      id="invoice-actions"
+      aria-label="Invoice actions"
+      class="w-64 rounded-none border-2 border-black p-2 shadow-[6px_6px_0_0_#000]"
+    >
+      <a
+        href="/invoices/42"
+        class="flex w-full border-2 border-transparent px-3 py-2 text-sm font-medium text-black no-underline outline-none hover:border-black focus:border-black"
+      >
+        Preview invoice
+      </a>
+      <button
+        type="button"
+        class="flex w-full border-2 border-transparent px-3 py-2 text-left text-sm font-medium text-red-700 outline-none hover:border-red-700 focus:border-red-700"
+      >
+        Void invoice
+      </button>
+    </Menu>
+  </div>
+
+  <div class="dark bg-gray-950 p-6 text-white">
+    <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-400">
+      Slipway / deploy
+    </p>
+    <Button
+      popovertarget="deploy-actions"
+      class="min-h-9 min-w-0 bg-gray-800 px-3 py-1.5 text-sm hover:bg-gray-700"
+    >
+      Actions
+    </Button>
+    <Menu
+      id="deploy-actions"
+      aria-label="Deployment actions"
+      class="w-52 border-gray-700 bg-gray-900 p-1 text-white shadow-xl"
+    >
+      <button
+        type="button"
+        class="flex w-full rounded px-2 py-2 text-left text-sm text-gray-200 outline-none hover:bg-white/10 focus:bg-white/10"
+      >
+        Redeploy
+      </button>
+      <a
+        href="/deployments/42/logs"
+        class="flex w-full rounded px-2 py-2 text-sm text-gray-200 no-underline outline-none hover:bg-white/10 focus:bg-white/10"
+      >
+        View logs
+      </a>
+      <button
+        type="button"
+        disabled
+        class="flex w-full cursor-not-allowed rounded px-2 py-2 text-left text-sm text-gray-500 outline-none"
+      >
+        Stop provisioning
+      </button>
+    </Menu>
+  </div>
+</template>

--- a/docs/klean-ui/snippets/menu/usage.jsx
+++ b/docs/klean-ui/snippets/menu/usage.jsx
@@ -1,0 +1,25 @@
+import Button from '~/components/ui/button/Button.jsx'
+import Menu from '~/components/ui/menu/Menu.jsx'
+
+export default function ProjectActions() {
+  return (
+    <>
+      <Button popovertarget="project-actions">Actions</Button>
+
+      <Menu id="project-actions" aria-label="Project actions" className="w-56">
+        <button
+          type="button"
+          className="flex w-full rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
+        >
+          Redeploy
+        </button>
+        <a
+          href="/deployments"
+          className="flex w-full rounded px-3 py-2 text-sm no-underline outline-none hover:bg-gray-100 focus:bg-gray-100"
+        >
+          View deployments
+        </a>
+      </Menu>
+    </>
+  )
+}

--- a/docs/klean-ui/snippets/menu/usage.svelte
+++ b/docs/klean-ui/snippets/menu/usage.svelte
@@ -1,0 +1,21 @@
+<script>
+  import Button from '~/components/ui/button/Button.svelte'
+  import Menu from '~/components/ui/menu/Menu.svelte'
+</script>
+
+<Button popovertarget="project-actions">Actions</Button>
+
+<Menu id="project-actions" aria-label="Project actions" class="w-56">
+  <button
+    type="button"
+    class="flex w-full rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
+  >
+    Redeploy
+  </button>
+  <a
+    href="/deployments"
+    class="flex w-full rounded px-3 py-2 text-sm no-underline outline-none hover:bg-gray-100 focus:bg-gray-100"
+  >
+    View deployments
+  </a>
+</Menu>

--- a/docs/klean-ui/snippets/menu/usage.vue
+++ b/docs/klean-ui/snippets/menu/usage.vue
@@ -1,0 +1,23 @@
+<script setup>
+import Button from '~/components/ui/button/Button.vue'
+import Menu from '~/components/ui/menu/Menu.vue'
+</script>
+
+<template>
+  <Button popovertarget="project-actions">Actions</Button>
+
+  <Menu id="project-actions" aria-label="Project actions" class="w-56">
+    <button
+      type="button"
+      class="flex w-full rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
+    >
+      Redeploy
+    </button>
+    <a
+      href="/deployments"
+      class="flex w-full rounded px-3 py-2 text-sm no-underline outline-none hover:bg-gray-100 focus:bg-gray-100"
+    >
+      View deployments
+    </a>
+  </Menu>
+</template>

--- a/docs/klean-ui/sources/menu/Menu.jsx
+++ b/docs/klean-ui/sources/menu/Menu.jsx
@@ -1,0 +1,382 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react'
+import { twMerge } from 'tailwind-merge'
+import Popover from '../popover/Popover.jsx'
+
+const ITEM_SELECTOR =
+  '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+
+function eventPath(event) {
+  return (
+    event.nativeEvent?.composedPath?.() ??
+    event.composedPath?.() ?? [event.target]
+  )
+}
+
+function itemRole(element) {
+  return ['menuitem', 'menuitemcheckbox', 'menuitemradio'].includes(
+    element.getAttribute('role')
+  )
+}
+
+function itemIsDisabled(item) {
+  return (
+    item.matches(':disabled') ||
+    item.getAttribute('aria-disabled') === 'true' ||
+    item.hidden ||
+    item.closest('[hidden]') !== null
+  )
+}
+
+const Menu = forwardRef(function Menu(
+  {
+    id,
+    open: controlledOpen,
+    defaultOpen = false,
+    onOpenChange,
+    placement = 'bottom-start',
+    offset = 8,
+    className,
+    children,
+    onKeyDown,
+    onClickCapture,
+    ...contentProps
+  },
+  forwardedRef
+) {
+  const popoverRef = useRef(null)
+  const activeInvoker = useRef(null)
+  const pendingFocus = useRef('first')
+  const restoreOnClose = useRef(false)
+  const typeahead = useRef('')
+  const typeaheadTimer = useRef()
+  const [internalOpen, setInternalOpen] = useState(defaultOpen)
+  const isControlled = controlledOpen !== undefined
+  const isOpen = isControlled ? controlledOpen : internalOpen
+  const latestOpen = useRef(isOpen)
+  latestOpen.current = isOpen
+
+  const contentElement = useCallback(() => popoverRef.current?.content, [])
+
+  const invokers = useCallback(() => {
+    const content = contentElement()
+    const root = content?.getRootNode?.() ?? document
+
+    return [...(root.querySelectorAll?.('[popovertarget]') ?? [])].filter(
+      (element) => element.getAttribute('popovertarget') === content?.id
+    )
+  }, [contentElement])
+
+  const syncInvokerSemantics = useCallback(() => {
+    for (const invoker of invokers()) {
+      invoker.setAttribute('aria-haspopup', 'menu')
+    }
+  }, [invokers])
+
+  const matchingInvoker = useCallback(
+    (event) => {
+      const contentId = contentElement()?.id
+      return eventPath(event).find(
+        (element) => element?.getAttribute?.('popovertarget') === contentId
+      )
+    },
+    [contentElement]
+  )
+
+  const restoreInvokerFocus = useCallback(() => {
+    const invoker = activeInvoker.current?.isConnected
+      ? activeInvoker.current
+      : invokers()[0]
+    invoker?.focus?.({ preventScroll: true })
+  }, [invokers])
+
+  const menuItems = useCallback(() => {
+    const content = contentElement()
+    if (!content) return []
+
+    for (const element of content.querySelectorAll('button, a[href]')) {
+      if (!element.hasAttribute('role'))
+        element.setAttribute('role', 'menuitem')
+    }
+
+    const items = [...content.querySelectorAll(ITEM_SELECTOR)].filter(
+      (element) => element.closest('[role="menu"]') === content
+    )
+    for (const item of items) item.tabIndex = -1
+    return items
+  }, [contentElement])
+
+  const enabledItems = useCallback(
+    () => menuItems().filter((item) => !itemIsDisabled(item)),
+    [menuItems]
+  )
+
+  const focusedElement = useCallback(
+    () =>
+      contentElement()?.getRootNode?.().activeElement ?? document.activeElement,
+    [contentElement]
+  )
+
+  const focusItem = useCallback(
+    (item) => {
+      if (!item) return
+      for (const candidate of menuItems()) candidate.tabIndex = -1
+      item.tabIndex = 0
+      item.focus({ preventScroll: true })
+    },
+    [menuItems]
+  )
+
+  const focusEdge = useCallback(
+    (edge = 'first') => {
+      const items = enabledItems()
+      const item = edge === 'last' ? items.at(-1) : items[0]
+      if (item) focusItem(item)
+      else contentElement()?.focus({ preventScroll: true })
+    },
+    [contentElement, enabledItems, focusItem]
+  )
+
+  const clearTypeahead = useCallback(() => {
+    typeahead.current = ''
+    clearTimeout(typeaheadTimer.current)
+    typeaheadTimer.current = undefined
+  }, [])
+
+  const requestOpen = useCallback(
+    (nextOpen) => {
+      if (!isControlled) setInternalOpen(nextOpen)
+      onOpenChange?.(nextOpen)
+    },
+    [isControlled, onOpenChange]
+  )
+
+  const openMenu = useCallback(
+    (edge = 'first') => {
+      pendingFocus.current = edge
+      if (latestOpen.current) focusEdge(edge)
+      else requestOpen(true)
+    },
+    [focusEdge, requestOpen]
+  )
+
+  const closeMenu = useCallback(
+    ({ restoreFocus = false } = {}) => {
+      restoreOnClose.current ||= restoreFocus
+      if (latestOpen.current) requestOpen(false)
+      else if (restoreOnClose.current) {
+        restoreOnClose.current = false
+        queueMicrotask(restoreInvokerFocus)
+      }
+    },
+    [requestOpen, restoreInvokerFocus]
+  )
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({ content: contentElement(), open: openMenu, close: closeMenu }),
+    [closeMenu, contentElement, openMenu]
+  )
+
+  useEffect(() => {
+    syncInvokerSemantics()
+
+    if (isOpen) {
+      focusEdge(pendingFocus.current)
+      pendingFocus.current = 'first'
+      return
+    }
+
+    clearTypeahead()
+    menuItems()
+    if (restoreOnClose.current) restoreInvokerFocus()
+    restoreOnClose.current = false
+  }, [
+    clearTypeahead,
+    focusEdge,
+    isOpen,
+    menuItems,
+    restoreInvokerFocus,
+    syncInvokerSemantics
+  ])
+
+  useEffect(() => {
+    const content = contentElement()
+    const root = content?.getRootNode?.() ?? document
+
+    function rememberInvoker(event) {
+      const invoker = matchingInvoker(event)
+      if (invoker) activeInvoker.current = invoker
+    }
+
+    function handleInvokerKeydown(event) {
+      const invoker = matchingInvoker(event)
+      if (!invoker || invoker.matches(':disabled')) return
+      activeInvoker.current = invoker
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        openMenu(event.key === 'ArrowUp' ? 'last' : 'first')
+      }
+    }
+
+    root.addEventListener('keydown', handleInvokerKeydown)
+    root.addEventListener('click', rememberInvoker, true)
+    syncInvokerSemantics()
+    menuItems()
+
+    const observer =
+      typeof MutationObserver !== 'undefined' && content
+        ? new MutationObserver(menuItems)
+        : undefined
+    observer?.observe(content, { childList: true, subtree: true })
+
+    return () => {
+      observer?.disconnect()
+      root.removeEventListener('keydown', handleInvokerKeydown)
+      root.removeEventListener('click', rememberInvoker, true)
+      clearTypeahead()
+    }
+  }, [
+    clearTypeahead,
+    contentElement,
+    matchingInvoker,
+    menuItems,
+    openMenu,
+    syncInvokerSemantics
+  ])
+
+  function itemFromEvent(event) {
+    const content = contentElement()
+    return eventPath(event).find(
+      (element) =>
+        element?.nodeType === 1 &&
+        itemRole(element) &&
+        element.closest?.('[role="menu"]') === content
+    )
+  }
+
+  function handleClick(event) {
+    const item = itemFromEvent(event)
+    if (!item) {
+      onClickCapture?.(event)
+      return
+    }
+
+    if (itemIsDisabled(item)) {
+      event.preventDefault()
+      event.nativeEvent.stopImmediatePropagation()
+      return
+    }
+
+    closeMenu({ restoreFocus: true })
+    onClickCapture?.(event)
+  }
+
+  function handleTypeahead(event) {
+    if (
+      event.key.length !== 1 ||
+      event.key === ' ' ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey
+    ) {
+      return false
+    }
+
+    event.preventDefault()
+    clearTimeout(typeaheadTimer.current)
+    typeahead.current += event.key.toLocaleLowerCase()
+    typeaheadTimer.current = setTimeout(clearTypeahead, 500)
+
+    const items = enabledItems()
+    if (!items.length) return true
+    const current = items.indexOf(focusedElement())
+    const ordered = [
+      ...items.slice(current + 1),
+      ...items.slice(0, current + 1)
+    ]
+    const itemText = (item) =>
+      (item.getAttribute('aria-label') ?? item.textContent ?? '')
+        .trim()
+        .toLocaleLowerCase()
+    let match = ordered.find((item) =>
+      itemText(item).startsWith(typeahead.current)
+    )
+
+    if (!match && new Set(typeahead.current).size === 1) {
+      typeahead.current = typeahead.current.at(-1)
+      match = ordered.find((item) =>
+        itemText(item).startsWith(typeahead.current)
+      )
+    }
+
+    if (match) focusItem(match)
+    return true
+  }
+
+  function handleKeydown(event) {
+    const items = enabledItems()
+    const currentIndex = items.indexOf(focusedElement())
+    let nextIndex
+
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      closeMenu({ restoreFocus: true })
+    } else if (event.key === 'Tab') {
+      clearTypeahead()
+      closeMenu()
+    } else if (event.key === 'ArrowDown') {
+      nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+    } else if (event.key === 'ArrowUp') {
+      nextIndex =
+        currentIndex < 0
+          ? items.length - 1
+          : (currentIndex - 1 + items.length) % items.length
+    } else if (event.key === 'Home') {
+      nextIndex = 0
+    } else if (event.key === 'End') {
+      nextIndex = items.length - 1
+    } else if (!handleTypeahead(event)) {
+      onKeyDown?.(event)
+      return
+    }
+
+    if (nextIndex !== undefined && items.length) {
+      event.preventDefault()
+      focusItem(items[nextIndex])
+    }
+    onKeyDown?.(event)
+  }
+
+  return (
+    <Popover
+      {...contentProps}
+      ref={popoverRef}
+      id={id}
+      open={isOpen}
+      onOpenChange={requestOpen}
+      placement={placement}
+      offset={offset}
+      role="menu"
+      tabIndex={-1}
+      data-slot="menu"
+      className={twMerge('min-w-40 p-1', className)}
+      onClickCapture={handleClick}
+      onKeyDown={handleKeydown}
+    >
+      {typeof children === 'function'
+        ? children({ open: isOpen, close: closeMenu })
+        : children}
+    </Popover>
+  )
+})
+
+export default Menu

--- a/docs/klean-ui/sources/menu/Menu.svelte
+++ b/docs/klean-ui/sources/menu/Menu.svelte
@@ -1,0 +1,319 @@
+<script>
+  import { onMount, untrack } from "svelte";
+  import { twMerge } from "tailwind-merge";
+  import Popover from "../popover/Popover.svelte";
+
+  let {
+    id,
+    open = $bindable(),
+    defaultOpen = false,
+    onOpenChange,
+    placement = "bottom-start",
+    offset = 8,
+    class: className = "",
+    children,
+    onkeydown,
+    onclickcapture,
+    ...contentProps
+  } = $props();
+
+  let popoverElement = $state();
+  let internalOpen = $state(untrack(() => defaultOpen));
+  let activeInvoker = $state();
+  let isOpen = $derived(open ?? internalOpen);
+  let pendingFocus = "first";
+  let restoreOnClose = false;
+  let typeahead = "";
+  let typeaheadTimer;
+
+  function contentElement() {
+    return popoverElement?.getContent?.();
+  }
+
+  function eventPath(event) {
+    return event.composedPath?.() ?? [event.target];
+  }
+
+  function invokers() {
+    const content = contentElement();
+    const root = content?.getRootNode?.() ?? document;
+
+    return [...(root.querySelectorAll?.("[popovertarget]") ?? [])].filter(
+      (element) => element.getAttribute("popovertarget") === content?.id,
+    );
+  }
+
+  function syncInvokerSemantics() {
+    for (const invoker of invokers()) {
+      invoker.setAttribute("aria-haspopup", "menu");
+    }
+  }
+
+  function matchingInvoker(event) {
+    const contentId = contentElement()?.id;
+    return eventPath(event).find(
+      (element) => element?.getAttribute?.("popovertarget") === contentId,
+    );
+  }
+
+  function restoreInvokerFocus() {
+    const invoker = activeInvoker?.isConnected ? activeInvoker : invokers()[0];
+    invoker?.focus?.({ preventScroll: true });
+  }
+
+  function itemRole(element) {
+    return ["menuitem", "menuitemcheckbox", "menuitemradio"].includes(
+      element.getAttribute("role"),
+    );
+  }
+
+  function menuItems() {
+    const content = contentElement();
+    if (!content) return [];
+
+    for (const element of content.querySelectorAll("button, a[href]")) {
+      if (!element.hasAttribute("role")) element.setAttribute("role", "menuitem");
+    }
+
+    const items = [
+      ...content.querySelectorAll(
+        '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]',
+      ),
+    ].filter((element) => element.closest('[role="menu"]') === content);
+
+    for (const item of items) item.tabIndex = -1;
+    return items;
+  }
+
+  function itemIsDisabled(item) {
+    return (
+      item.matches(":disabled") ||
+      item.getAttribute("aria-disabled") === "true" ||
+      item.hidden ||
+      item.closest("[hidden]") !== null
+    );
+  }
+
+  function enabledItems() {
+    return menuItems().filter((item) => !itemIsDisabled(item));
+  }
+
+  function focusedElement() {
+    return contentElement()?.getRootNode?.().activeElement ?? document.activeElement;
+  }
+
+  function focusItem(item) {
+    if (!item) return;
+    for (const candidate of menuItems()) candidate.tabIndex = -1;
+    item.tabIndex = 0;
+    item.focus({ preventScroll: true });
+  }
+
+  function focusEdge(edge = "first") {
+    const items = enabledItems();
+    const item = edge === "last" ? items.at(-1) : items[0];
+    if (item) focusItem(item);
+    else contentElement()?.focus({ preventScroll: true });
+  }
+
+  function clearTypeahead() {
+    typeahead = "";
+    clearTimeout(typeaheadTimer);
+    typeaheadTimer = undefined;
+  }
+
+  function normalizedText(item) {
+    return (item.getAttribute("aria-label") ?? item.textContent ?? "")
+      .trim()
+      .toLocaleLowerCase();
+  }
+
+  function handleTypeahead(event) {
+    if (
+      event.key.length !== 1 ||
+      event.key === " " ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey
+    ) {
+      return false;
+    }
+
+    event.preventDefault();
+    clearTimeout(typeaheadTimer);
+    typeahead += event.key.toLocaleLowerCase();
+    typeaheadTimer = setTimeout(clearTypeahead, 500);
+
+    const items = enabledItems();
+    if (!items.length) return true;
+    const current = items.indexOf(focusedElement());
+    const ordered = [...items.slice(current + 1), ...items.slice(0, current + 1)];
+    let match = ordered.find((item) => normalizedText(item).startsWith(typeahead));
+
+    if (!match && new Set(typeahead).size === 1) {
+      typeahead = typeahead.at(-1);
+      match = ordered.find((item) => normalizedText(item).startsWith(typeahead));
+    }
+
+    if (match) focusItem(match);
+    return true;
+  }
+
+  function requestOpen(nextOpen) {
+    if (open === undefined) internalOpen = nextOpen;
+    else open = nextOpen;
+    onOpenChange?.(nextOpen);
+  }
+
+  function openMenu(edge = "first") {
+    pendingFocus = edge;
+    if (isOpen) focusEdge(edge);
+    else requestOpen(true);
+  }
+
+  function closeMenu({ restoreFocus = false } = {}) {
+    restoreOnClose ||= restoreFocus;
+    if (isOpen) requestOpen(false);
+    else if (restoreOnClose) {
+      restoreOnClose = false;
+      queueMicrotask(restoreInvokerFocus);
+    }
+  }
+
+  function itemFromEvent(event) {
+    const content = contentElement();
+    return eventPath(event).find(
+      (element) =>
+        element?.nodeType === 1 &&
+        itemRole(element) &&
+        element.closest?.('[role="menu"]') === content,
+    );
+  }
+
+  function handleClick(event) {
+    const item = itemFromEvent(event);
+    if (!item) {
+      onclickcapture?.(event);
+      return;
+    }
+
+    if (itemIsDisabled(item)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    closeMenu({ restoreFocus: true });
+    onclickcapture?.(event);
+  }
+
+  function handleKeydown(event) {
+    const items = enabledItems();
+    const currentIndex = items.indexOf(focusedElement());
+    let nextIndex;
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      closeMenu({ restoreFocus: true });
+    } else if (event.key === "Tab") {
+      clearTypeahead();
+      closeMenu();
+    } else if (event.key === "ArrowDown") {
+      nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
+    } else if (event.key === "ArrowUp") {
+      nextIndex =
+        currentIndex < 0
+          ? items.length - 1
+          : (currentIndex - 1 + items.length) % items.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = items.length - 1;
+    } else if (!handleTypeahead(event)) {
+      onkeydown?.(event);
+      return;
+    }
+
+    if (nextIndex !== undefined && items.length) {
+      event.preventDefault();
+      focusItem(items[nextIndex]);
+    }
+    onkeydown?.(event);
+  }
+
+  $effect(() => {
+    const nextOpen = isOpen;
+    queueMicrotask(() => {
+      syncInvokerSemantics();
+
+      if (nextOpen) {
+        focusEdge(pendingFocus);
+        pendingFocus = "first";
+        return;
+      }
+
+      clearTypeahead();
+      menuItems();
+      if (restoreOnClose) restoreInvokerFocus();
+      restoreOnClose = false;
+    });
+  });
+
+  onMount(() => {
+    const content = contentElement();
+    const root = content?.getRootNode?.() ?? document;
+
+    function rememberInvoker(event) {
+      const invoker = matchingInvoker(event);
+      if (invoker) activeInvoker = invoker;
+    }
+
+    function handleInvokerKeydown(event) {
+      const invoker = matchingInvoker(event);
+      if (!invoker || invoker.matches(":disabled")) return;
+      activeInvoker = invoker;
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        openMenu(event.key === "ArrowUp" ? "last" : "first");
+      }
+    }
+
+    root.addEventListener("keydown", handleInvokerKeydown);
+    root.addEventListener("click", rememberInvoker, true);
+    syncInvokerSemantics();
+    menuItems();
+
+    const observer =
+      typeof MutationObserver !== "undefined" && content
+        ? new MutationObserver(menuItems)
+        : undefined;
+    observer?.observe(content, { childList: true, subtree: true });
+
+    return () => {
+      observer?.disconnect();
+      root.removeEventListener("keydown", handleInvokerKeydown);
+      root.removeEventListener("click", rememberInvoker, true);
+      clearTypeahead();
+    };
+  });
+</script>
+
+<Popover
+  {...contentProps}
+  bind:this={popoverElement}
+  {id}
+  open={isOpen}
+  onOpenChange={requestOpen}
+  {placement}
+  {offset}
+  role="menu"
+  tabindex={-1}
+  data-slot="menu"
+  class={twMerge("min-w-40 p-1", className)}
+  onclickcapture={handleClick}
+  onkeydown={handleKeydown}
+>
+  {@render children?.({ open: isOpen, close: closeMenu })}
+</Popover>


### PR DESCRIPTION
## What changed

- add Menu under the Klean UI Components sidebar
- add a live isolated preview backed by the actual Vue component source
- document zero-configuration installation and Popover prerequisite resolution
- add copyable Vue, React, and Svelte usage plus complete framework sources
- document truthful button/link items, disabled behavior, API, keyboard and focus behavior
- add live Hagfish and Slipway caller-styled recipes
- extend the Components overview and installation page

## Why

The public docs should be the canonical home for seeing, installing, copying, and understanding each Klean UI component. Menu now follows the same bespoke preview/source/install experience as the existing components.

## Validation

- `npm run lint`
- `npm run build`
- live preview verified for open state, roving focus, Arrow navigation, typeahead, and Escape focus restoration
- no browser console warnings or errors
- no horizontal overflow at 390px

Closes #150