### PR TITLE
fix: render component motion in isolated previews

### DIFF
--- a/docs/.vitepress/theme/components/KleanPreview.vue
+++ b/docs/.vitepress/theme/components/KleanPreview.vue
@@ -31,6 +31,13 @@ const { copied, copyFailed, copy } = useClipboard()
 
 let themeObserver
 
+function extractPreviewStyles(source) {
+  return [...source.matchAll(/<style(?:\s[^>]*)?>([\s\S]*?)<\/style>/gi)]
+    .map(([, styles]) => styles.trim())
+    .filter(Boolean)
+    .join('\n')
+}
+
 function syncPreviewTheme() {
   previewTarget.value?.classList.toggle(
     'dark',
@@ -43,7 +50,7 @@ onMounted(() => {
   const style = document.createElement('style')
   const stage = document.createElement('div')
 
-  style.textContent = `${previewStyles}\n
+  style.textContent = `${previewStyles}\n${extractPreviewStyles(props.source)}\n
     :host { display: block; }
 
     .klean-preview__stage {


### PR DESCRIPTION
Fixes #157

KleanPreview now extracts style blocks from the already supplied component source and includes them inside the preview Shadow DOM. Toast therefore runs its real enter and exit motion instead of waiting for the 450ms controller fallback.

Measured in the live docs preview:
- before: about 509ms to remove after dismissal
- after: about 304ms including browser automation overhead, with the intended 200ms exit visible

Verified with:
- npm run lint
- npm run build
- live browser dismissal timing