### PR TITLE
docs: add Klean Spinner guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -119,6 +119,7 @@ function kleanUiGuide() {
         { text: 'Checkbox', link: '/klean-ui/components/checkbox' },
         { text: 'Radio', link: '/klean-ui/components/radio' },
         { text: 'Switch', link: '/klean-ui/components/switch' },
+        { text: 'Spinner', link: '/klean-ui/components/spinner' },
         { text: 'Popover', link: '/klean-ui/components/popover' },
         { text: 'Menu', link: '/klean-ui/components/menu' },
         { text: 'Select', link: '/klean-ui/components/select' },

--- a/docs/.vitepress/theme/components/klean/spinner/ProductLoader.vue
+++ b/docs/.vitepress/theme/components/klean/spinner/ProductLoader.vue
@@ -1,0 +1,62 @@
+<template>
+  <svg
+    viewBox="0 0 32 32"
+    fill="none"
+    aria-hidden="true"
+    data-product-loader=""
+    class="product-loader h-5 w-5"
+  >
+    <path
+      d="M7 17C7 3 25 3 25 17Z"
+      fill="currentColor"
+      fill-opacity="0.1"
+      stroke="currentColor"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M7 17C4 21 4 25 8 28M12 17C11 21 10 25 13 28M20 17C21 21 22 25 19 28M25 17C28 21 28 25 24 28"
+      stroke="currentColor"
+      stroke-width="2.5"
+      stroke-linecap="round"
+    />
+    <circle cx="13" cy="11" r="1.8" fill="currentColor" />
+    <ellipse
+      class="product-loader-wink"
+      cx="19"
+      cy="11"
+      rx="1.8"
+      ry="1.8"
+      fill="currentColor"
+    />
+  </svg>
+</template>
+
+<style>
+.product-loader {
+  animation: product-loader-bob 1.6s ease-in-out infinite;
+}
+
+.product-loader-wink {
+  animation: product-loader-wink 4s ease-in-out infinite;
+}
+
+@keyframes product-loader-bob {
+  50% {
+    transform: translateY(-15%);
+  }
+}
+
+@keyframes product-loader-wink {
+  0%,
+  38%,
+  42%,
+  100% {
+    ry: 1.8;
+  }
+  40% {
+    ry: 0.2;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/klean/spinner/Spinner.vue
+++ b/docs/.vitepress/theme/components/klean/spinner/Spinner.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { computed, useAttrs, useSlots } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
+const slots = useSlots()
+const hasCustomMark = computed(() => Boolean(slots.default))
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    'aria-hidden': _ariaHidden,
+    role: _role,
+    focusable: _focusable,
+    tabindex: _tabindex,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+</script>
+
+<template>
+  <span
+    v-bind="forwardedAttrs"
+    data-slot="spinner"
+    aria-hidden="true"
+    :class="
+      twMerge(
+        [
+          'inline-flex size-4 shrink-0 items-center justify-center motion-reduce:animate-none! motion-reduce:[&_*]:animate-none! [&>*]:size-full',
+          hasCustomMark ? '' : 'animate-spin'
+        ],
+        attrs.class
+      )
+    "
+  >
+    <slot>
+      <svg
+        data-slot="spinner-mark"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 24 24"
+        fill="none"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          stroke="currentColor"
+          stroke-width="2"
+          opacity="0.2"
+        />
+        <path
+          d="M21 12a9 9 0 0 0-9-9"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+        />
+      </svg>
+    </slot>
+  </span>
+</template>

--- a/docs/klean-ui/components/button.md
+++ b/docs/klean-ui/components/button.md
@@ -10,8 +10,11 @@ import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
 import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
 import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
 import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
+import ProductLoader from '../../.vitepress/theme/components/klean/spinner/ProductLoader.vue'
+import KleanSpinner from '../../.vitepress/theme/components/klean/spinner/Spinner.vue'
 import buttonSource from '../../.vitepress/theme/components/klean/Button.vue?raw'
 import basicUsage from '../snippets/button/usage.vue?raw'
+import pendingUsage from '../snippets/button/pending.vue?raw'
 import semanticUsage from '../snippets/button/semantics.vue?raw'
 import productRecipes from '../snippets/button/products.vue?raw'
 </script>
@@ -52,6 +55,26 @@ The standard Boring Stack path requires no `init`, `klean-ui.json`, alias prompt
 <CopyCode :code="basicUsage" label="usage.vue" />
 
 Visual styling stays in the framework's ordinary class API. If the same product treatment repeats, create an application-owned component such as `PrimaryButton.vue` using Button as its semantic base.
+
+## Pending actions
+
+Button intentionally has no `loading` prop. The real request state owns `disabled` and `aria-busy`, the visible label says what is happening, and Spinner supplies a decorative mark. A product such as Slipway can pass its own animated mascot through Spinner without changing Button's API.
+
+<KleanPreview id="button-pending" :source="pendingUsage" filename="pending-button.vue">
+  <template #preview>
+    <KleanButton type="button" disabled aria-busy="true">
+      <KleanSpinner class="size-4">
+        <ProductLoader />
+      </KleanSpinner>
+      Deploying service…
+    </KleanButton>
+  </template>
+  <template #source>
+
+<<< ../snippets/button/pending.vue
+
+  </template>
+</KleanPreview>
 
 ## API
 
@@ -134,6 +157,7 @@ Klean's neutral default stays motionless and uses tonal feedback. Hagfish delibe
 
 ## Related components
 
+- [Spinner](/klean-ui/components/spinner) — a decorative pending mark inside a truthfully labelled busy button.
 - [Slide](/klean-ui/components/slide) — higher-friction confirmation for consequential actions.
 - [Menu](/klean-ui/components/menu) — a compact list of actions and destinations.
 - [Popover](/klean-ui/components/popover) — a non-modal surface invoked by a button.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -37,6 +37,10 @@ A native-first mutually exclusive choice for short visible lists. Shared names, 
 
 A native-first boolean setting that takes effect immediately, with real checked state, browser keyboard and form behavior, honest optimistic rollback recipes, and caller-owned Tailwind styling.
 
+### [Spinner](/klean-ui/components/spinner)
+
+A calm decorative mark for indeterminate work, with caller-owned Tailwind styling and truthful busy and status semantics left in visible application markup.
+
 ### [Popover](/klean-ui/components/popover)
 
 A native-first non-modal floating surface with light dismissal, focus return, collision-aware positioning, and ordinary semantic content. A real button invokes it through the browser's `popovertarget` relationship.

--- a/docs/klean-ui/components/slide.md
+++ b/docs/klean-ui/components/slide.md
@@ -175,5 +175,6 @@ Copy, inspect, and change the complete source for your framework.
 ## Related components
 
 - [Button](/klean-ui/components/button) — the ordinary choice for actions that do not need extra friction.
+- [Spinner](/klean-ui/components/spinner) — a decorative pending mark after confirmation starts real work.
 - [Toast](/klean-ui/components/toast) — announce the result after confirmation.
 - [Dialog](/klean-ui/components/dialog) — gather context or explicit choices before a consequential action.

--- a/docs/klean-ui/components/spinner.md
+++ b/docs/klean-ui/components/spinner.md
@@ -1,0 +1,217 @@
+---
+title: Spinner
+titleTemplate: Klean UI
+description: A calm, accessible loading wrapper for Vue, React, and Svelte with a neutral fallback and product-owned marks.
+outline: [2, 3]
+---
+
+<script setup>
+import { onBeforeUnmount, ref } from 'vue'
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
+import ProductLoader from '../../.vitepress/theme/components/klean/spinner/ProductLoader.vue'
+import KleanSpinner from '../../.vitepress/theme/components/klean/spinner/Spinner.vue'
+import spinnerSource from '../../.vitepress/theme/components/klean/spinner/Spinner.vue?raw'
+import reactSource from '../sources/spinner/Spinner.jsx?raw'
+import svelteSource from '../sources/spinner/Spinner.svelte?raw'
+import vueUsage from '../snippets/spinner/usage.vue?raw'
+import reactUsage from '../snippets/spinner/usage.jsx?raw'
+import svelteUsage from '../snippets/spinner/usage.svelte?raw'
+import customUsage from '../snippets/spinner/custom.vue?raw'
+import stylingUsage from '../snippets/spinner/styling.vue?raw'
+
+const loading = ref(false)
+const message = ref('Ready to refresh.')
+let finishTimer
+
+function refresh() {
+  if (loading.value) return
+
+  loading.value = true
+  message.value = 'Refreshing deployments…'
+  clearTimeout(finishTimer)
+  finishTimer = setTimeout(() => {
+    loading.value = false
+    message.value = 'Deployments are up to date.'
+  }, 2400)
+}
+
+onBeforeUnmount(() => clearTimeout(finishTimer))
+</script>
+
+# Spinner
+
+Spinner is a small decorative wrapper for indeterminate work. It includes a neutral fallback ring, accepts an application-owned loading mark, inherits the caller's text color, and leaves loading state and meaningful language with the application.
+
+<KleanPreview id="spinner-source" :source="spinnerSource" filename="Spinner.vue">
+  <template #preview>
+    <section
+      class="grid min-h-64 w-full place-items-center rounded-xl bg-gray-950 p-6 text-white"
+      :aria-busy="loading"
+      aria-describedby="spinner-preview-status"
+    >
+      <div class="grid justify-items-center gap-5 text-center">
+        <div>
+          <h2 class="font-semibold">Recent deployments</h2>
+          <p class="mt-1 text-sm text-gray-400">The region remains understandable while it refreshes.</p>
+        </div>
+        <KleanButton
+          type="button"
+          :disabled="loading"
+          :aria-busy="loading"
+          class="min-h-10 min-w-0 bg-white px-4 py-2 text-gray-950 disabled:opacity-70 dark:bg-white dark:text-gray-950"
+          @click="refresh"
+        >
+          <KleanSpinner v-if="loading">
+            <ProductLoader />
+          </KleanSpinner>
+          {{ loading ? 'Refreshing…' : 'Refresh deployments' }}
+        </KleanButton>
+        <p id="spinner-preview-status" role="status" aria-live="polite" aria-atomic="true" class="min-h-5 text-sm text-gray-400">
+          {{ message }}
+        </p>
+      </div>
+    </section>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/spinner/Spinner.vue
+
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and installs the framework-native source:
+
+<KleanInstallation
+  id="spinner-installation"
+  component="spinner"
+  :source="spinnerSource"
+  filename="Spinner.vue"
+  destination="assets/js/components/ui/spinner/Spinner.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+The installed file belongs to the application. There is no initializer, Klean runtime, configuration file, provider, alias prompt, generated helper, or animation package.
+
+## Usage
+
+Keep the status surface mounted before its contents change. Spinner is decorative, so the useful status is announced once rather than as an unnamed image and again as text.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="DeploymentStatus.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="DeploymentStatus.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="DeploymentStatus.svelte" />
+
+## Loading semantics
+
+Spinner's wrapper renders `aria-hidden="true"`; its fallback SVG is also non-focusable. The surrounding application describes the work:
+
+- put `aria-busy="true"` on the button or region whose content is changing;
+- keep specific visible text such as “Saving invoice…” or “Deploying service…”;
+- use a persistent `role="status"` surface when a dynamic change should be announced;
+- keep existing content readable when refreshing it is safer than replacing the whole region;
+- disable a submitting button when a second activation would duplicate the request.
+
+Do not put `role="status"` or an accessible label on Spinner itself. One page can contain several visual marks while exposing one useful status message.
+
+## Product-owned marks
+
+The neutral ring works without setup. When an application's identity belongs in the loading moment, put its own component inside Spinner:
+
+<CopyCode :code="customUsage" label="SlippySpinner.vue" />
+
+The wrapper owns one size class and makes its direct child fill that space. A supplied mark keeps its own animation; Spinner does not rotate it a second time. This is how Slipway retains the animated Slippy mascot while adopting Klean's shared loading contract. Slippy remains Slipway source—it does not become a `mascot`, `icon`, or `variant` prop.
+
+## Buttons and regions
+
+The button owns its native state:
+
+```vue
+<Button type="submit" :disabled="form.processing" :aria-busy="form.processing">
+  <Spinner v-if="form.processing" class="size-4">
+    <SlippyLoader />
+  </Spinner>
+  {{ form.processing ? 'Saving changes…' : 'Save changes' }}
+</Button>
+```
+
+For a refreshed surface, put busy state on the surface and connect it to useful status text:
+
+```vue
+<section :aria-busy="refreshing" aria-describedby="deployment-status">
+  <p id="deployment-status" role="status">
+    <template v-if="refreshing">
+      <Spinner /> Refreshing deployments…
+    </template>
+  </p>
+
+  <!-- Existing deployment rows -->
+</section>
+```
+
+Spinner represents indeterminate work. When progress can be measured and that measurement helps someone decide whether to wait, use visible progress text or the native `<progress>` element.
+
+## Styling with Tailwind
+
+The wrapper and its mark use `currentColor`. Size and color are ordinary caller classes:
+
+<CopyCode :code="stylingUsage" label="loading-styles.vue" />
+
+The fallback is a small neutral ring. There are no `size`, `color`, `speed`, `stroke`, `variant`, `tone`, `mascot`, or `loading` props. Repeated product treatment belongs in an application component. Brand characters and product-specific loaders remain product-owned.
+
+## API
+
+| Concern        | Vue                                      | React                                    | Svelte                                   |
+| -------------- | ---------------------------------------- | ---------------------------------------- | ---------------------------------------- |
+| Styling        | `class`                                  | `className`                              | `class`                                  |
+| Element access | template ref                             | forwarded `ref`                          | component binding                        |
+| Wrapper attrs  | non-conflicting native `span` attributes | non-conflicting native `span` attributes | non-conflicting native `span` attributes |
+| Custom mark    | default slot                             | `children`                               | default snippet                          |
+| Semantics      | fixed decorative wrapper                 | fixed decorative wrapper                 | fixed decorative wrapper                 |
+
+`data-slot="spinner"` is stable for inspection and nearby selectors. The caller owns loading state, status text, `aria-busy`, cancellation, progress, retry, and persistence.
+
+## Motion
+
+The default ring follows `prefers-reduced-motion` without JavaScript. A custom mark supplies its own normal animation; Spinner's reduced-motion guard stops CSS animation inside the wrapper. With motion reduced, the mark remains visible and adjacent text continues communicating the state.
+
+Avoid bounce, wobble, dramatic entrances, and long exits. Loading is already an interruption; its utility indicator should be calm.
+
+## Durable behavior
+
+Loading state is ephemeral and should be derived from the real request, navigation, or job. Spinner never writes it to local storage, the URL, or a component timer.
+
+Long-running server work is different from an in-flight browser request. Restore its true state from the server after navigation or reload, then render Spinner from that state. This keeps the interface honest after refreshes and reconnects.
+
+## Complete framework source
+
+Copy, inspect, and change the complete source for your framework.
+
+### Vue source
+
+<CopyCode :code="spinnerSource" label="Spinner.vue" />
+
+### React source
+
+<CopyCode :code="reactSource" label="Spinner.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteSource" label="Spinner.svelte" />
+
+## Related components
+
+- [Button](/klean-ui/components/button) — owns a command's disabled, busy, and truthful pending states.
+- [Toast](/klean-ui/components/toast) — announces a completed background outcome without blocking the current task.
+- [Slide](/klean-ui/components/slide) — may expose pending state after a consequential action is confirmed.

--- a/docs/klean-ui/components/toast.md
+++ b/docs/klean-ui/components/toast.md
@@ -515,6 +515,7 @@ Copy, inspect, and change the complete source for your framework.
 
 ## Related components
 
+- [Spinner](/klean-ui/components/spinner) — represents work in progress; Toast reports a useful outcome.
 - [Button](/klean-ui/components/button) — a truthful toast action or dismissal control.
 - [Slide](/klean-ui/components/slide) — confirm consequential work before announcing its result.
 - [Schedule Picker](/klean-ui/components/schedule-picker) — choose an instant, then announce the server outcome.

--- a/docs/klean-ui/snippets/button/pending.vue
+++ b/docs/klean-ui/snippets/button/pending.vue
@@ -1,0 +1,18 @@
+<script setup>
+import Button from '@/components/ui/button/Button.vue'
+import Spinner from '@/components/ui/spinner/Spinner.vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
+</script>
+
+<template>
+  <Button
+    type="submit"
+    :disabled="form.processing"
+    :aria-busy="form.processing"
+  >
+    <Spinner v-if="form.processing" class="size-4">
+      <SlippyLoader />
+    </Spinner>
+    {{ form.processing ? 'Deploying service…' : 'Deploy service' }}
+  </Button>
+</template>

--- a/docs/klean-ui/snippets/spinner/custom.vue
+++ b/docs/klean-ui/snippets/spinner/custom.vue
@@ -1,0 +1,10 @@
+<script setup>
+import Spinner from '@/components/ui/spinner/Spinner.vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
+</script>
+
+<template>
+  <Spinner class="size-4">
+    <SlippyLoader />
+  </Spinner>
+</template>

--- a/docs/klean-ui/snippets/spinner/styling.vue
+++ b/docs/klean-ui/snippets/spinner/styling.vue
@@ -1,0 +1,12 @@
+<template>
+  <!-- Compact secondary status -->
+  <Spinner class="size-3 text-gray-500" />
+
+  <!-- Prominent application status -->
+  <Spinner class="size-8 text-sky-600" />
+
+  <!-- Product-owned mark, sized by the same wrapper -->
+  <Spinner class="size-6 text-white">
+    <ProductLoader />
+  </Spinner>
+</template>

--- a/docs/klean-ui/snippets/spinner/usage.jsx
+++ b/docs/klean-ui/snippets/spinner/usage.jsx
@@ -1,0 +1,14 @@
+import Spinner from '@/components/ui/spinner/Spinner.jsx'
+
+export default function DeploymentStatus({ loading }) {
+  return (
+    <span role="status" aria-live="polite" aria-atomic="true">
+      {loading ? (
+        <>
+          <Spinner className="size-4" />
+          <span>Loading deployments…</span>
+        </>
+      ) : null}
+    </span>
+  )
+}

--- a/docs/klean-ui/snippets/spinner/usage.svelte
+++ b/docs/klean-ui/snippets/spinner/usage.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Spinner from '$lib/components/ui/spinner/Spinner.svelte'
+
+  let { loading = false } = $props()
+</script>
+
+<span role="status" aria-live="polite" aria-atomic="true">
+  {#if loading}
+    <Spinner class="size-4" />
+    <span>Loading deployments…</span>
+  {/if}
+</span>

--- a/docs/klean-ui/snippets/spinner/usage.vue
+++ b/docs/klean-ui/snippets/spinner/usage.vue
@@ -1,0 +1,12 @@
+<script setup>
+import Spinner from '@/components/ui/spinner/Spinner.vue'
+</script>
+
+<template>
+  <span role="status" aria-live="polite" aria-atomic="true">
+    <template v-if="loading">
+      <Spinner class="size-4" />
+      <span>Loading deployments…</span>
+    </template>
+  </span>
+</template>

--- a/docs/klean-ui/sources/spinner/Spinner.jsx
+++ b/docs/klean-ui/sources/spinner/Spinner.jsx
@@ -1,0 +1,59 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const Spinner = forwardRef(function Spinner(
+  {
+    children,
+    className,
+    'aria-hidden': _ariaHidden,
+    role: _role,
+    focusable: _focusable,
+    tabIndex: _tabIndex,
+    'data-slot': _dataSlot,
+    ...props
+  },
+  ref
+) {
+  return (
+    <span
+      {...props}
+      ref={ref}
+      data-slot="spinner"
+      aria-hidden="true"
+      className={twMerge(
+        [
+          'inline-flex size-4 shrink-0 items-center justify-center motion-reduce:animate-none! motion-reduce:[&_*]:animate-none! [&>*]:size-full',
+          children ? '' : 'animate-spin'
+        ],
+        className
+      )}
+    >
+      {children ?? (
+        <svg
+          data-slot="spinner-mark"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="9"
+            stroke="currentColor"
+            strokeWidth="2"
+            opacity="0.2"
+          />
+          <path
+            d="M21 12a9 9 0 0 0-9-9"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+    </span>
+  )
+})
+
+export default Spinner

--- a/docs/klean-ui/sources/spinner/Spinner.svelte
+++ b/docs/klean-ui/sources/spinner/Spinner.svelte
@@ -1,0 +1,54 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  let {
+    children,
+    class: className,
+    "aria-hidden": _ariaHidden,
+    role: _role,
+    focusable: _focusable,
+    tabindex: _tabindex,
+    "data-slot": _dataSlot,
+    ...props
+  } = $props();
+</script>
+
+<span
+  {...props}
+  data-slot="spinner"
+  aria-hidden="true"
+  class={twMerge(
+    [
+      "inline-flex size-4 shrink-0 items-center justify-center motion-reduce:animate-none! motion-reduce:[&_*]:animate-none! [&>*]:size-full",
+      children ? "" : "animate-spin",
+    ],
+    className,
+  )}
+>
+  {#if children}
+    {@render children()}
+  {:else}
+    <svg
+      data-slot="spinner-mark"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+      fill="none"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="9"
+        stroke="currentColor"
+        stroke-width="2"
+        opacity="0.2"
+      />
+      <path
+        d="M21 12a9 9 0 0 0-9-9"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  {/if}
+</span>


### PR DESCRIPTION
## Summary

- add the canonical Klean Spinner component guide
- include live previews, installation, and copyable Vue, React, and Svelte source
- document custom product marks, pending Button composition, and related components

## Validation

- `npm run build`
- verified the live Spinner examples in the docs development server

Resolves sailscastshq/klean-ui#60