### PR TITLE
Document corrected Date Range Picker behavior

### DIFF
--- a/docs/.vitepress/theme/components/klean/date-range-picker/DateRangePicker.vue
+++ b/docs/.vitepress/theme/components/klean/date-range-picker/DateRangePicker.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, ref, useAttrs, useId, watch } from 'vue'
 import { twMerge } from 'tailwind-merge'
 import Calendar from '../calendar/Calendar.vue'
 import {
+  addDays,
   compareDates,
   dateIsUnavailable,
   dateLabel,
@@ -19,6 +20,22 @@ function normalizeRange(value) {
     start: parseIsoDate(value?.start) ? value.start : '',
     end: parseIsoDate(value?.end) ? value.end : ''
   }
+}
+
+function rangeContainsUnavailable(start, end, unavailable) {
+  if (!unavailable || !parseIsoDate(start) || !parseIsoDate(end)) return false
+  const [first, last] =
+    compareDates(start, end) <= 0 ? [start, end] : [end, start]
+
+  for (
+    let date = first;
+    date && compareDates(date, last) <= 0;
+    date = addDays(date, 1)
+  ) {
+    if (unavailable(date)) return true
+  }
+
+  return false
 }
 
 const props = defineProps({
@@ -61,6 +78,7 @@ const startDraft = ref(value.value.start)
 const endDraft = ref(value.value.end)
 const activePart = ref('start')
 const preview = ref('')
+const internalPopoverOpen = ref(props.defaultOpen)
 const startInput = ref()
 const endInput = ref()
 const popover = ref()
@@ -82,17 +100,44 @@ const endInvalid = computed(
     (!parseIsoDate(endDraft.value) ||
       dateIsUnavailable(endDraft.value, limits.value))
 )
+const endWithoutStartInvalid = computed(
+  () => Boolean(endDraft.value) && !Boolean(startDraft.value)
+)
 const orderInvalid = computed(
   () =>
     parseIsoDate(startDraft.value) &&
     parseIsoDate(endDraft.value) &&
     compareDates(endDraft.value, startDraft.value) < 0
 )
+const rangeUnavailable = computed(
+  () =>
+    !orderInvalid.value &&
+    rangeContainsUnavailable(
+      startDraft.value,
+      endDraft.value,
+      props.unavailable
+    )
+)
+const popoverOpen = computed(() =>
+  props.open === undefined ? internalPopoverOpen.value : props.open
+)
+const calendarUnavailable = computed(
+  () => (date) =>
+    dateIsUnavailable(date, limits.value) ||
+    (activePart.value === 'end' &&
+      value.value.start &&
+      rangeContainsUnavailable(value.value.start, date, props.unavailable))
+)
 const statusText = computed(() => {
+  if (endWithoutStartInvalid.value)
+    return 'Choose a start date before the end date.'
   if (orderInvalid.value)
     return 'The end date must be on or after the start date.'
   if (startInvalid.value || endInvalid.value) {
     return 'Enter available dates as YYYY-MM-DD.'
+  }
+  if (rangeUnavailable.value) {
+    return 'The range cannot include an unavailable date.'
   }
   if (value.value.start && value.value.end) {
     return `${dateLabel(value.value.start, locale.value)} through ${dateLabel(value.value.end, locale.value)}.`
@@ -131,16 +176,26 @@ function updateRange(nextRange) {
   emit('change', normalized)
 }
 
-function openPart(part) {
+function openPart(part, source) {
+  if (props.disabled || props.readonly) return
   activePart.value = part
   preview.value = ''
-  popover.value?.open()
+  const input =
+    part === 'end' ? endInput.value?.element : startInput.value?.element
+  popover.value?.open(source ?? input)
 }
 
 function handleDraft(part, event) {
   const next = event.target.value.trim()
   if (part === 'start') startDraft.value = next
   else endDraft.value = next
+
+  if (part === 'start' && !next) {
+    endDraft.value = ''
+    updateRange({ start: '', end: '' })
+    return
+  }
+  if (part === 'end' && next && !value.value.start) return
   if (next && (!parseIsoDate(next) || dateIsUnavailable(next, limits.value)))
     return
 
@@ -155,10 +210,20 @@ function handleDraft(part, event) {
   ) {
     return
   }
+  if (
+    nextRange.start &&
+    nextRange.end &&
+    rangeContainsUnavailable(nextRange.start, nextRange.end, props.unavailable)
+  ) {
+    return
+  }
   updateRange(nextRange)
 }
 
 function chooseDate(date) {
+  if (props.disabled || props.readonly || calendarUnavailable.value(date))
+    return
+
   if (activePart.value === 'start' || !value.value.start) {
     updateRange({ start: date, end: '' })
     startDraft.value = date
@@ -180,13 +245,24 @@ function chooseDate(date) {
 }
 
 function handleCalendarFocus(date) {
-  if (activePart.value === 'end' && value.value.start) preview.value = date
+  if (
+    activePart.value === 'end' &&
+    value.value.start &&
+    !calendarUnavailable.value(date)
+  ) {
+    preview.value = date
+  }
 }
 
 function handleInputKeydown(event, part) {
   if (event.key !== 'ArrowDown' || props.disabled || props.readonly) return
   event.preventDefault()
-  openPart(part)
+  openPart(part, event.currentTarget)
+}
+
+function handleOpenChange(nextOpen) {
+  if (props.open === undefined) internalPopoverOpen.value = nextOpen
+  emit('update:open', nextOpen)
 }
 
 watch(value, (nextValue) => {
@@ -198,7 +274,9 @@ watch(
   () => [
     startInvalid.value,
     endInvalid.value,
+    endWithoutStartInvalid.value,
     orderInvalid.value,
+    rangeUnavailable.value,
     props.required,
     value.value.start,
     value.value.end
@@ -209,7 +287,7 @@ watch(
     const endElement = endInput.value?.element
     if (startElement) {
       startElement.setCustomValidity(
-        startInvalid.value || orderInvalid.value
+        startInvalid.value || orderInvalid.value || rangeUnavailable.value
           ? statusText.value
           : props.required && !value.value.start
             ? 'Choose a start date.'
@@ -218,7 +296,10 @@ watch(
     }
     if (endElement) {
       endElement.setCustomValidity(
-        endInvalid.value || orderInvalid.value
+        endInvalid.value ||
+          endWithoutStartInvalid.value ||
+          orderInvalid.value ||
+          rangeUnavailable.value
           ? statusText.value
           : props.required && !value.value.end
             ? 'Choose an end date.'
@@ -265,11 +346,16 @@ defineExpose({
             placeholder="YYYY-MM-DD"
             :required="required"
             :readonly="readonly"
-            :aria-invalid="startInvalid || orderInvalid || undefined"
+            :aria-invalid="
+              startInvalid || orderInvalid || rangeUnavailable || undefined
+            "
             :aria-describedby="statusId"
+            :aria-controls="popoverId"
+            :aria-expanded="popoverOpen && activePart === 'start'"
+            aria-haspopup="grid"
             data-slot="date-range-start"
             @input="handleDraft('start', $event)"
-            @click="openPart('start')"
+            @click="openPart('start', $event.currentTarget)"
             @keydown="handleInputKeydown($event, 'start')"
           />
           <button
@@ -280,6 +366,7 @@ defineExpose({
             class="absolute inset-y-0 end-0 grid min-w-11 place-items-center rounded-e-md text-gray-500 hover:bg-gray-100 hover:text-gray-950 focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white dark:focus-visible:outline-white"
             :disabled="disabled || readonly"
             :aria-label="`Choose ${startLabel.toLowerCase()}`"
+            aria-haspopup="grid"
             @click="activePart = 'start'"
           >
             <svg
@@ -314,11 +401,20 @@ defineExpose({
             placeholder="YYYY-MM-DD"
             :required="required"
             :readonly="readonly"
-            :aria-invalid="endInvalid || orderInvalid || undefined"
+            :aria-invalid="
+              endWithoutStartInvalid ||
+              endInvalid ||
+              orderInvalid ||
+              rangeUnavailable ||
+              undefined
+            "
             :aria-describedby="statusId"
+            :aria-controls="popoverId"
+            :aria-expanded="popoverOpen && activePart === 'end'"
+            aria-haspopup="grid"
             data-slot="date-range-end"
             @input="handleDraft('end', $event)"
-            @click="openPart('end')"
+            @click="openPart('end', $event.currentTarget)"
             @keydown="handleInputKeydown($event, 'end')"
           />
           <button
@@ -329,6 +425,7 @@ defineExpose({
             class="absolute inset-y-0 end-0 grid min-w-11 place-items-center rounded-e-md text-gray-500 hover:bg-gray-100 hover:text-gray-950 focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white dark:focus-visible:outline-white"
             :disabled="disabled || readonly"
             :aria-label="`Choose ${endLabel.toLowerCase()}`"
+            aria-haspopup="grid"
             @click="activePart = 'end'"
           >
             <svg
@@ -354,7 +451,11 @@ defineExpose({
       class="text-sm text-gray-600 dark:text-gray-400"
       :class="{
         'text-red-700 dark:text-red-400':
-          startInvalid || endInvalid || orderInvalid
+          startInvalid ||
+          endInvalid ||
+          endWithoutStartInvalid ||
+          orderInvalid ||
+          rangeUnavailable
       }"
       aria-live="polite"
     >
@@ -369,14 +470,14 @@ defineExpose({
       placement="bottom-start"
       data-slot="date-range-popover"
       class="w-[min(22rem,calc(100vw-1rem))] p-0"
-      @update:open="emit('update:open', $event)"
+      @update:open="handleOpenChange"
     >
       <Calendar
         :model-value="calendarValue"
         :default-value="value.start"
         :min="min"
         :max="max"
-        :unavailable="unavailable"
+        :unavailable="calendarUnavailable"
         :range-start="orderedDecoration.start"
         :range-end="value.end ? orderedDecoration.end : undefined"
         :range-preview="!value.end ? orderedDecoration.end : undefined"

--- a/docs/.vitepress/theme/components/klean/popover/Popover.vue
+++ b/docs/.vitepress/theme/components/klean/popover/Popover.vue
@@ -105,7 +105,7 @@ function eventPath(event) {
 }
 
 function resolveInvoker(candidate) {
-  if (candidate?.getAttribute?.('popovertarget') === contentId.value) {
+  if (candidate?.isConnected) {
     activeInvoker.value = candidate
   }
 
@@ -168,7 +168,8 @@ function close({ restoreFocus = isOpen.value } = {}) {
   setOpen(false, { restoreFocus })
 }
 
-function open() {
+function open(source) {
+  resolveInvoker(source)
   setOpen(true)
 }
 
@@ -216,9 +217,12 @@ function handleFallbackInvokerClick(event) {
 
 function handleOutsidePointer(event) {
   const path = eventPath(event)
+  const reference = resolveInvoker()
 
   if (
     path.includes(content.value) ||
+    (reference &&
+      (path.includes(reference) || reference.contains?.(event.target))) ||
     invokers().some(
       (invoker) => path.includes(invoker) || invoker.contains(event.target)
     )
@@ -281,9 +285,11 @@ async function syncOpenEffects() {
   document.addEventListener('pointerdown', handleOutsidePointer, true)
 }
 
-watch(() => [isOpen.value, props.placement, props.offset], syncOpenEffects, {
-  flush: 'post'
-})
+watch(
+  () => [isOpen.value, props.placement, props.offset, activeInvoker.value],
+  syncOpenEffects,
+  { flush: 'post' }
+)
 
 onMounted(() => {
   nativePopover.value =

--- a/docs/klean-ui/components/date-range-picker.md
+++ b/docs/klean-ui/components/date-range-picker.md
@@ -23,6 +23,7 @@ import reactUsage from '../snippets/date-range-picker/usage.jsx?raw'
 import svelteUsage from '../snippets/date-range-picker/usage.svelte?raw'
 
 const period = ref({ start: '2026-08-08', end: '2026-08-12' })
+const unavailable = (date) => date >= '2026-08-14' && date <= '2026-08-16'
 const vueFiles = [
   {
     filename: 'Input.vue',
@@ -67,11 +68,15 @@ visible in Calendar.
         label="Reporting period"
         start-label="From"
         end-label="To"
+        :unavailable="unavailable"
         required
       />
       <output class="font-mono text-sm text-gray-600 dark:text-gray-300">
         {{ period.start }} → {{ period.end }}
       </output>
+      <p class="text-sm text-gray-600 dark:text-gray-400">
+        August 14–16 is unavailable, so a contiguous range cannot cross it.
+      </p>
     </div>
   </template>
   <template #source>
@@ -126,8 +131,9 @@ when the date surface should remain visible.
 ## Value and form contract
 
 The value is `{ start, end }`. A picker named `period` submits two native form
-entries: `period[start]` and `period[end]`. An unfinished boundary stays an
-empty string rather than becoming a partial date or a timezone-dependent Date.
+entries: `period[start]` and `period[end]`. Committed state is always empty,
+start-only, or a complete ordered range. It never contains a partial date, an
+end without a start, or a timezone-dependent Date.
 
 Ranges are inclusive: the start and end may be the same day. That is useful for
 one-day reports and stays. If a product requires at least one day between the
@@ -136,6 +142,24 @@ Pickers with derived `min` and `max` values.
 
 Choosing a second date earlier than the first orders the result. The component
 does not leave the application with an inverted range.
+
+## Range rules
+
+- The calendar anchors to the field that opened it. It flips or shifts before
+  leaving the viewport and follows the field through scroll, resize, and layout
+  changes.
+- Start and end are inclusive; selecting the same date twice creates a valid
+  one-day range.
+- Reverse calendar selection is ordered automatically. An inverted typed draft
+  is reported as invalid without changing committed application state.
+- Clearing the start clears both boundaries. Typing an end without a start
+  remains an invalid draft.
+- `min` and `max` constrain both boundaries. An `unavailable` date cannot be
+  selected or crossed, so the result remains one contiguous range.
+- Arrow Down opens from either field. Escape and explicit dismissal return
+  focus to that field; outside dismissal leaves focus at the new target.
+- Required, disabled, readonly, controlled, uncontrolled, locale, direction,
+  and native form behavior need no additional configuration.
 
 ## API
 

--- a/docs/klean-ui/components/popover.md
+++ b/docs/klean-ui/components/popover.md
@@ -129,6 +129,11 @@ Use the framework-native `close` value when an application action already runs c
 
 Escape and explicit dismissal return focus to the connected invoker. Outside pointer dismissal leaves focus with the element the person selected instead of moving it unexpectedly.
 
+Composed controls may pass their active element when opening programmatically.
+Vue and React expose `open(source)`; Svelte exposes `show(source)`. That element
+becomes the placement and focus-return anchor, so Date Picker and Date Range
+Picker remain attached to the field currently in use.
+
 ## Observable, never persisted
 
 Most Popovers need no application state. Observe visibility only when another part of the interface truly responds to it.

--- a/docs/klean-ui/sources/date-range-picker/DateRangePicker.jsx
+++ b/docs/klean-ui/sources/date-range-picker/DateRangePicker.jsx
@@ -9,6 +9,7 @@ import {
 import { twMerge } from 'tailwind-merge'
 import Calendar from '../calendar/Calendar.jsx'
 import {
+  addDays,
   compareDates,
   dateIsUnavailable,
   dateLabel,
@@ -23,6 +24,22 @@ function normalizeRange(value) {
     start: parseIsoDate(value?.start) ? value.start : '',
     end: parseIsoDate(value?.end) ? value.end : ''
   }
+}
+
+function rangeContainsUnavailable(start, end, unavailable) {
+  if (!unavailable || !parseIsoDate(start) || !parseIsoDate(end)) return false
+  const [first, last] =
+    compareDates(start, end) <= 0 ? [start, end] : [end, start]
+
+  for (
+    let date = first;
+    date && compareDates(date, last) <= 0;
+    date = addDays(date, 1)
+  ) {
+    if (unavailable(date)) return true
+  }
+
+  return false
 }
 
 const DateRangePicker = forwardRef(function DateRangePicker(
@@ -65,6 +82,7 @@ const DateRangePicker = forwardRef(function DateRangePicker(
   const [endDraft, setEndDraft] = useState(range.end)
   const [activePart, setActivePart] = useState('start')
   const [preview, setPreview] = useState('')
+  const [internalPopoverOpen, setInternalPopoverOpen] = useState(defaultOpen)
   const startInput = useRef(null)
   const endInput = useRef(null)
   const popoverRef = useRef(null)
@@ -77,16 +95,25 @@ const DateRangePicker = forwardRef(function DateRangePicker(
   const endInvalid = Boolean(
     endDraft && (!parseIsoDate(endDraft) || dateIsUnavailable(endDraft, limits))
   )
+  const endWithoutStartInvalid = Boolean(endDraft && !startDraft)
   const orderInvalid = Boolean(
     parseIsoDate(startDraft) &&
       parseIsoDate(endDraft) &&
       compareDates(endDraft, startDraft) < 0
   )
+  const rangeUnavailable = Boolean(
+    !orderInvalid && rangeContainsUnavailable(startDraft, endDraft, unavailable)
+  )
+  const popoverOpen = open === undefined ? internalPopoverOpen : open
   let statusText
-  if (orderInvalid)
+  if (endWithoutStartInvalid)
+    statusText = 'Choose a start date before the end date.'
+  else if (orderInvalid)
     statusText = 'The end date must be on or after the start date.'
   else if (startInvalid || endInvalid)
     statusText = 'Enter available dates as YYYY-MM-DD.'
+  else if (rangeUnavailable)
+    statusText = 'The range cannot include an unavailable date.'
   else if (range.start && range.end)
     statusText = `${dateLabel(range.start, locale)} through ${dateLabel(range.end, locale)}.`
   else if (range.start) statusText = 'Choose an end date.'
@@ -105,16 +132,34 @@ const DateRangePicker = forwardRef(function DateRangePicker(
     onValueChange?.(normalized)
   }
 
-  function openPart(part) {
+  function calendarUnavailable(date) {
+    return (
+      dateIsUnavailable(date, limits) ||
+      (activePart === 'end' &&
+        range.start &&
+        rangeContainsUnavailable(range.start, date, unavailable))
+    )
+  }
+
+  function openPart(part, source) {
+    if (disabled || readOnly) return
     setActivePart(part)
     setPreview('')
-    popoverRef.current?.open()
+    const input = part === 'end' ? endInput.current : startInput.current
+    popoverRef.current?.open(source ?? input)
   }
 
   function handleDraft(part, event) {
     const next = event.target.value.trim()
     if (part === 'start') setStartDraft(next)
     else setEndDraft(next)
+
+    if (part === 'start' && !next) {
+      setEndDraft('')
+      updateRange({ start: '', end: '' })
+      return
+    }
+    if (part === 'end' && next && !range.start) return
     if (next && (!parseIsoDate(next) || dateIsUnavailable(next, limits))) return
     const nextRange = {
       start: part === 'start' ? next : range.start,
@@ -127,10 +172,19 @@ const DateRangePicker = forwardRef(function DateRangePicker(
     ) {
       return
     }
+    if (
+      nextRange.start &&
+      nextRange.end &&
+      rangeContainsUnavailable(nextRange.start, nextRange.end, unavailable)
+    ) {
+      return
+    }
     updateRange(nextRange)
   }
 
   function chooseDate(date) {
+    if (disabled || readOnly || calendarUnavailable(date)) return
+
     if (activePart === 'start' || !range.start) {
       updateRange({ start: date, end: '' })
       setStartDraft(date)
@@ -150,6 +204,11 @@ const DateRangePicker = forwardRef(function DateRangePicker(
     popoverRef.current?.close()
   }
 
+  function handleOpenChange(nextOpen) {
+    if (open === undefined) setInternalPopoverOpen(nextOpen)
+    onOpenChange?.(nextOpen)
+  }
+
   useEffect(() => {
     setStartDraft(range.start)
     setEndDraft(range.end)
@@ -158,7 +217,7 @@ const DateRangePicker = forwardRef(function DateRangePicker(
   useEffect(() => {
     if (startInput.current) {
       startInput.current.setCustomValidity(
-        startInvalid || orderInvalid
+        startInvalid || orderInvalid || rangeUnavailable
           ? statusText
           : required && !range.start
             ? 'Choose a start date.'
@@ -167,7 +226,7 @@ const DateRangePicker = forwardRef(function DateRangePicker(
     }
     if (endInput.current) {
       endInput.current.setCustomValidity(
-        endInvalid || orderInvalid
+        endInvalid || endWithoutStartInvalid || orderInvalid || rangeUnavailable
           ? statusText
           : required && !range.end
             ? 'Choose an end date.'
@@ -176,7 +235,9 @@ const DateRangePicker = forwardRef(function DateRangePicker(
     }
   }, [
     endInvalid,
+    endWithoutStartInvalid,
     orderInvalid,
+    rangeUnavailable,
     range.end,
     range.start,
     required,
@@ -227,15 +288,20 @@ const DateRangePicker = forwardRef(function DateRangePicker(
               placeholder="YYYY-MM-DD"
               required={required}
               readOnly={readOnly}
-              aria-invalid={startInvalid || orderInvalid || undefined}
+              aria-invalid={
+                startInvalid || orderInvalid || rangeUnavailable || undefined
+              }
               aria-describedby={statusId}
+              aria-controls={popoverId}
+              aria-expanded={popoverOpen && activePart === 'start'}
+              aria-haspopup="grid"
               data-slot="date-range-start"
               onChange={(event) => handleDraft('start', event)}
-              onClick={() => openPart('start')}
+              onClick={(event) => openPart('start', event.currentTarget)}
               onKeyDown={(event) => {
                 if (event.key === 'ArrowDown' && !disabled && !readOnly) {
                   event.preventDefault()
-                  openPart('start')
+                  openPart('start', event.currentTarget)
                 }
               }}
             />
@@ -247,6 +313,7 @@ const DateRangePicker = forwardRef(function DateRangePicker(
               className={calendarButtonClasses}
               disabled={disabled || readOnly}
               aria-label={`Choose ${startLabel.toLowerCase()}`}
+              aria-haspopup="grid"
               onClick={() => setActivePart('start')}
             >
               <svg
@@ -281,15 +348,24 @@ const DateRangePicker = forwardRef(function DateRangePicker(
               placeholder="YYYY-MM-DD"
               required={required}
               readOnly={readOnly}
-              aria-invalid={endInvalid || orderInvalid || undefined}
+              aria-invalid={
+                endInvalid ||
+                endWithoutStartInvalid ||
+                orderInvalid ||
+                rangeUnavailable ||
+                undefined
+              }
               aria-describedby={statusId}
+              aria-controls={popoverId}
+              aria-expanded={popoverOpen && activePart === 'end'}
+              aria-haspopup="grid"
               data-slot="date-range-end"
               onChange={(event) => handleDraft('end', event)}
-              onClick={() => openPart('end')}
+              onClick={(event) => openPart('end', event.currentTarget)}
               onKeyDown={(event) => {
                 if (event.key === 'ArrowDown' && !disabled && !readOnly) {
                   event.preventDefault()
-                  openPart('end')
+                  openPart('end', event.currentTarget)
                 }
               }}
             />
@@ -301,6 +377,7 @@ const DateRangePicker = forwardRef(function DateRangePicker(
               className={calendarButtonClasses}
               disabled={disabled || readOnly}
               aria-label={`Choose ${endLabel.toLowerCase()}`}
+              aria-haspopup="grid"
               onClick={() => setActivePart('end')}
             >
               <svg
@@ -322,7 +399,11 @@ const DateRangePicker = forwardRef(function DateRangePicker(
         data-slot="date-range-status"
         className={twMerge(
           'text-sm text-gray-600 dark:text-gray-400',
-          (startInvalid || endInvalid || orderInvalid) &&
+          (startInvalid ||
+            endInvalid ||
+            endWithoutStartInvalid ||
+            orderInvalid ||
+            rangeUnavailable) &&
             'text-red-700 dark:text-red-400'
         )}
         aria-live="polite"
@@ -334,7 +415,7 @@ const DateRangePicker = forwardRef(function DateRangePicker(
         id={popoverId}
         open={open}
         defaultOpen={defaultOpen}
-        onOpenChange={onOpenChange}
+        onOpenChange={handleOpenChange}
         placement="bottom-start"
         data-slot="date-range-popover"
         className="w-[min(22rem,calc(100vw-1rem))] p-0"
@@ -344,7 +425,7 @@ const DateRangePicker = forwardRef(function DateRangePicker(
           defaultValue={range.start}
           min={min}
           max={max}
-          unavailable={unavailable}
+          unavailable={calendarUnavailable}
           rangeStart={decoration.start}
           rangeEnd={range.end ? decoration.end : undefined}
           rangePreview={!range.end ? decoration.end : undefined}
@@ -353,7 +434,13 @@ const DateRangePicker = forwardRef(function DateRangePicker(
           disabled={disabled}
           readOnly={readOnly}
           onFocusChange={(date) => {
-            if (activePart === 'end' && range.start) setPreview(date)
+            if (
+              activePart === 'end' &&
+              range.start &&
+              !calendarUnavailable(date)
+            ) {
+              setPreview(date)
+            }
           }}
           onValueChange={chooseDate}
         />

--- a/docs/klean-ui/sources/date-range-picker/DateRangePicker.svelte
+++ b/docs/klean-ui/sources/date-range-picker/DateRangePicker.svelte
@@ -3,6 +3,7 @@
   import { twMerge } from "tailwind-merge";
   import Calendar from "../calendar/Calendar.svelte";
   import {
+    addDays,
     compareDates,
     dateIsUnavailable,
     dateLabel,
@@ -17,6 +18,22 @@
       start: parseIsoDate(candidate?.start) ? candidate.start : "",
       end: parseIsoDate(candidate?.end) ? candidate.end : "",
     };
+  }
+
+  function rangeContainsUnavailable(start, end, unavailable) {
+    if (!unavailable || !parseIsoDate(start) || !parseIsoDate(end)) return false;
+    const [first, last] =
+      compareDates(start, end) <= 0 ? [start, end] : [end, start];
+
+    for (
+      let date = first;
+      date && compareDates(date, last) <= 0;
+      date = addDays(date, 1)
+    ) {
+      if (unavailable(date)) return true;
+    }
+
+    return false;
   }
 
   let {
@@ -59,6 +76,7 @@
   let endDraft = $state(initialRange.end);
   let activePart = $state("start");
   let preview = $state("");
+  let internalPopoverOpen = $state(untrack(() => defaultOpen));
   let startInput;
   let endInput;
   let popover;
@@ -77,6 +95,7 @@
           dateIsUnavailable(endDraft, { min, max, unavailable })),
     ),
   );
+  let endWithoutStartInvalid = $derived(Boolean(endDraft && !startDraft));
   let orderInvalid = $derived(
     Boolean(
       parseIsoDate(startDraft) &&
@@ -84,10 +103,19 @@
         compareDates(endDraft, startDraft) < 0,
     ),
   );
+  let rangeUnavailable = $derived(
+    !orderInvalid &&
+      rangeContainsUnavailable(startDraft, endDraft, unavailable),
+  );
+  let popoverOpen = $derived(open ?? internalPopoverOpen);
   let statusText = $derived.by(() => {
+    if (endWithoutStartInvalid)
+      return "Choose a start date before the end date.";
     if (orderInvalid) return "The end date must be on or after the start date.";
     if (startInvalid || endInvalid)
       return "Enter available dates as YYYY-MM-DD.";
+    if (rangeUnavailable)
+      return "The range cannot include an unavailable date.";
     if (range.start && range.end)
       return `${dateLabel(range.start, locale)} through ${dateLabel(range.end, locale)}.`;
     if (range.start) return "Choose an end date.";
@@ -114,16 +142,35 @@
     onchange?.(value);
   }
 
-  function openPart(part) {
+  function calendarUnavailable(date) {
+    return (
+      dateIsUnavailable(date, { min, max, unavailable }) ||
+      (activePart === "end" &&
+        range.start &&
+        rangeContainsUnavailable(range.start, date, unavailable))
+    );
+  }
+
+  function openPart(part, source) {
+    if (disabled || readonly) return;
     activePart = part;
     preview = "";
-    popover?.show();
+    const input =
+      part === "end" ? endInput?.getElement() : startInput?.getElement();
+    popover?.show(source ?? input);
   }
 
   function handleDraft(part, event) {
     const next = event.target.value.trim();
     if (part === "start") startDraft = next;
     else endDraft = next;
+
+    if (part === "start" && !next) {
+      endDraft = "";
+      updateRange({ start: "", end: "" });
+      return;
+    }
+    if (part === "end" && next && !range.start) return;
     if (
       next &&
       (!parseIsoDate(next) ||
@@ -141,10 +188,19 @@
     ) {
       return;
     }
+    if (
+      nextRange.start &&
+      nextRange.end &&
+      rangeContainsUnavailable(nextRange.start, nextRange.end, unavailable)
+    ) {
+      return;
+    }
     updateRange(nextRange);
   }
 
   function chooseDate(date) {
+    if (disabled || readonly || calendarUnavailable(date)) return;
+
     if (activePart === "start" || !range.start) {
       updateRange({ start: date, end: "" });
       startDraft = date;
@@ -167,7 +223,12 @@
   function handleKeydown(event, part) {
     if (event.key !== "ArrowDown" || disabled || readonly) return;
     event.preventDefault();
-    openPart(part);
+    openPart(part, event.currentTarget);
+  }
+
+  function handleOpenChange(nextOpen) {
+    if (open === undefined) internalPopoverOpen = nextOpen;
+    onopenchange?.(nextOpen);
   }
 
   $effect(() => {
@@ -180,7 +241,7 @@
     const endElement = endInput?.getElement();
     if (startElement) {
       startElement.setCustomValidity(
-        startInvalid || orderInvalid
+        startInvalid || orderInvalid || rangeUnavailable
           ? statusText
           : required && !range.start
             ? "Choose a start date."
@@ -189,7 +250,10 @@
     }
     if (endElement) {
       endElement.setCustomValidity(
-        endInvalid || orderInvalid
+        endInvalid ||
+        endWithoutStartInvalid ||
+        orderInvalid ||
+        rangeUnavailable
           ? statusText
           : required && !range.end
             ? "Choose an end date."
@@ -240,11 +304,17 @@
           placeholder="YYYY-MM-DD"
           {required}
           {readonly}
-          aria-invalid={startInvalid || orderInvalid || undefined}
+          aria-invalid={startInvalid ||
+            orderInvalid ||
+            rangeUnavailable ||
+            undefined}
           aria-describedby={statusId}
+          aria-controls={popoverId}
+          aria-expanded={popoverOpen && activePart === "start"}
+          aria-haspopup="grid"
           data-slot="date-range-start"
           oninput={(event) => handleDraft("start", event)}
-          onclick={() => openPart("start")}
+          onclick={(event) => openPart("start", event.currentTarget)}
           onkeydown={(event) => handleKeydown(event, "start")}
         />
         <button
@@ -255,6 +325,7 @@
           class={calendarButtonClasses}
           disabled={disabled || readonly}
           aria-label={`Choose ${startLabel.toLowerCase()}`}
+          aria-haspopup="grid"
           onclick={() => (activePart = "start")}
         >
           <svg
@@ -288,11 +359,18 @@
           placeholder="YYYY-MM-DD"
           {required}
           {readonly}
-          aria-invalid={endInvalid || orderInvalid || undefined}
+          aria-invalid={endInvalid ||
+            endWithoutStartInvalid ||
+            orderInvalid ||
+            rangeUnavailable ||
+            undefined}
           aria-describedby={statusId}
+          aria-controls={popoverId}
+          aria-expanded={popoverOpen && activePart === "end"}
+          aria-haspopup="grid"
           data-slot="date-range-end"
           oninput={(event) => handleDraft("end", event)}
-          onclick={() => openPart("end")}
+          onclick={(event) => openPart("end", event.currentTarget)}
           onkeydown={(event) => handleKeydown(event, "end")}
         />
         <button
@@ -303,6 +381,7 @@
           class={calendarButtonClasses}
           disabled={disabled || readonly}
           aria-label={`Choose ${endLabel.toLowerCase()}`}
+          aria-haspopup="grid"
           onclick={() => (activePart = "end")}
         >
           <svg
@@ -326,7 +405,11 @@
     data-slot="date-range-status"
     class={twMerge(
       "text-sm text-gray-600 dark:text-gray-400",
-      (startInvalid || endInvalid || orderInvalid) &&
+      (startInvalid ||
+        endInvalid ||
+        endWithoutStartInvalid ||
+        orderInvalid ||
+        rangeUnavailable) &&
         "text-red-700 dark:text-red-400",
     )}
     aria-live="polite"
@@ -338,7 +421,7 @@
     bind:open
     id={popoverId}
     {defaultOpen}
-    onOpenChange={onopenchange}
+    onOpenChange={handleOpenChange}
     placement="bottom-start"
     data-slot="date-range-popover"
     class="w-[min(22rem,calc(100vw-1rem))] p-0"
@@ -348,7 +431,7 @@
       defaultValue={range.start}
       {min}
       {max}
-      {unavailable}
+      unavailable={calendarUnavailable}
       rangeStart={decoration.start}
       rangeEnd={range.end ? decoration.end : undefined}
       rangePreview={!range.end ? decoration.end : undefined}
@@ -357,7 +440,13 @@
       {disabled}
       {readonly}
       onfocuschange={(date) => {
-        if (activePart === "end" && range.start) preview = date;
+        if (
+          activePart === "end" &&
+          range.start &&
+          !calendarUnavailable(date)
+        ) {
+          preview = date;
+        }
       }}
       onchange={chooseDate}
     />


### PR DESCRIPTION
Closes #166

- sync the corrected Vue, React, and Svelte Date Range Picker sources
- sync programmatic Popover source anchoring
- document active-field positioning and contiguous range rules
- demonstrate unavailable dates in the live docs example

Checks:
- npm run lint
- npm run build