### PR TITLE
docs(slipway): document Bearing

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -1094,6 +1094,7 @@ function slipwayGuide() {
       items: [
         { text: 'Helm', link: '/slipway/helm' },
         { text: 'Bridge', link: '/slipway/bridge' },
+        { text: 'Bearing', link: '/slipway/bearing' },
         { text: 'Content', link: '/slipway/content' },
         { text: 'Quest', link: '/slipway/quest' },
         { text: 'Dock', link: '/slipway/dock' },

--- a/docs/slipway/bearing.md
+++ b/docs/slipway/bearing.md
@@ -1,0 +1,157 @@
+---
+head:
+  - - meta
+    - property: 'og:image'
+      content: https://docs.sailscasts.com/slipway-social.png
+title: Bearing
+titleTemplate: Slipway
+description: Collect feedback, publish a roadmap, and announce product updates on your application's own domain.
+prev:
+  text: Bridge
+  link: /slipway/bridge
+next:
+  text: Content
+  link: /slipway/content
+editLink: true
+---
+
+# Bearing
+
+Bearing turns customer feedback into visible product direction without adding another service or account system to your application.
+
+Your customers see three familiar surfaces:
+
+- **Feedback** for sharing and supporting ideas;
+- **Roadmap** for seeing what is planned and in progress; and
+- **Updates** for learning what shipped.
+
+The product is called Bearing inside Slipway. Public pages use the plain labels your customers already understand.
+
+## App-owned URLs
+
+Bearing stays on the deployed application's domain. A root application uses:
+
+```text
+https://your-app.example.com/feedback
+https://your-app.example.com/roadmap
+https://your-app.example.com/updates
+```
+
+For an application mounted below `/academy`, the same pages become:
+
+```text
+https://example.com/academy/feedback
+https://example.com/academy/roadmap
+https://example.com/academy/updates
+```
+
+Slipway serves these pages through the application's existing Caddy route. Navigation, sessions, and assets remain on the app's origin.
+
+## Enable Bearing
+
+1. Install `sails-hook-slipway@^0.0.7` in the Sails application.
+2. Open the app in Slipway and choose **Bearing** from the app menu.
+3. Enable Bearing and choose who may participate.
+4. Redeploy the app once so Slipway can inject its private app-scoped exchange credential and activate the host-app integration.
+
+Slipway owns the public routes and runtime settings. You do not need to add Feedback, Roadmap, or Updates routes to the application.
+
+## Participation
+
+Anyone can read the public pages. Writing has a stricter default.
+
+By default, submitting feedback and voting require an authenticated user of the host application. Bearing uses the application's existing server-side session and verified email state; it does not create a separate customer account.
+
+Bearing and Bridge share one host-app identity contract. Configure
+`slipway.identity` once when an app does not use the default Boring Stack model
+or login route. Bearing can inherit an existing `slipway.bridge.identity` and
+`bridge.loginPath` configuration, so adding Bearing does not duplicate app
+authentication code. For tenant-aware or external authentication, a
+`loginHelper` may compute the safe local login URL and return destination from
+the request instead of hard-coding `/login` or `/signin` into either feature.
+
+The handoff works as follows:
+
+1. The customer chooses **Sign in to share**.
+2. The app's installed Slipway hook resolves its current authenticated user.
+3. The hook sends the stable user ID, display name, and verified email to Slipway over an app-authenticated server channel.
+4. Slipway returns a short-lived, single-use code.
+5. Redeeming that code establishes an app-scoped Bearing participant session.
+
+Raw identity is never placed in a query string. A participant is not a Slipway team member, Slipway user, or Bridge access grant.
+
+### Anonymous participation
+
+Enable **Allow anonymous participation** when guests should be able to submit and vote without signing in. It is disabled by default.
+
+Turning it off immediately blocks new anonymous mutations without deleting feedback that was already submitted anonymously.
+
+## Settings
+
+Bearing is configured per app because each app owns its domain, route prefix, deployment, and user session.
+
+| Setting                       | Default | Effect                                                         |
+| ----------------------------- | ------- | -------------------------------------------------------------- |
+| Bearing                       | Off     | Master switch for all Bearing routes and writes                |
+| Accept new feedback           | On      | Pauses new submissions while keeping existing feedback visible |
+| Allow anonymous participation | Off     | Allows guests to submit and vote                               |
+| Public roadmap                | On      | Publishes or hides `/roadmap`                                  |
+| Public updates                | On      | Publishes or hides `/updates`                                  |
+| In-app widget                 | Off     | Adds the Bearing launcher to successful HTML pages             |
+| Widget side                   | Right   | Places the launcher at the bottom right or bottom left         |
+| Opening view                  | Updates | Opens the widget on Updates or Feedback                        |
+| Unread indicator              | On      | Shows What's new until that visitor opens the latest update    |
+
+The master switch and participation rules are enforced on the server. Hiding a control in the browser is never treated as authorization.
+
+## Feedback and roadmap
+
+New feedback enters the Bearing inbox as **Reviewing**. An app owner or administrator can move it through:
+
+```text
+Reviewing → Planned → In progress → Shipped
+          ↘ Closed
+```
+
+Planned and In-progress feedback automatically appears on the public Roadmap. There is no second roadmap record to keep synchronized.
+
+## Updates
+
+An update explains something useful that changed. Link it to one or more feedback items when the release delivers what customers requested.
+
+Publishing the update marks those linked items Shipped and makes the update available on `/updates` and in the widget.
+
+This publish and state change happen in one database transaction. A failed
+publish cannot leave the public update and its linked roadmap items disagreeing.
+
+## In-app widget
+
+When enabled, `sails-hook-slipway` inserts the same-origin Bearing bootstrap into eligible HTML responses. The bootstrap checks the current Slipway setting before rendering, so disabling the widget takes effect without another deployment.
+
+The widget:
+
+- is isolated from host styles;
+- waits for interaction before loading its full interface;
+- supports keyboard navigation, Escape, and focus restoration;
+- respects reduced-motion preferences; and
+- fails open, leaving the host page unchanged if Bearing is unavailable.
+
+The attention state is deliberately temporary. Bearing compares the latest
+published update's public ID with a small seen watermark in that visitor's
+browser. The trigger says **What's new** only when those IDs differ, then clears
+the attention as soon as the visitor opens the widget. With no published update
+there is nothing to mark as new, and a previously seen release does not stay
+highlighted forever.
+
+The hook skips JSON, redirects, downloads, streams, Server-Sent Events, and responses whose Content Security Policy cannot safely allow the same-origin script.
+
+## Security boundaries
+
+- Bearing is disabled per app by default.
+- Its private exchange credential never reaches the browser.
+- Host identity must have a verified email unless the app uses an explicit identity helper with equivalent proof.
+- Launch codes expire quickly and can be redeemed only once.
+- Disabling Bearing or rotating its app credential invalidates stale writing sessions.
+- Public responses never include participant email addresses or stable host-user IDs.
+
+For the underlying app identity convention and custom identity helpers, see [Bridge app-local access](/slipway/bridge#app-local-access). Bearing shares that provider-neutral resolver, but not Bridge invitations or roles.

--- a/docs/slipway/bridge.md
+++ b/docs/slipway/bridge.md
@@ -10,8 +10,8 @@ prev:
   text: Helm
   link: /slipway/helm
 next:
-  text: Content
-  link: /slipway/content
+  text: Bearing
+  link: /slipway/bearing
 editLink: true
 ---
 

--- a/docs/slipway/content.md
+++ b/docs/slipway/content.md
@@ -7,8 +7,8 @@ title: Content
 titleTemplate: Slipway
 description: Manage sails-content Markdown and JSON files from a visual, Git-backed editor in Slipway.
 prev:
-  text: Bridge
-  link: /slipway/bridge
+  text: Bearing
+  link: /slipway/bearing
 next:
   text: Quest
   link: /slipway/quest

--- a/docs/slipway/index.md
+++ b/docs/slipway/index.md
@@ -40,6 +40,11 @@ features:
   - icon: 🔧
     title: Production REPL
     details: Debug and inspect your running app with Helm. Execute Sails helpers and queries in a production console.
+    link: /slipway/helm
+  - icon: 🧭
+    title: Customer Feedback
+    details: Turn feedback into a public roadmap and useful product updates with Bearing, all on your application's own domain.
+    link: /slipway/bearing
   - icon: 🔄
     title: Push-to-Deploy
     details: Connect your GitHub repo and deploy automatically on every push via webhooks.

--- a/docs/slipway/what-is-slipway.md
+++ b/docs/slipway/what-is-slipway.md
@@ -17,7 +17,7 @@ editLink: true
 
 # What is Slipway?
 
-Slipway is an open-source, self-hosted deployment platform for **Sails.js** and **The Boring JavaScript Stack** applications. It combines deployment, database management, admin access, REPL access, and Quest monitoring in one platform.
+Slipway is an open-source, self-hosted deployment platform for **Sails.js** and **The Boring JavaScript Stack** applications. It combines deployment, database management, admin access, customer feedback, REPL access, and Quest monitoring in one platform.
 
 ## The Goal
 
@@ -30,6 +30,7 @@ Slipway provides:
 - **Admin panel** — Auto-generated CRUD for your Sails models (Bridge)
 - **Production REPL** — Query your production data safely (Helm)
 - **Queue monitoring** — Sails Quest integration (Quest Dashboard)
+- **Customer feedback** — App-owned feedback, roadmap, updates, and widget (Bearing)
 
 ## The Slipway Suite
 
@@ -40,6 +41,7 @@ Slipway includes these tools:
 | **Slipway Deploy**  | Forge/Coolify   | Deployment & infrastructure      |
 | **Slipway Helm**    | Tinkerwell      | Production REPL for Sails        |
 | **Slipway Bridge**  | Nova/AdminJS    | Auto-generated data management   |
+| **Slipway Bearing** | UserJot/Canny   | Feedback, roadmap, and updates   |
 | **Quest Dashboard** | Laravel Horizon | Queue monitoring for Sails Quest |
 
 ### Helm
@@ -70,6 +72,15 @@ Bridge auto-generates an admin panel from your Sails models:
 - File upload handling
 - Role-based access control
 
+### Bearing
+
+Bearing gives every app a feedback loop on its own domain:
+
+- Public Feedback, Roadmap, and Updates pages
+- Host-app identity without another customer account
+- Server-enforced identified or anonymous participation
+- A Slipway-controlled in-app updates widget
+
 ### Quest Dashboard
 
 If your app uses [Sails Quest](https://docs.sailscasts.com/sails-quest) for job queues, Slipway automatically provides a queue dashboard:
@@ -85,7 +96,7 @@ If your app uses [Sails Quest](https://docs.sailscasts.com/sails-quest) for job 
 2. **Connect your Sails app** — Via Git or CLI deploy
 3. **Slipway detects your app** — Reads your models, config, and hooks
 4. **Deploy with one command** — `slipway slide` deploys your app
-5. **Manage everything from the dashboard** — Bridge, Helm, logs, domains
+5. **Manage everything from the dashboard** — Bridge, Bearing, Helm, logs, domains
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- add a complete Bearing guide covering Feedback, Roadmap, Updates, app-owned URLs, participation, settings, identity handoff, the widget, and security boundaries
- add Bearing to the Slipway platform navigation and documentation landing page
- add Bearing to the Slipway suite overview and feature list
- update the Bridge → Bearing → Content documentation sequence

## Why

Bearing is now a first-class Slipway capability. Operators need one customer-facing guide that explains what their users see and one precise operational contract for configuring participation and app-owned delivery.

The public product surfaces already link “Powered by Slipway” to the Slipway documentation and have application-level coverage for that attribution.

## Validation

- `npm run lint`
- `npm run build` after rebasing onto current `main`
- internal navigation and page sequencing reviewed

Closes #146