### PR TITLE
fix(klean-ui): correct Select source recipe

### DIFF
--- a/docs/.vitepress/theme/components/klean/select/SlipwaySelectRecipe.vue
+++ b/docs/.vitepress/theme/components/klean/select/SlipwaySelectRecipe.vue
@@ -1,0 +1,63 @@
+<script setup>
+import { ref } from 'vue'
+import KleanSelect from './Select.vue'
+
+const category = ref('feature')
+const categoryOptions = [
+  { value: 'feature', label: 'Feature' },
+  { value: 'bug', label: 'Bug' }
+]
+</script>
+
+<template>
+  <div
+    class="w-full max-w-2xl rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-950 sm:p-7"
+  >
+    <div
+      class="flex items-center gap-3 [&_[data-slot=select]]:w-auto [&_[data-slot=select-content]]:max-h-64 [&_[data-slot=select-content]]:min-w-44 [&_[data-slot=select-content]]:max-w-[min(20rem,calc(100vw-2.5rem))] [&_[data-slot=select-content]]:rounded-xl [&_[data-slot=select-content]]:border-gray-200 [&_[data-slot=select-content]]:bg-white [&_[data-slot=select-content]]:p-1 [&_[data-slot=select-content]]:shadow-xl [&_[data-slot=select-content]]:shadow-gray-950/10 dark:[&_[data-slot=select-content]]:border-gray-700 dark:[&_[data-slot=select-content]]:bg-gray-900 dark:[&_[data-slot=select-content]]:shadow-black/30 [&_[data-slot=select-option]]:min-h-10 [&_[data-slot=select-option]]:rounded-none [&_[data-slot=select-option]]:px-3.5 [&_[data-slot=select-option]]:py-2 [&_[data-slot=select-option]]:text-gray-700 dark:[&_[data-slot=select-option]]:text-gray-300 [&_[data-slot=select-option][data-highlighted]]:bg-gray-50 dark:[&_[data-slot=select-option][data-highlighted]]:bg-gray-800 [&_[data-slot=select-indicator]]:text-gray-500 dark:[&_[data-slot=select-indicator]]:text-gray-400"
+    >
+      <span
+        role="img"
+        aria-label="Posting as Kelvin"
+        title="Posting as Kelvin"
+        class="grid size-10 shrink-0 place-items-center rounded-full bg-gray-950 text-xs font-semibold text-white dark:bg-white dark:text-gray-950"
+      >
+        <span aria-hidden="true">KO</span>
+      </span>
+
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        class="size-4 shrink-0 text-gray-300 dark:text-gray-700"
+        fill="none"
+      >
+        <path
+          d="m6 3.5 4.5 4.5L6 12.5"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+        />
+      </svg>
+
+      <div>
+        <span id="docs-slipway-category-label" class="sr-only">Category</span>
+        <KleanSelect
+          id="docs-slipway-category"
+          v-model="category"
+          :options="categoryOptions"
+          aria-labelledby="docs-slipway-category-label"
+          class="min-h-10 w-auto max-w-[16rem] rounded-lg border-0 bg-gray-100 px-3.5 py-2 text-sm font-semibold text-gray-950 shadow-none hover:border-transparent hover:bg-gray-200 focus-visible:border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 dark:bg-gray-900 dark:text-white dark:hover:border-transparent dark:hover:bg-gray-800 dark:focus-visible:border-transparent dark:focus-visible:ring-white dark:focus-visible:ring-offset-gray-950"
+        />
+      </div>
+    </div>
+
+    <label for="docs-slipway-feedback-summary" class="sr-only">Summary</label>
+    <input
+      id="docs-slipway-feedback-summary"
+      type="text"
+      placeholder="What would make this better?"
+      class="mt-7 w-full border-0 bg-transparent p-0 text-xl font-semibold tracking-tight text-gray-950 placeholder:font-medium placeholder:text-gray-300 focus:ring-0 dark:text-white dark:placeholder:text-gray-500 sm:text-2xl"
+    />
+  </div>
+</template>

--- a/docs/klean-ui/components/select.md
+++ b/docs/klean-ui/components/select.md
@@ -11,6 +11,7 @@ import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
 import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
 import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
 import KleanSelect from '../../.vitepress/theme/components/klean/select/Select.vue'
+import SlipwaySelectRecipe from '../../.vitepress/theme/components/klean/select/SlipwaySelectRecipe.vue'
 import selectSource from '../../.vitepress/theme/components/klean/select/Select.vue?raw'
 import popoverSource from '../../.vitepress/theme/components/klean/popover/Popover.vue?raw'
 import reactSource from '../sources/select/Select.jsx?raw'
@@ -26,8 +27,6 @@ const roleOptions = [
   { value: 'editor', label: 'Editor', disabled: true },
   { value: 'administrator', label: 'Administrator' }
 ]
-const invoiceStatus = ref('draft')
-const environment = ref('production')
 const vueFiles = [
   {
     filename: 'Popover.vue',
@@ -213,53 +212,16 @@ hatch.
 
 ### Product recipes
 
-Hagfish can retain its square border and offset shadow while Slipway keeps its
-compact operational treatment. They share behavior without selecting a Klean
-theme.
+This compact treatment comes directly from Slipway's Bearing feedback composer.
+Source-app recipes appear here only when they map to an interface that actually
+exists; Klean does not invent a product look to fill a comparison.
 
-<KleanPreview id="select-products" :source="productSource" filename="product-selects.vue">
+<KleanPreview id="select-products" :source="productSource" filename="slipway-select.vue">
   <template #preview>
-    <div class="grid w-full max-w-2xl gap-8 sm:grid-cols-2">
-      <section class="bg-[#f4f0e8] p-6 [&_[data-slot=select-content]]:rounded-none [&_[data-slot=select-content]]:border-2 [&_[data-slot=select-content]]:border-black [&_[data-slot=select-content]]:shadow-[6px_6px_0_0_#000]">
-        <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-600">
-          Hagfish / invoice
-        </p>
-        <label for="docs-invoice-status" class="mb-2 block text-sm font-medium text-black">
-          Invoice status
-        </label>
-        <KleanSelect
-          id="docs-invoice-status"
-          v-model="invoiceStatus"
-          :options="[
-            { value: 'draft', label: 'Draft' },
-            { value: 'sent', label: 'Sent' },
-            { value: 'paid', label: 'Paid' }
-          ]"
-          class="rounded-none border-2 border-black bg-white text-black shadow-[4px_4px_0_0_#000] hover:border-black focus-visible:border-black focus-visible:outline-black"
-        />
-      </section>
-      <section class="dark bg-gray-950 p-6 text-white [&_[data-slot=select-content]]:border-gray-700 [&_[data-slot=select-content]]:bg-gray-900 [&_[data-slot=select-content]]:shadow-xl">
-        <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-400">
-          Slipway / deploy
-        </p>
-        <label for="docs-environment" class="mb-2 block text-sm font-medium">
-          Environment
-        </label>
-        <KleanSelect
-          id="docs-environment"
-          v-model="environment"
-          :options="[
-            { value: 'preview', label: 'Preview' },
-            { value: 'staging', label: 'Staging' },
-            { value: 'production', label: 'Production' }
-          ]"
-          class="min-h-9 border-gray-700 bg-gray-900 px-3 py-1.5 text-sm text-white shadow-none hover:border-gray-600 focus-visible:border-white focus-visible:outline-white"
-        />
-      </section>
-    </div>
+    <SlipwaySelectRecipe />
   </template>
   <template #caption>
-    Every visual choice is ordinary caller Tailwind. Neither treatment needs a variant or theme selector.
+    Slipway's compact trigger and popup are ordinary caller Tailwind. They do not require a variant or theme selector.
   </template>
 </KleanPreview>
 

--- a/docs/klean-ui/snippets/select/products.vue
+++ b/docs/klean-ui/snippets/select/products.vue
@@ -2,28 +2,18 @@
 import { ref } from 'vue'
 import Select from '@/components/ui/select/Select.vue'
 
-const invoiceStatus = ref('draft')
-const environment = ref('production')
+const category = ref('feature')
+const categories = [
+  { value: 'feature', label: 'Feature' },
+  { value: 'bug', label: 'Bug' }
+]
 </script>
 
 <template>
   <Select
-    v-model="invoiceStatus"
-    :options="[
-      { value: 'draft', label: 'Draft' },
-      { value: 'sent', label: 'Sent' },
-      { value: 'paid', label: 'Paid' }
-    ]"
-    class="rounded-none border-2 border-black bg-white text-black shadow-[4px_4px_0_0_#000]"
-  />
-
-  <Select
-    v-model="environment"
-    :options="[
-      { value: 'preview', label: 'Preview' },
-      { value: 'staging', label: 'Staging' },
-      { value: 'production', label: 'Production' }
-    ]"
-    class="min-h-9 border-gray-700 bg-gray-900 px-3 py-1.5 text-sm text-white shadow-none"
+    v-model="category"
+    :options="categories"
+    aria-label="Feedback category"
+    class="min-h-10 w-auto max-w-[16rem] rounded-lg border-0 bg-gray-100 px-3.5 py-2 text-sm font-semibold text-gray-950 shadow-none hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2"
   />
 </template>


### PR DESCRIPTION
Fixes #170

- remove the fabricated Hagfish Select comparison
- render Slipway's real Bearing feedback treatment in the live preview
- keep the consumer source copyable and free of docs-only markup
- preserve the no-variant Tailwind styling contract