### PR TITLE
Document corrected Klean Menu cursor and Tab behavior

### DIFF
--- a/docs/.vitepress/theme/components/klean/menu/Menu.vue
+++ b/docs/.vitepress/theme/components/klean/menu/Menu.vue
@@ -46,11 +46,15 @@ const menuAttrs = computed(() => {
   return rest
 })
 const menuClasses = computed(() => twMerge('min-w-40 p-1', attrs.class))
+const TABBABLE_SELECTOR =
+  'a[href], button, input, select, textarea, [tabindex], [contenteditable="true"]'
 
 let interactionRoot
 let itemObserver
 let pendingFocus = 'first'
 let restoreOnClose = false
+let tabExitPending = false
+let tabExitTarget
 let typeahead = ''
 let typeaheadTimer
 
@@ -95,6 +99,60 @@ function restoreInvokerFocus() {
     ? activeInvoker.value
     : invokers()[0]
   invoker?.focus?.({ preventScroll: true })
+}
+
+function tabStopsOutsideMenu(root, content) {
+  return [...(root.querySelectorAll?.(TABBABLE_SELECTOR) ?? [])].filter(
+    (element) =>
+      !content?.contains(element) &&
+      element.tabIndex >= 0 &&
+      !element.matches(':disabled') &&
+      !element.closest('[hidden], [inert]')
+  )
+}
+
+function adjacentTabStop(backward) {
+  const content = contentElement()
+  const invoker = activeInvoker.value?.isConnected
+    ? activeInvoker.value
+    : invokers()[0]
+  let anchor = invoker
+  let root = content?.getRootNode?.() ?? document
+
+  while (anchor && root) {
+    const stops = tabStopsOutsideMenu(root, content)
+    const current = stops.indexOf(anchor)
+    let target
+
+    if (current >= 0) {
+      target = stops[current + (backward ? -1 : 1)]
+    } else {
+      const candidates = stops.filter((element) => {
+        const relation = anchor.compareDocumentPosition(element)
+        return backward ? Boolean(relation & 2) : Boolean(relation & 4)
+      })
+      target = backward ? candidates.at(-1) : candidates[0]
+    }
+
+    if (target) return target
+    if (!root.host) return undefined
+    anchor = root.host
+    root = anchor.getRootNode?.()
+  }
+
+  return undefined
+}
+
+function completeTabExit() {
+  if (tabExitTarget?.isConnected) {
+    tabExitTarget.focus({ preventScroll: true })
+  } else {
+    const root = contentElement()?.getRootNode?.() ?? document
+    root.activeElement?.blur?.()
+  }
+
+  tabExitTarget = undefined
+  tabExitPending = false
 }
 
 function itemRole(element) {
@@ -269,7 +327,11 @@ function handleKeydown(event) {
   }
 
   if (event.key === 'Tab') {
+    event.preventDefault()
     clearTypeahead()
+    restoreOnClose = false
+    tabExitTarget = adjacentTabStop(event.shiftKey)
+    tabExitPending = true
     closeMenu()
     return
   }
@@ -310,7 +372,8 @@ watch(
 
     clearTypeahead()
     menuItems()
-    if (restoreOnClose) restoreInvokerFocus()
+    if (tabExitPending) completeTabExit()
+    else if (restoreOnClose) restoreInvokerFocus()
     restoreOnClose = false
   },
   { flush: 'post' }

--- a/docs/klean-ui/components/menu.md
+++ b/docs/klean-ui/components/menu.md
@@ -62,7 +62,7 @@ The application supplies real buttons and links plus ordinary Tailwind. There is
     >
       <button
         type="button"
-        class="flex w-full rounded px-3 py-2 text-left text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 focus:text-gray-950 dark:text-gray-200 dark:hover:bg-white/10 dark:focus:bg-white/10"
+        class="flex w-full cursor-pointer rounded px-3 py-2 text-left text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 focus:text-gray-950 dark:text-gray-200 dark:hover:bg-white/10 dark:focus:bg-white/10"
       >
         Edit project
       </button>
@@ -81,7 +81,7 @@ The application supplies real buttons and links plus ordinary Tailwind. There is
       </button>
       <button
         type="button"
-        class="flex w-full rounded px-3 py-2 text-left text-sm text-red-700 outline-none hover:bg-red-50 focus:bg-red-50 focus:text-red-800 dark:text-red-400 dark:hover:bg-red-500/10 dark:focus:bg-red-500/10"
+        class="flex w-full cursor-pointer rounded px-3 py-2 text-left text-sm text-red-700 outline-none hover:bg-red-50 focus:bg-red-50 focus:text-red-800 dark:text-red-400 dark:hover:bg-red-500/10 dark:focus:bg-red-500/10"
       >
         Delete project
       </button>
@@ -94,8 +94,9 @@ The application supplies real buttons and links plus ordinary Tailwind. There is
   </template>
   <template #caption>
     This preview runs inside an isolated Shadow DOM root. Click Actions, then try
-    Arrow Up/Down, Home/End, typing “d”, and Escape. The children remain real
-    buttons and an anchor.
+    Arrow Up/Down, Home/End, typing “d”, Tab, and Escape. Arrow keys move inside;
+    Tab exits to the next page control. The children remain real buttons and an
+    anchor.
   </template>
 </KleanPreview>
 
@@ -136,7 +137,11 @@ The framework syntax changes; the HTML contract does not. A real button uses nat
 Use a native button when selection performs an action:
 
 ```vue
-<button type="button" class="..." @click="redeploy">Redeploy</button>
+<button
+  type="button"
+  class="cursor-pointer ..."
+  @click="redeploy"
+>Redeploy</button>
 ```
 
 Use an anchor for navigation. The Boring Stack Link renders an anchor too, so it works without an adapter:
@@ -146,6 +151,8 @@ Use an anchor for navigation. The Boring Stack Link renders an anchor too, so it
 ```
 
 Menu does not accept an item array because an array forces the component to guess whether each record is a button, anchor, download, or framework Link. Authorization, conditional visibility, event handlers, and destinations remain obvious in application markup.
+
+Native buttons keep the browser's default arrow cursor, so button-item recipes opt into `cursor-pointer` explicitly. That visible Tailwind class is part of the application-owned visual API; Menu does not mutate its children's appearance.
 
 ### Disabled items
 
@@ -185,7 +192,7 @@ Vue uses `v-model:open`, React uses `open` with `onOpenChange`, and Svelte uses 
 - Enter and Space activation remain native to the real button or anchor, avoiding double firing.
 - Escape closes and restores focus to the invoker.
 - Selection closes and restores focus; link navigation may then move to the destination.
-- Tab closes without pulling focus backward.
+- Tab or Shift+Tab closes and continues to the next or previous control outside the menu; neither key moves between menu items.
 - Outside interaction closes without stealing focus from the selected target.
 
 The vertical key contract is the same in right-to-left documents. Menu adds no animation, so reduced-motion users get a stable surface by default. Product motion, if useful, belongs in caller Tailwind and must use `motion-safe:` or an equivalent fallback.
@@ -223,7 +230,7 @@ Slipway needs compact operational actions; Hagfish needs a stronger border and o
           class="w-64 rounded-none border-2 border-black p-2 shadow-[6px_6px_0_0_#000]"
         >
           <a href="#product-recipes" class="flex w-full border-2 border-transparent px-3 py-2 text-sm font-medium text-black no-underline outline-none hover:border-black focus:border-black">Preview invoice</a>
-          <button type="button" class="flex w-full border-2 border-transparent px-3 py-2 text-left text-sm font-medium text-red-700 outline-none hover:border-red-700 focus:border-red-700">Void invoice</button>
+          <button type="button" class="flex w-full cursor-pointer border-2 border-transparent px-3 py-2 text-left text-sm font-medium text-red-700 outline-none hover:border-red-700 focus:border-red-700">Void invoice</button>
         </KleanMenu>
       </div>
       <div class="dark bg-gray-950 p-6 text-white">
@@ -241,7 +248,7 @@ Slipway needs compact operational actions; Hagfish needs a stronger border and o
           aria-label="Deployment actions"
           class="w-52 border-gray-700 bg-gray-900 p-1 text-white shadow-xl"
         >
-          <button type="button" class="flex w-full rounded px-2 py-2 text-left text-sm text-gray-200 outline-none hover:bg-white/10 focus:bg-white/10">Redeploy</button>
+          <button type="button" class="flex w-full cursor-pointer rounded px-2 py-2 text-left text-sm text-gray-200 outline-none hover:bg-white/10 focus:bg-white/10">Redeploy</button>
           <a href="#product-recipes" class="flex w-full rounded px-2 py-2 text-sm text-gray-200 no-underline outline-none hover:bg-white/10 focus:bg-white/10">View logs</a>
           <button type="button" disabled class="flex w-full cursor-not-allowed rounded px-2 py-2 text-left text-sm text-gray-500 outline-none">Stop provisioning</button>
         </KleanMenu>
@@ -271,7 +278,7 @@ The preview Source tab contains the complete Vue component. The equivalent frame
 - The invoker remains a real button and automatically receives `aria-haspopup="menu"`, `aria-controls`, and synchronized `aria-expanded`.
 - Button and anchor children keep their truthful native activation while Menu supplies composite roles and roving focus.
 - Disabled items cannot activate and never become the active roving focus stop.
-- Escape and selection restore focus only when the invoker still exists; Tab and outside interaction do not steal focus.
+- Escape and selection restore focus only when the invoker still exists; Tab exits forward or backward in composed document order; outside interaction does not steal focus.
 - Shadow DOM, RTL, dynamic items, listener cleanup, observer cleanup, and typeahead-timer cleanup are part of the tested contract.
 - Menu open state is ephemeral and is never written to storage, cookies, server data, or the URL.
 - Meaningful state selected from a menu follows the [Durable UI contract](/klean-ui/durable-ui); appearance follows the application-owned [theming convention](/klean-ui/theming).

--- a/docs/klean-ui/index.md
+++ b/docs/klean-ui/index.md
@@ -17,7 +17,9 @@ import quickUsage from './snippets/introduction/usage.vue?raw'
 
 Klean UI means **Kelvin's Lean UI**. It is the source-owned component system for The Boring JavaScript Stack: accessible markup, Durable UI behavior, neutral defaults, and Tailwind left directly in your hands.
 
-Vue, React, and Svelte are equal product targets. Each implementation uses its framework's native conventions while preserving the same semantics, states, anatomy, accessibility outcomes, and source-ownership model.
+**Vue, React, and Svelte. Three framework-native sources, one Klean contract.**
+
+They are equal product targets. Each implementation uses its framework's native conventions while preserving the same semantics, states, anatomy, accessibility outcomes, and source-ownership model—without adding a Klean runtime to the application.
 
 <KleanPreview id="klean-introduction" :source="quickUsage" filename="usage.vue">
   <template #preview>

--- a/docs/klean-ui/snippets/menu/products.vue
+++ b/docs/klean-ui/snippets/menu/products.vue
@@ -27,7 +27,7 @@ import Menu from '~/components/ui/menu/Menu.vue'
       </a>
       <button
         type="button"
-        class="flex w-full border-2 border-transparent px-3 py-2 text-left text-sm font-medium text-red-700 outline-none hover:border-red-700 focus:border-red-700"
+        class="flex w-full cursor-pointer border-2 border-transparent px-3 py-2 text-left text-sm font-medium text-red-700 outline-none hover:border-red-700 focus:border-red-700"
       >
         Void invoice
       </button>
@@ -51,7 +51,7 @@ import Menu from '~/components/ui/menu/Menu.vue'
     >
       <button
         type="button"
-        class="flex w-full rounded px-2 py-2 text-left text-sm text-gray-200 outline-none hover:bg-white/10 focus:bg-white/10"
+        class="flex w-full cursor-pointer rounded px-2 py-2 text-left text-sm text-gray-200 outline-none hover:bg-white/10 focus:bg-white/10"
       >
         Redeploy
       </button>

--- a/docs/klean-ui/snippets/menu/usage.jsx
+++ b/docs/klean-ui/snippets/menu/usage.jsx
@@ -9,7 +9,7 @@ export default function ProjectActions() {
       <Menu id="project-actions" aria-label="Project actions" className="w-56">
         <button
           type="button"
-          className="flex w-full rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
+          className="flex w-full cursor-pointer rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
         >
           Redeploy
         </button>

--- a/docs/klean-ui/snippets/menu/usage.svelte
+++ b/docs/klean-ui/snippets/menu/usage.svelte
@@ -8,7 +8,7 @@
 <Menu id="project-actions" aria-label="Project actions" class="w-56">
   <button
     type="button"
-    class="flex w-full rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
+    class="flex w-full cursor-pointer rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
   >
     Redeploy
   </button>

--- a/docs/klean-ui/snippets/menu/usage.vue
+++ b/docs/klean-ui/snippets/menu/usage.vue
@@ -9,7 +9,7 @@ import Menu from '~/components/ui/menu/Menu.vue'
   <Menu id="project-actions" aria-label="Project actions" class="w-56">
     <button
       type="button"
-      class="flex w-full rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
+      class="flex w-full cursor-pointer rounded px-3 py-2 text-left text-sm outline-none hover:bg-gray-100 focus:bg-gray-100"
     >
       Redeploy
     </button>

--- a/docs/klean-ui/sources/menu/Menu.jsx
+++ b/docs/klean-ui/sources/menu/Menu.jsx
@@ -11,6 +11,8 @@ import Popover from '../popover/Popover.jsx'
 
 const ITEM_SELECTOR =
   '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+const TABBABLE_SELECTOR =
+  'a[href], button, input, select, textarea, [tabindex], [contenteditable="true"]'
 
 function eventPath(event) {
   return (
@@ -54,6 +56,7 @@ const Menu = forwardRef(function Menu(
   const activeInvoker = useRef(null)
   const pendingFocus = useRef('first')
   const restoreOnClose = useRef(false)
+  const tabExit = useRef({ pending: false, target: undefined })
   const typeahead = useRef('')
   const typeaheadTimer = useRef()
   const [internalOpen, setInternalOpen] = useState(defaultOpen)
@@ -95,6 +98,61 @@ const Menu = forwardRef(function Menu(
       : invokers()[0]
     invoker?.focus?.({ preventScroll: true })
   }, [invokers])
+
+  const adjacentTabStop = useCallback(
+    (backward) => {
+      const content = contentElement()
+      const invoker = activeInvoker.current?.isConnected
+        ? activeInvoker.current
+        : invokers()[0]
+      let anchor = invoker
+      let root = content?.getRootNode?.() ?? document
+
+      while (anchor && root) {
+        const stops = [
+          ...(root.querySelectorAll?.(TABBABLE_SELECTOR) ?? [])
+        ].filter(
+          (element) =>
+            !content?.contains(element) &&
+            element.tabIndex >= 0 &&
+            !element.matches(':disabled') &&
+            !element.closest('[hidden], [inert]')
+        )
+        const current = stops.indexOf(anchor)
+        let target
+
+        if (current >= 0) {
+          target = stops[current + (backward ? -1 : 1)]
+        } else {
+          const candidates = stops.filter((element) => {
+            const relation = anchor.compareDocumentPosition(element)
+            return backward ? Boolean(relation & 2) : Boolean(relation & 4)
+          })
+          target = backward ? candidates.at(-1) : candidates[0]
+        }
+
+        if (target) return target
+        if (!root.host) return undefined
+        anchor = root.host
+        root = anchor.getRootNode?.()
+      }
+
+      return undefined
+    },
+    [contentElement, invokers]
+  )
+
+  const completeTabExit = useCallback(() => {
+    const target = tabExit.current.target
+    if (target?.isConnected) {
+      target.focus({ preventScroll: true })
+    } else {
+      const root = contentElement()?.getRootNode?.() ?? document
+      root.activeElement?.blur?.()
+    }
+
+    tabExit.current = { pending: false, target: undefined }
+  }, [contentElement])
 
   const menuItems = useCallback(() => {
     const content = contentElement()
@@ -195,10 +253,12 @@ const Menu = forwardRef(function Menu(
 
     clearTypeahead()
     menuItems()
-    if (restoreOnClose.current) restoreInvokerFocus()
+    if (tabExit.current.pending) completeTabExit()
+    else if (restoreOnClose.current) restoreInvokerFocus()
     restoreOnClose.current = false
   }, [
     clearTypeahead,
+    completeTabExit,
     focusEdge,
     isOpen,
     menuItems,
@@ -331,7 +391,13 @@ const Menu = forwardRef(function Menu(
       event.stopPropagation()
       closeMenu({ restoreFocus: true })
     } else if (event.key === 'Tab') {
+      event.preventDefault()
       clearTypeahead()
+      restoreOnClose.current = false
+      tabExit.current = {
+        pending: true,
+        target: adjacentTabStop(event.shiftKey)
+      }
       closeMenu()
     } else if (event.key === 'ArrowDown') {
       nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length

--- a/docs/klean-ui/sources/menu/Menu.svelte
+++ b/docs/klean-ui/sources/menu/Menu.svelte
@@ -3,6 +3,9 @@
   import { twMerge } from "tailwind-merge";
   import Popover from "../popover/Popover.svelte";
 
+  const TABBABLE_SELECTOR =
+    'a[href], button, input, select, textarea, [tabindex], [contenteditable="true"]';
+
   let {
     id,
     open = $bindable(),
@@ -23,6 +26,8 @@
   let isOpen = $derived(open ?? internalOpen);
   let pendingFocus = "first";
   let restoreOnClose = false;
+  let tabExitPending = false;
+  let tabExitTarget;
   let typeahead = "";
   let typeaheadTimer;
 
@@ -59,6 +64,54 @@
   function restoreInvokerFocus() {
     const invoker = activeInvoker?.isConnected ? activeInvoker : invokers()[0];
     invoker?.focus?.({ preventScroll: true });
+  }
+
+  function adjacentTabStop(backward) {
+    const content = contentElement();
+    const invoker = activeInvoker?.isConnected ? activeInvoker : invokers()[0];
+    let anchor = invoker;
+    let root = content?.getRootNode?.() ?? document;
+
+    while (anchor && root) {
+      const stops = [...(root.querySelectorAll?.(TABBABLE_SELECTOR) ?? [])].filter(
+        (element) =>
+          !content?.contains(element) &&
+          element.tabIndex >= 0 &&
+          !element.matches(":disabled") &&
+          !element.closest("[hidden], [inert]"),
+      );
+      const current = stops.indexOf(anchor);
+      let target;
+
+      if (current >= 0) {
+        target = stops[current + (backward ? -1 : 1)];
+      } else {
+        const candidates = stops.filter((element) => {
+          const relation = anchor.compareDocumentPosition(element);
+          return backward ? Boolean(relation & 2) : Boolean(relation & 4);
+        });
+        target = backward ? candidates.at(-1) : candidates[0];
+      }
+
+      if (target) return target;
+      if (!root.host) return undefined;
+      anchor = root.host;
+      root = anchor.getRootNode?.();
+    }
+
+    return undefined;
+  }
+
+  function completeTabExit() {
+    if (tabExitTarget?.isConnected) {
+      tabExitTarget.focus({ preventScroll: true });
+    } else {
+      const root = contentElement()?.getRootNode?.() ?? document;
+      root.activeElement?.blur?.();
+    }
+
+    tabExitTarget = undefined;
+    tabExitPending = false;
   }
 
   function itemRole(element) {
@@ -217,7 +270,11 @@
       event.stopPropagation();
       closeMenu({ restoreFocus: true });
     } else if (event.key === "Tab") {
+      event.preventDefault();
       clearTypeahead();
+      restoreOnClose = false;
+      tabExitTarget = adjacentTabStop(event.shiftKey);
+      tabExitPending = true;
       closeMenu();
     } else if (event.key === "ArrowDown") {
       nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
@@ -255,7 +312,8 @@
 
       clearTypeahead();
       menuItems();
-      if (restoreOnClose) restoreInvokerFocus();
+      if (tabExitPending) completeTabExit();
+      else if (restoreOnClose) restoreInvokerFocus();
       restoreOnClose = false;
     });
   });


### PR DESCRIPTION
## What changed

- make enabled native menu-button cursors explicit in the live preview and copyable Vue, React, and Svelte recipes
- explain that Arrow keys navigate inside Menu while Tab/Shift+Tab exit it
- publish corrected complete Vue, React, and Svelte Menu source
- update the live Shadow DOM preview caption and accessibility contract
- promote “Vue, React, and Svelte. Three framework-native sources, one Klean contract.” on the Klean UI introduction

## Why

The docs should show the exact application-owned Tailwind affordance and the actual composite keyboard contract. They are also the canonical copyable source for all three supported frameworks.

## Validation

- `npm run lint`
- `npm run build`
- live preview destructive action computes to `cursor: pointer`
- live Shadow DOM Menu closes on Tab and focus continues into the surrounding docs page
- Vue live source plus complete React and Svelte sources render in the page
- landing-page framework support statement renders visibly

Closes #152