### PR TITLE
docs: add the canonical Tooltip guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -120,6 +120,7 @@ function kleanUiGuide() {
         { text: 'Radio', link: '/klean-ui/components/radio' },
         { text: 'Switch', link: '/klean-ui/components/switch' },
         { text: 'Spinner', link: '/klean-ui/components/spinner' },
+        { text: 'Tooltip', link: '/klean-ui/components/tooltip' },
         { text: 'Popover', link: '/klean-ui/components/popover' },
         { text: 'Menu', link: '/klean-ui/components/menu' },
         { text: 'Select', link: '/klean-ui/components/select' },

--- a/docs/.vitepress/theme/components/klean/tooltip/Tooltip.vue
+++ b/docs/.vitepress/theme/components/klean/tooltip/Tooltip.vue
@@ -1,0 +1,345 @@
+<script>
+let closeActiveTooltip
+</script>
+
+<script setup>
+import {
+  arrow as floatingArrow,
+  autoUpdate,
+  computePosition,
+  flip,
+  offset as floatingOffset,
+  shift
+} from '@floating-ui/dom'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  useId
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Short supplementary text. Interactive content belongs in Popover. */
+  text: { type: String, required: true },
+  /** Preferred side. Collision handling may flip it. */
+  placement: {
+    type: String,
+    default: 'top',
+    validator: (value) => ['top', 'right', 'bottom', 'left'].includes(value)
+  },
+  /** Space in pixels between the trigger and floating surface. */
+  offset: { type: Number, default: 8 }
+})
+
+const attrs = useAttrs()
+const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+const tooltipId = `klean-tooltip-${generatedId}`
+const root = ref()
+const trigger = ref()
+const content = ref()
+const arrow = ref()
+const isOpen = ref(false)
+const supportsNative = ref(false)
+const resolvedPlacement = ref(props.placement)
+const positionStyle = ref({ position: 'fixed', left: '0px', top: '0px' })
+const arrowStyle = ref({})
+let openTimer
+let closeTimer
+let cleanupPosition = () => {}
+let observer
+let lastTouchAt = 0
+
+const OPEN_DELAY = 400
+const CLOSE_DELAY = 80
+
+const contentAttrs = computed(() => {
+  const {
+    class: _class,
+    style: _style,
+    id: _id,
+    role: _role,
+    popover: _popover,
+    hidden: _hidden,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const contentClasses = computed(() =>
+  twMerge(
+    [
+      'z-50 m-0 w-max max-w-[calc(100vw-1rem)] rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
+      'transition-opacity duration-100 starting:opacity-0 motion-reduce:transition-none',
+      'forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]'
+    ],
+    attrs.class
+  )
+)
+
+function descriptionTokens(element) {
+  return (element?.getAttribute('aria-describedby') ?? '')
+    .split(/\s+/)
+    .filter(Boolean)
+}
+
+function addDescription(element) {
+  if (!element) return
+  const tokens = new Set(descriptionTokens(element))
+  tokens.add(tooltipId)
+  element.setAttribute('aria-describedby', [...tokens].join(' '))
+}
+
+function removeDescription(element) {
+  if (!element) return
+  const tokens = descriptionTokens(element).filter(
+    (token) => token !== tooltipId
+  )
+  if (tokens.length) element.setAttribute('aria-describedby', tokens.join(' '))
+  else element.removeAttribute('aria-describedby')
+}
+
+function syncTrigger() {
+  const nextTrigger = root.value?.firstElementChild
+  if (nextTrigger === trigger.value) return
+
+  removeDescription(trigger.value)
+  trigger.value = nextTrigger
+  addDescription(trigger.value)
+
+  if (!trigger.value) closeNow()
+}
+
+function popoverIsShowing() {
+  if (!supportsNative.value || !content.value) return false
+  try {
+    return content.value.matches(':popover-open')
+  } catch {
+    return false
+  }
+}
+
+function syncNativePopover() {
+  if (!supportsNative.value || !content.value) return
+  try {
+    if (isOpen.value && !popoverIsShowing()) {
+      content.value.showPopover({ source: trigger.value })
+    } else if (!isOpen.value && popoverIsShowing()) {
+      content.value.hidePopover()
+    }
+  } catch {
+    // Rapid pointer and focus changes can make show/hide requests redundant.
+  }
+}
+
+async function updatePosition() {
+  if (!trigger.value?.isConnected || !content.value?.isConnected) {
+    closeNow()
+    return
+  }
+
+  const result = await computePosition(trigger.value, content.value, {
+    placement: props.placement,
+    strategy: 'fixed',
+    middleware: [
+      floatingOffset(props.offset),
+      flip(),
+      shift({ padding: 8 }),
+      floatingArrow({ element: arrow.value, padding: 6 })
+    ]
+  })
+
+  const side = result.placement.split('-')[0]
+  const staticSide = {
+    top: 'bottom',
+    right: 'left',
+    bottom: 'top',
+    left: 'right'
+  }[side]
+  const arrowData = result.middlewareData.arrow ?? {}
+
+  resolvedPlacement.value = result.placement
+  positionStyle.value = {
+    position: 'fixed',
+    left: `${result.x}px`,
+    top: `${result.y}px`
+  }
+  arrowStyle.value = {
+    left: arrowData.x == null ? '' : `${arrowData.x}px`,
+    top: arrowData.y == null ? '' : `${arrowData.y}px`,
+    right: '',
+    bottom: '',
+    [staticSide]: '-4px'
+  }
+}
+
+function startPositioning() {
+  cleanupPosition()
+  if (!trigger.value || !content.value) return
+  cleanupPosition = autoUpdate(trigger.value, content.value, updatePosition)
+}
+
+async function openNow() {
+  clearTimeout(openTimer)
+  clearTimeout(closeTimer)
+  syncTrigger()
+  if (!trigger.value || !props.text) return
+
+  if (closeActiveTooltip && closeActiveTooltip !== closeNow) {
+    closeActiveTooltip()
+  }
+  closeActiveTooltip = closeNow
+  isOpen.value = true
+  syncNativePopover()
+  await nextTick()
+  startPositioning()
+}
+
+function closeNow() {
+  clearTimeout(openTimer)
+  clearTimeout(closeTimer)
+  cleanupPosition()
+  cleanupPosition = () => {}
+  isOpen.value = false
+  syncNativePopover()
+  if (closeActiveTooltip === closeNow) closeActiveTooltip = undefined
+}
+
+function scheduleOpen() {
+  clearTimeout(closeTimer)
+  if (isOpen.value) return
+  clearTimeout(openTimer)
+  openTimer = setTimeout(openNow, OPEN_DELAY)
+}
+
+function scheduleClose() {
+  clearTimeout(openTimer)
+  clearTimeout(closeTimer)
+  closeTimer = setTimeout(closeNow, CLOSE_DELAY)
+}
+
+function handlePointerOver(event) {
+  if (event.pointerType === 'touch') return
+  if (content.value?.contains(event.target)) {
+    clearTimeout(closeTimer)
+    return
+  }
+  scheduleOpen()
+}
+
+function handlePointerOut(event) {
+  if (
+    root.value?.contains(event.relatedTarget) ||
+    content.value?.contains(event.relatedTarget)
+  ) {
+    return
+  }
+  scheduleClose()
+}
+
+function handlePointerDown(event) {
+  if (event.pointerType !== 'touch') return
+  lastTouchAt = Date.now()
+  closeNow()
+}
+
+function handleFocusIn() {
+  if (Date.now() - lastTouchAt < 1000) return
+  scheduleOpen()
+}
+
+function handleFocusOut(event) {
+  if (root.value?.contains(event.relatedTarget)) return
+  scheduleClose()
+}
+
+function handleEscape(event) {
+  if (event.key !== 'Escape' || !isOpen.value) return
+  event.preventDefault()
+  closeNow()
+}
+
+function handleContextChange(event) {
+  if (!isOpen.value) return
+  const path = event.composedPath?.() ?? [event.target]
+  if (path.includes(trigger.value) || path.includes(content.value)) return
+  closeNow()
+}
+
+function handleNativeToggle(event) {
+  if (event.newState === 'closed' && isOpen.value) {
+    isOpen.value = false
+    cleanupPosition()
+    cleanupPosition = () => {}
+  }
+}
+
+onMounted(async () => {
+  await nextTick()
+  supportsNative.value =
+    typeof content.value?.showPopover === 'function' &&
+    typeof content.value?.hidePopover === 'function'
+  syncTrigger()
+
+  observer = new MutationObserver(syncTrigger)
+  observer.observe(root.value, { childList: true })
+  document.addEventListener('keydown', handleEscape)
+  document.addEventListener('pointerdown', handleContextChange, true)
+  window.addEventListener('blur', closeNow)
+})
+
+onBeforeUnmount(() => {
+  closeNow()
+  removeDescription(trigger.value)
+  observer?.disconnect()
+  document.removeEventListener('keydown', handleEscape)
+  document.removeEventListener('pointerdown', handleContextChange, true)
+  window.removeEventListener('blur', closeNow)
+})
+</script>
+
+<template>
+  <span
+    ref="root"
+    role="presentation"
+    class="contents"
+    @pointerover="handlePointerOver"
+    @pointerout="handlePointerOut"
+    @pointerdown="handlePointerDown"
+    @focusin="handleFocusIn"
+    @focusout="handleFocusOut"
+  >
+    <slot />
+    <div
+      v-bind="contentAttrs"
+      :id="tooltipId"
+      ref="content"
+      popover="hint"
+      role="tooltip"
+      data-slot="tooltip"
+      :data-state="isOpen ? 'open' : 'closed'"
+      :data-placement="resolvedPlacement"
+      :hidden="!supportsNative && !isOpen"
+      :class="contentClasses"
+      :style="[positionStyle, attrs.style]"
+      @pointerenter="clearTimeout(closeTimer)"
+      @pointerleave="scheduleClose"
+      @toggle="handleNativeToggle"
+    >
+      {{ text }}
+      <span
+        ref="arrow"
+        aria-hidden="true"
+        data-slot="tooltip-arrow"
+        class="absolute -z-10 size-2 rotate-45 border border-inherit bg-inherit forced-colors:hidden"
+        :style="arrowStyle"
+      />
+    </div>
+  </span>
+</template>

--- a/docs/klean-ui/components/button.md
+++ b/docs/klean-ui/components/button.md
@@ -157,6 +157,7 @@ Klean's neutral default stays motionless and uses tonal feedback. Hagfish delibe
 
 ## Related components
 
+- [Tooltip](/klean-ui/components/tooltip) — adds short supplementary text without changing the button or link semantics.
 - [Spinner](/klean-ui/components/spinner) — a decorative pending mark inside a truthfully labelled busy button.
 - [Slide](/klean-ui/components/slide) — higher-friction confirmation for consequential actions.
 - [Menu](/klean-ui/components/menu) — a compact list of actions and destinations.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -41,6 +41,10 @@ A native-first boolean setting that takes effect immediately, with real checked 
 
 A calm decorative mark for indeterminate work, with caller-owned Tailwind styling and truthful busy and status semantics left in visible application markup.
 
+### [Tooltip](/klean-ui/components/tooltip)
+
+Short supplementary text for one semantic button or link, with accessible hover, focus, dismissal, collision handling, and caller-owned Tailwind styling.
+
 ### [Popover](/klean-ui/components/popover)
 
 A native-first non-modal floating surface with light dismissal, focus return, collision-aware positioning, and ordinary semantic content. A real button invokes it through the browser's `popovertarget` relationship.

--- a/docs/klean-ui/components/popover.md
+++ b/docs/klean-ui/components/popover.md
@@ -245,6 +245,7 @@ Hagfish's share surface and Slipway's operational filters need the same interact
 
 ## Related components
 
+- [Tooltip](/klean-ui/components/tooltip) — short supplementary text for one semantic control, never interactive content.
 - [Menu](/klean-ui/components/menu) — action and navigation semantics with roving focus.
 - [Select](/klean-ui/components/select) — a fixed-list value picker composed with Popover.
 - [Date Picker](/klean-ui/components/date-picker) — a date-only `YYYY-MM-DD` field composed with Popover.

--- a/docs/klean-ui/components/tooltip.md
+++ b/docs/klean-ui/components/tooltip.md
@@ -1,0 +1,174 @@
+---
+title: Tooltip
+titleTemplate: Klean UI
+description: Short supplementary text for a semantic button or link, with accessible hover, focus, dismissal, and caller-owned Tailwind styling.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
+import KleanTooltip from '../../.vitepress/theme/components/klean/tooltip/Tooltip.vue'
+import tooltipSource from '../../.vitepress/theme/components/klean/tooltip/Tooltip.vue?raw'
+import reactSource from '../sources/tooltip/Tooltip.jsx?raw'
+import svelteSource from '../sources/tooltip/Tooltip.svelte?raw'
+import vueUsage from '../snippets/tooltip/usage.vue?raw'
+import reactUsage from '../snippets/tooltip/usage.jsx?raw'
+import svelteUsage from '../snippets/tooltip/usage.svelte?raw'
+import stylingUsage from '../snippets/tooltip/styling.vue?raw'
+</script>
+
+# Tooltip
+
+Tooltip adds short supplementary text to one real button or link. Wrap the trigger, provide the text, and keep the trigger's semantics and Tailwind classes where they are visible.
+
+Klean supplies the accessible description, hover and keyboard behavior, collision-safe placement, Escape dismissal, touch behavior, and cleanup. There are no trigger IDs, compound components, providers, visual variants, or configuration ceremony.
+
+<KleanPreview id="tooltip-source" :source="tooltipSource" filename="Tooltip.vue">
+  <template #preview>
+    <div class="grid justify-items-center gap-4">
+      <KleanTooltip text="Re-run query" placement="top">
+        <KleanButton
+          type="button"
+          aria-label="Re-run query"
+          class="size-11 min-h-0 min-w-0 p-0"
+        >
+          <svg
+            aria-hidden="true"
+            class="size-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+          >
+            <path
+              d="M20 11a8 8 0 1 0-2.34 5.66M20 4v7h-7"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </KleanButton>
+      </KleanTooltip>
+      <p class="text-sm text-gray-600 dark:text-gray-400">
+        Hover the button or focus it with the keyboard.
+      </p>
+    </div>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/tooltip/Tooltip.vue
+
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte, writes the matching source, and installs its direct dependencies:
+
+<KleanInstallation
+  id="tooltip-installation"
+  component="tooltip"
+  :source="tooltipSource"
+  filename="Tooltip.vue"
+  destination="assets/js/components/ui/tooltip/Tooltip.vue"
+  :dependencies="['@floating-ui/dom', 'tailwind-merge']"
+/>
+
+The installed source belongs to the application. There is no initializer, provider, generated ID to coordinate, configuration file, or shared class helper.
+
+## Usage
+
+The child is the trigger. Use a real button for an action and a real anchor or Boring Stack Link for navigation.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="QueryToolbar.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="QueryToolbar.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="QueryToolbar.svelte" />
+
+The icon is decorative because the button already has the accessible name “Re-run query.” Tooltip text supplements the control; it does not replace the button's name.
+
+## API
+
+| Input                 | Default  | Purpose                                                                |
+| --------------------- | -------- | ---------------------------------------------------------------------- |
+| `text`                | required | Short, non-interactive supplementary text.                             |
+| `placement`           | `top`    | Preferred `top`, `right`, `bottom`, or `left` side; may flip to fit.   |
+| `offset`              | `8`      | Pixel distance between the trigger and tooltip.                        |
+| `class` / `className` | —        | Ordinary Tailwind classes merged last on the tooltip surface.          |
+| default child         | required | One semantic button, anchor, or framework Link that renders an anchor. |
+
+Other non-conflicting attributes are forwarded to the tooltip surface. Trigger attributes and styling stay on the trigger itself.
+
+## Semantics before appearance
+
+Tooltip never decides what the trigger means:
+
+- use `<button type="button">` for an action;
+- use `<a href="…">` for navigation;
+- use the Boring Stack Link component when navigation should retain client-side routing semantics;
+- give an icon-only trigger its own accessible name with `aria-label` or visible text;
+- keep the icon itself decorative with `aria-hidden="true"`.
+
+Klean adds its generated description to the trigger without discarding an existing `aria-describedby` relationship. It removes only its own relationship when the component unmounts.
+
+Do not put links, buttons, fields, headings, or long instructions inside a Tooltip. Use [Popover](/klean-ui/components/popover) for interactive or structured content.
+
+## Styling with Tailwind
+
+Style the trigger on the trigger. Style the floating surface through Tooltip's ordinary class input:
+
+<CopyCode :code="stylingUsage" label="invoice-tooltip.vue" />
+
+`data-slot="tooltip"` and `data-slot="tooltip-arrow"` are stable nearby styling hooks. The example hides the arrow with an ordinary Tailwind selector; there is no `arrow`, `tone`, `size`, `radius`, `elevation`, or `variant` prop.
+
+Repeated product treatment can become a small application-owned wrapper. Hagfish and Slipway can therefore share the accessible behavior without sharing a visual identity.
+
+## Accessible behavior
+
+- Pointer hover and keyboard focus reveal the same supplementary text.
+- Escape dismisses an open Tooltip without moving focus away from its trigger.
+- Moving between the trigger and Tooltip does not dismiss it prematurely.
+- Only one Tooltip is open at a time.
+- Touch activation does not create a sticky synthetic hover surface.
+- Placement flips or shifts when the preferred side would leave the viewport.
+- Reduced-motion and forced-colors preferences retain a useful, readable result.
+- The trigger remains the actual focusable element; Tooltip does not add a styled trigger wrapper.
+
+The text remains supplementary. A critical label, validation error, destructive warning, or operation result must stay visible in the interface.
+
+## Durable behavior
+
+Tooltip visibility is ephemeral. It is derived from current hover or focus and is never written to local storage, the URL, cookies, or server state. Timers, position observers, generated accessibility relationships, and global listeners are cleaned up when no longer needed.
+
+The durable state belongs to the application action or destination—not to whether its explanation happened to be visible.
+
+## Complete framework source
+
+Copy, inspect, and change the complete source for your framework.
+
+### Vue source
+
+<CopyCode :code="tooltipSource" label="Tooltip.vue" />
+
+### React source
+
+<CopyCode :code="reactSource" label="Tooltip.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteSource" label="Tooltip.svelte" />
+
+## Related components
+
+- [Button](/klean-ui/components/button) — supplies truthful button, anchor, and Boring Stack Link semantics.
+- [Popover](/klean-ui/components/popover) — hosts interactive or structured non-modal content.
+- [Menu](/klean-ui/components/menu) — presents a keyboard-navigable collection of actions or destinations.

--- a/docs/klean-ui/snippets/tooltip/styling.vue
+++ b/docs/klean-ui/snippets/tooltip/styling.vue
@@ -1,0 +1,13 @@
+<Tooltip
+  text="Copy public invoice link"
+  placement="bottom"
+  class="rounded-none border-2 border-black bg-amber-50 px-3 py-2 font-mono text-[11px] uppercase tracking-wider text-black shadow-[3px_3px_0_0_#000] [&_[data-slot=tooltip-arrow]]:hidden"
+>
+  <button
+    type="button"
+    aria-label="Copy public invoice link"
+    class="grid size-12 place-items-center border-2 border-black bg-black text-white"
+  >
+    <CopyIcon aria-hidden="true" />
+  </button>
+</Tooltip>

--- a/docs/klean-ui/snippets/tooltip/usage.jsx
+++ b/docs/klean-ui/snippets/tooltip/usage.jsx
@@ -1,0 +1,16 @@
+import Button from '@/components/ui/button/Button.jsx'
+import Tooltip from '@/components/ui/tooltip/Tooltip.jsx'
+
+export default function QueryToolbar() {
+  return (
+    <Tooltip text="Re-run query">
+      <Button
+        type="button"
+        aria-label="Re-run query"
+        className="size-10 min-h-0 p-0"
+      >
+        <RefreshIcon aria-hidden="true" />
+      </Button>
+    </Tooltip>
+  )
+}

--- a/docs/klean-ui/snippets/tooltip/usage.svelte
+++ b/docs/klean-ui/snippets/tooltip/usage.svelte
@@ -1,0 +1,10 @@
+<script>
+  import Button from '$lib/components/ui/button/Button.svelte'
+  import Tooltip from '$lib/components/ui/tooltip/Tooltip.svelte'
+</script>
+
+<Tooltip text="Re-run query">
+  <Button type="button" aria-label="Re-run query" class="size-10 min-h-0 p-0">
+    <RefreshIcon aria-hidden="true" />
+  </Button>
+</Tooltip>

--- a/docs/klean-ui/snippets/tooltip/usage.vue
+++ b/docs/klean-ui/snippets/tooltip/usage.vue
@@ -1,0 +1,12 @@
+<script setup>
+import Button from '@/components/ui/button/Button.vue'
+import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+</script>
+
+<template>
+  <Tooltip text="Re-run query">
+    <Button type="button" aria-label="Re-run query" class="size-10 min-h-0 p-0">
+      <RefreshIcon aria-hidden="true" />
+    </Button>
+  </Tooltip>
+</template>

--- a/docs/klean-ui/sources/tooltip/Tooltip.jsx
+++ b/docs/klean-ui/sources/tooltip/Tooltip.jsx
@@ -1,0 +1,306 @@
+import {
+  arrow as floatingArrow,
+  autoUpdate,
+  computePosition,
+  flip,
+  offset as floatingOffset,
+  shift
+} from '@floating-ui/dom'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES = [
+  'z-50 m-0 w-max max-w-[calc(100vw-1rem)] rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
+  'transition-opacity duration-100 starting:opacity-0 motion-reduce:transition-none',
+  'forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]'
+]
+const OPEN_DELAY = 400
+const CLOSE_DELAY = 80
+let closeActiveTooltip
+
+function descriptionTokens(element) {
+  return (element?.getAttribute('aria-describedby') ?? '')
+    .split(/\s+/)
+    .filter(Boolean)
+}
+
+export default function Tooltip({
+  text,
+  placement = 'top',
+  offset = 8,
+  className,
+  style,
+  children,
+  ...contentProps
+}) {
+  const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+  const tooltipId = `klean-tooltip-${generatedId}`
+  const rootRef = useRef(null)
+  const triggerRef = useRef(null)
+  const contentRef = useRef(null)
+  const arrowRef = useRef(null)
+  const openTimer = useRef()
+  const closeTimer = useRef()
+  const cleanupPosition = useRef(() => {})
+  const lastTouchAt = useRef(0)
+  const [isOpen, setIsOpen] = useState(false)
+  const [supportsNative, setSupportsNative] = useState(false)
+  const [resolvedPlacement, setResolvedPlacement] = useState(placement)
+  const [positionStyle, setPositionStyle] = useState({
+    position: 'fixed',
+    left: 0,
+    top: 0
+  })
+  const [arrowStyle, setArrowStyle] = useState({})
+
+  const removeDescription = useCallback(
+    (element) => {
+      if (!element) return
+      const tokens = descriptionTokens(element).filter(
+        (token) => token !== tooltipId
+      )
+      if (tokens.length) {
+        element.setAttribute('aria-describedby', tokens.join(' '))
+      } else {
+        element.removeAttribute('aria-describedby')
+      }
+    },
+    [tooltipId]
+  )
+
+  const syncTrigger = useCallback(() => {
+    const nextTrigger = rootRef.current?.firstElementChild
+    if (nextTrigger === triggerRef.current) return triggerRef.current
+
+    removeDescription(triggerRef.current)
+    triggerRef.current = nextTrigger
+    if (nextTrigger) {
+      const tokens = new Set(descriptionTokens(nextTrigger))
+      tokens.add(tooltipId)
+      nextTrigger.setAttribute('aria-describedby', [...tokens].join(' '))
+    }
+    return nextTrigger
+  }, [removeDescription, tooltipId])
+
+  const closeNow = useCallback(() => {
+    clearTimeout(openTimer.current)
+    clearTimeout(closeTimer.current)
+    cleanupPosition.current()
+    cleanupPosition.current = () => {}
+    setIsOpen(false)
+    if (closeActiveTooltip === closeNow) closeActiveTooltip = undefined
+  }, [])
+
+  const openNow = useCallback(() => {
+    clearTimeout(openTimer.current)
+    clearTimeout(closeTimer.current)
+    const trigger = syncTrigger()
+    if (!trigger || !text) return
+
+    if (closeActiveTooltip && closeActiveTooltip !== closeNow) {
+      closeActiveTooltip()
+    }
+    closeActiveTooltip = closeNow
+    setIsOpen(true)
+  }, [closeNow, syncTrigger, text])
+
+  const scheduleOpen = useCallback(() => {
+    clearTimeout(closeTimer.current)
+    if (isOpen) return
+    clearTimeout(openTimer.current)
+    openTimer.current = setTimeout(openNow, OPEN_DELAY)
+  }, [isOpen, openNow])
+
+  const scheduleClose = useCallback(() => {
+    clearTimeout(openTimer.current)
+    clearTimeout(closeTimer.current)
+    closeTimer.current = setTimeout(closeNow, CLOSE_DELAY)
+  }, [closeNow])
+
+  useEffect(() => {
+    setSupportsNative(
+      typeof contentRef.current?.showPopover === 'function' &&
+        typeof contentRef.current?.hidePopover === 'function'
+    )
+    syncTrigger()
+
+    const observer = new MutationObserver(syncTrigger)
+    observer.observe(rootRef.current, { childList: true })
+    return () => {
+      observer.disconnect()
+      removeDescription(triggerRef.current)
+      closeNow()
+    }
+  }, [closeNow, removeDescription, syncTrigger])
+
+  useEffect(() => {
+    const content = contentRef.current
+    const trigger = triggerRef.current
+    if (!content) return
+
+    if (supportsNative) {
+      let showing = false
+      try {
+        showing = content.matches(':popover-open')
+        if (isOpen && !showing) content.showPopover({ source: trigger })
+        else if (!isOpen && showing) content.hidePopover()
+      } catch {
+        // Rapid pointer and focus changes can make requests redundant.
+      }
+    }
+
+    cleanupPosition.current()
+    cleanupPosition.current = () => {}
+    if (!isOpen || !trigger?.isConnected || !content.isConnected) return
+
+    const updatePosition = async () => {
+      if (!trigger.isConnected || !content.isConnected) {
+        closeNow()
+        return
+      }
+
+      const result = await computePosition(trigger, content, {
+        placement,
+        strategy: 'fixed',
+        middleware: [
+          floatingOffset(offset),
+          flip(),
+          shift({ padding: 8 }),
+          floatingArrow({ element: arrowRef.current, padding: 6 })
+        ]
+      })
+      const side = result.placement.split('-')[0]
+      const staticSide = {
+        top: 'bottom',
+        right: 'left',
+        bottom: 'top',
+        left: 'right'
+      }[side]
+      const arrowData = result.middlewareData.arrow ?? {}
+
+      setResolvedPlacement(result.placement)
+      setPositionStyle({ position: 'fixed', left: result.x, top: result.y })
+      setArrowStyle({
+        left: arrowData.x == null ? '' : arrowData.x,
+        top: arrowData.y == null ? '' : arrowData.y,
+        right: '',
+        bottom: '',
+        [staticSide]: -4
+      })
+    }
+
+    cleanupPosition.current = autoUpdate(trigger, content, updatePosition)
+    return () => {
+      cleanupPosition.current()
+      cleanupPosition.current = () => {}
+    }
+  }, [closeNow, isOpen, offset, placement, supportsNative])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleEscape(event) {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      closeNow()
+    }
+
+    function handleContextChange(event) {
+      const path = event.composedPath?.() ?? [event.target]
+      if (
+        path.includes(triggerRef.current) ||
+        path.includes(contentRef.current)
+      ) {
+        return
+      }
+      closeNow()
+    }
+
+    document.addEventListener('keydown', handleEscape)
+    document.addEventListener('pointerdown', handleContextChange, true)
+    window.addEventListener('blur', closeNow)
+    return () => {
+      document.removeEventListener('keydown', handleEscape)
+      document.removeEventListener('pointerdown', handleContextChange, true)
+      window.removeEventListener('blur', closeNow)
+    }
+  }, [closeNow, isOpen])
+
+  function handlePointerOver(event) {
+    if (event.pointerType === 'touch') return
+    if (contentRef.current?.contains(event.target)) {
+      clearTimeout(closeTimer.current)
+      return
+    }
+    scheduleOpen()
+  }
+
+  function handlePointerOut(event) {
+    if (
+      rootRef.current?.contains(event.relatedTarget) ||
+      contentRef.current?.contains(event.relatedTarget)
+    ) {
+      return
+    }
+    scheduleClose()
+  }
+
+  function handlePointerDown(event) {
+    if (event.pointerType !== 'touch') return
+    lastTouchAt.current = Date.now()
+    closeNow()
+  }
+
+  function handleFocusIn() {
+    if (Date.now() - lastTouchAt.current < 1000) return
+    scheduleOpen()
+  }
+
+  function handleFocusOut(event) {
+    if (rootRef.current?.contains(event.relatedTarget)) return
+    scheduleClose()
+  }
+
+  return (
+    <span
+      ref={rootRef}
+      role="presentation"
+      className="contents"
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
+      onPointerDown={handlePointerDown}
+      onFocus={handleFocusIn}
+      onBlur={handleFocusOut}
+    >
+      {children}
+      <div
+        {...contentProps}
+        id={tooltipId}
+        ref={contentRef}
+        popover="hint"
+        role="tooltip"
+        data-slot="tooltip"
+        data-state={isOpen ? 'open' : 'closed'}
+        data-placement={resolvedPlacement}
+        hidden={!supportsNative && !isOpen}
+        className={twMerge(BASE_CLASSES, className)}
+        style={{ ...positionStyle, ...style }}
+        onPointerEnter={() => clearTimeout(closeTimer.current)}
+        onPointerLeave={scheduleClose}
+        onToggle={(event) => {
+          if (event.newState === 'closed' && isOpen) setIsOpen(false)
+          contentProps.onToggle?.(event)
+        }}
+      >
+        {text}
+        <span
+          ref={arrowRef}
+          aria-hidden="true"
+          data-slot="tooltip-arrow"
+          className="absolute -z-10 size-2 rotate-45 border border-inherit bg-inherit forced-colors:hidden"
+          style={arrowStyle}
+        />
+      </div>
+    </span>
+  )
+}

--- a/docs/klean-ui/sources/tooltip/Tooltip.svelte
+++ b/docs/klean-ui/sources/tooltip/Tooltip.svelte
@@ -1,0 +1,316 @@
+<script module>
+  let closeActiveTooltip;
+</script>
+
+<script>
+  import {
+    arrow as floatingArrow,
+    autoUpdate,
+    computePosition,
+    flip,
+    offset as floatingOffset,
+    shift,
+  } from "@floating-ui/dom";
+  import { onMount, untrack } from "svelte";
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES = [
+    "z-50 m-0 w-max max-w-[calc(100vw-1rem)] rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none",
+    "transition-opacity duration-100 starting:opacity-0 motion-reduce:transition-none",
+    "forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]",
+  ];
+  const OPEN_DELAY = 400;
+  const CLOSE_DELAY = 80;
+
+  let {
+    text,
+    placement = "top",
+    offset = 8,
+    class: className = "",
+    style,
+    children,
+    ...contentProps
+  } = $props();
+
+  const rawComponentId = $props.id();
+  const componentId = rawComponentId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const tooltipId = `klean-tooltip-${componentId}`;
+  let rootElement;
+  let triggerElement = $state();
+  let contentElement;
+  let arrowElement;
+  let isOpen = $state(false);
+  let supportsNative = $state(false);
+  let resolvedPlacement = $state(untrack(() => placement));
+  let positionStyle = $state({ position: "fixed", left: "0px", top: "0px" });
+  let arrowStyle = $state({});
+  let openTimer;
+  let closeTimer;
+  let cleanupPosition = () => {};
+  let observer;
+  let lastTouchAt = 0;
+
+  function descriptionTokens(element) {
+    return (element?.getAttribute("aria-describedby") ?? "")
+      .split(/\s+/)
+      .filter(Boolean);
+  }
+
+  function removeDescription(element) {
+    if (!element) return;
+    const tokens = descriptionTokens(element).filter(
+      (token) => token !== tooltipId,
+    );
+    if (tokens.length) element.setAttribute("aria-describedby", tokens.join(" "));
+    else element.removeAttribute("aria-describedby");
+  }
+
+  function syncTrigger() {
+    const nextTrigger = rootElement?.firstElementChild;
+    if (nextTrigger === triggerElement) return triggerElement;
+
+    removeDescription(triggerElement);
+    triggerElement = nextTrigger;
+    if (nextTrigger) {
+      const tokens = new Set(descriptionTokens(nextTrigger));
+      tokens.add(tooltipId);
+      nextTrigger.setAttribute("aria-describedby", [...tokens].join(" "));
+    }
+    return nextTrigger;
+  }
+
+  function popoverIsShowing() {
+    if (!supportsNative || !contentElement) return false;
+    try {
+      return contentElement.matches(":popover-open");
+    } catch {
+      return false;
+    }
+  }
+
+  function syncNativePopover() {
+    if (!supportsNative || !contentElement) return;
+    try {
+      if (isOpen && !popoverIsShowing()) {
+        contentElement.showPopover({ source: triggerElement });
+      } else if (!isOpen && popoverIsShowing()) {
+        contentElement.hidePopover();
+      }
+    } catch {
+      // Rapid pointer and focus changes can make requests redundant.
+    }
+  }
+
+  async function updatePosition() {
+    if (!triggerElement?.isConnected || !contentElement?.isConnected) {
+      closeNow();
+      return;
+    }
+
+    const result = await computePosition(triggerElement, contentElement, {
+      placement,
+      strategy: "fixed",
+      middleware: [
+        floatingOffset(offset),
+        flip(),
+        shift({ padding: 8 }),
+        floatingArrow({ element: arrowElement, padding: 6 }),
+      ],
+    });
+    const side = result.placement.split("-")[0];
+    const staticSide = {
+      top: "bottom",
+      right: "left",
+      bottom: "top",
+      left: "right",
+    }[side];
+    const arrowData = result.middlewareData.arrow ?? {};
+
+    resolvedPlacement = result.placement;
+    positionStyle = {
+      position: "fixed",
+      left: `${result.x}px`,
+      top: `${result.y}px`,
+    };
+    arrowStyle = {
+      left: arrowData.x == null ? "" : `${arrowData.x}px`,
+      top: arrowData.y == null ? "" : `${arrowData.y}px`,
+      right: "",
+      bottom: "",
+      [staticSide]: "-4px",
+    };
+  }
+
+  function startPositioning() {
+    cleanupPosition();
+    if (!triggerElement || !contentElement) return;
+    cleanupPosition = autoUpdate(triggerElement, contentElement, updatePosition);
+  }
+
+  function openNow() {
+    clearTimeout(openTimer);
+    clearTimeout(closeTimer);
+    const trigger = syncTrigger();
+    if (!trigger || !text) return;
+
+    if (closeActiveTooltip && closeActiveTooltip !== closeNow) {
+      closeActiveTooltip();
+    }
+    closeActiveTooltip = closeNow;
+    isOpen = true;
+    syncNativePopover();
+    queueMicrotask(startPositioning);
+  }
+
+  function closeNow() {
+    clearTimeout(openTimer);
+    clearTimeout(closeTimer);
+    cleanupPosition();
+    cleanupPosition = () => {};
+    isOpen = false;
+    syncNativePopover();
+    if (closeActiveTooltip === closeNow) closeActiveTooltip = undefined;
+  }
+
+  function scheduleOpen() {
+    clearTimeout(closeTimer);
+    if (isOpen) return;
+    clearTimeout(openTimer);
+    openTimer = setTimeout(openNow, OPEN_DELAY);
+  }
+
+  function scheduleClose() {
+    clearTimeout(openTimer);
+    clearTimeout(closeTimer);
+    closeTimer = setTimeout(closeNow, CLOSE_DELAY);
+  }
+
+  function handlePointerOver(event) {
+    if (event.pointerType === "touch") return;
+    if (contentElement?.contains(event.target)) {
+      clearTimeout(closeTimer);
+      return;
+    }
+    scheduleOpen();
+  }
+
+  function handlePointerOut(event) {
+    if (
+      rootElement?.contains(event.relatedTarget) ||
+      contentElement?.contains(event.relatedTarget)
+    ) {
+      return;
+    }
+    scheduleClose();
+  }
+
+  function handlePointerDown(event) {
+    if (event.pointerType !== "touch") return;
+    lastTouchAt = Date.now();
+    closeNow();
+  }
+
+  function handleFocusIn() {
+    if (Date.now() - lastTouchAt < 1000) return;
+    scheduleOpen();
+  }
+
+  function handleFocusOut(event) {
+    if (rootElement?.contains(event.relatedTarget)) return;
+    scheduleClose();
+  }
+
+  function handleEscape(event) {
+    if (event.key !== "Escape" || !isOpen) return;
+    event.preventDefault();
+    closeNow();
+  }
+
+  function handleContextChange(event) {
+    if (!isOpen) return;
+    const path = event.composedPath?.() ?? [event.target];
+    if (path.includes(triggerElement) || path.includes(contentElement)) return;
+    closeNow();
+  }
+
+  function styleString(...values) {
+    return values
+      .flatMap((value) => {
+        if (!value) return [];
+        if (typeof value === "string") return value;
+        return Object.entries(value)
+          .filter(([, propertyValue]) => propertyValue != null)
+          .map(([property, propertyValue]) => {
+            const cssProperty = property.replace(
+              /[A-Z]/g,
+              (letter) => `-${letter.toLowerCase()}`,
+            );
+            return `${cssProperty}:${propertyValue}`;
+          });
+      })
+      .join(";");
+  }
+
+  onMount(() => {
+    supportsNative =
+      typeof contentElement?.showPopover === "function" &&
+      typeof contentElement?.hidePopover === "function";
+    syncTrigger();
+
+    observer = new MutationObserver(syncTrigger);
+    observer.observe(rootElement, { childList: true });
+    document.addEventListener("keydown", handleEscape);
+    document.addEventListener("pointerdown", handleContextChange, true);
+    window.addEventListener("blur", closeNow);
+
+    return () => {
+      closeNow();
+      removeDescription(triggerElement);
+      observer.disconnect();
+      document.removeEventListener("keydown", handleEscape);
+      document.removeEventListener("pointerdown", handleContextChange, true);
+      window.removeEventListener("blur", closeNow);
+    };
+  });
+</script>
+
+<span
+  bind:this={rootElement}
+  role="presentation"
+  class="contents"
+  onpointerover={handlePointerOver}
+  onpointerout={handlePointerOut}
+  onpointerdown={handlePointerDown}
+  onfocusin={handleFocusIn}
+  onfocusout={handleFocusOut}
+>
+  {@render children?.()}
+  <div
+    {...contentProps}
+    id={tooltipId}
+    bind:this={contentElement}
+    popover="hint"
+    role="tooltip"
+    data-slot="tooltip"
+    data-state={isOpen ? "open" : "closed"}
+    data-placement={resolvedPlacement}
+    hidden={!supportsNative && !isOpen}
+    class={twMerge(BASE_CLASSES, className)}
+    style={styleString(positionStyle, style)}
+    onpointerenter={() => clearTimeout(closeTimer)}
+    onpointerleave={scheduleClose}
+    ontoggle={(event) => {
+      if (event.newState === "closed" && isOpen) isOpen = false;
+      contentProps.ontoggle?.(event);
+    }}
+  >
+    {text}
+    <span
+      bind:this={arrowElement}
+      aria-hidden="true"
+      data-slot="tooltip-arrow"
+      class="absolute -z-10 size-2 rotate-45 border border-inherit bg-inherit forced-colors:hidden"
+      style={styleString(arrowStyle)}
+    ></span>
+  </div>
+</span>


### PR DESCRIPTION
## What changed

- adds Tooltip to the Klean UI component catalog and sidebar
- provides a live interactive preview and installation command
- documents the clean wrapper API, semantic button/link usage, caller-owned Tailwind styling, accessibility, and Durable UI behavior
- includes complete copyable Vue, React, and Svelte sources
- connects Button and Popover related-component guidance

## Why

Klean UI documentation belongs in docs.sailscasts.com and should teach the public design contract without exposing experimental trigger plumbing or framework ceremony.

## Validation

- `npm run build`
- live preview opens with its generated accessible description
- Escape closes the Tooltip while focus stays on the semantic trigger

Resolves sailscastshq/klean-ui#65