### PR TITLE
docs(klean): complete Popover, Menu, and Dialog coverage

### DIFF
--- a/docs/klean-ui/components/dialog.md
+++ b/docs/klean-ui/components/dialog.md
@@ -18,6 +18,7 @@ import svelteSource from '../sources/dialog/Dialog.svelte?raw'
 import vueUsage from '../snippets/dialog/usage.vue?raw'
 import reactUsage from '../snippets/dialog/usage.jsx?raw'
 import svelteUsage from '../snippets/dialog/usage.svelte?raw'
+import productSource from '../snippets/dialog/products.vue?raw'
 
 const result = ref('No choice yet.')
 
@@ -148,6 +149,49 @@ completion; observe state only when application behavior genuinely needs it.
 - Explicit completion remains available when ambient dismissal is disabled.
 - Open state stays ephemeral unless the Dialog represents a shareable resource.
 - No motion, product tone, or action layout is imposed by Klean.
+
+## Product recipes
+
+Hagfish and Slipway share the native modal contract while keeping their product language in visible Tailwind classes. The heading, consequence, safest initial action, and completion value remain ordinary application markup.
+
+<KleanPreview id="dialog-products" :source="productSource" filename="product-dialogs.vue">
+  <template #preview>
+    <div class="grid w-full max-w-3xl gap-8 sm:grid-cols-2">
+      <section class="bg-[#f7f3eb] p-8">
+        <p class="mb-5 text-xs font-medium uppercase tracking-[0.18em] text-black/60">
+          Hagfish / invoice editor
+        </p>
+        <KleanButton commandfor="docs-delete-invoice" command="show-modal" class="rounded-lg border-2 border-black bg-black text-white hover:bg-white hover:text-black hover:shadow-[4px_4px_0_0_rgba(0,0,0,1)]">
+          Delete draft
+        </KleanButton>
+        <KleanDialog id="docs-delete-invoice" aria-labelledby="docs-delete-invoice-title" aria-describedby="docs-delete-invoice-description" class="max-w-md rounded-2xl border-2 border-black p-6 shadow-[4px_4px_0_0_rgba(0,0,0,1)]">
+          <p class="text-xs font-medium uppercase tracking-wider text-red-700">Permanent action</p>
+          <h2 id="docs-delete-invoice-title" class="mt-1 text-xl font-semibold">Delete this draft invoice?</h2>
+          <p id="docs-delete-invoice-description" class="mt-4 text-sm leading-6 text-black/60">INV-1042 and its public link will be permanently removed.</p>
+          <form method="dialog" class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <KleanButton type="submit" value="cancel" autofocus class="border-2 border-black bg-white text-black hover:bg-black hover:text-white">Cancel</KleanButton>
+            <KleanButton type="submit" value="delete" class="border-2 border-red-700 bg-red-700 text-white hover:bg-white hover:text-red-700">Delete invoice</KleanButton>
+          </form>
+        </KleanDialog>
+      </section>
+      <section class="dark bg-gray-950 p-8 text-white">
+        <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-400">Slipway / project settings</p>
+        <KleanButton commandfor="docs-delete-slipway-project" command="show-modal" class="min-h-9 min-w-0 bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700">Delete project</KleanButton>
+        <KleanDialog id="docs-delete-slipway-project" aria-labelledby="docs-delete-slipway-title" aria-describedby="docs-delete-slipway-description" class="max-w-sm border-gray-700 bg-gray-900 p-6 text-white shadow-xl">
+          <h2 id="docs-delete-slipway-title" class="text-lg font-semibold">Delete project?</h2>
+          <p id="docs-delete-slipway-description" class="mt-2 text-sm text-gray-400">Recovery data remains unless you choose to purge it.</p>
+          <form method="dialog" class="mt-5 flex justify-end gap-3">
+            <KleanButton type="submit" value="cancel" autofocus class="min-h-9 min-w-0 border border-gray-600 bg-transparent px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-800">Cancel</KleanButton>
+            <KleanButton type="submit" value="delete" class="min-h-9 min-w-0 bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700">Delete</KleanButton>
+          </form>
+        </KleanDialog>
+      </section>
+    </div>
+  </template>
+  <template #caption>
+    Klean owns the modal behavior. Each app keeps its hierarchy, density, color, and action language at the call site.
+  </template>
+</KleanPreview>
 
 ## Complete framework source
 

--- a/docs/klean-ui/components/popover.md
+++ b/docs/klean-ui/components/popover.md
@@ -13,7 +13,11 @@ import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
 import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
 import KleanPopover from '../../.vitepress/theme/components/klean/popover/Popover.vue'
 import popoverSource from '../../.vitepress/theme/components/klean/popover/Popover.vue?raw'
-import usageSource from '../snippets/popover/usage.vue?raw'
+import reactSource from '../sources/popover/Popover.jsx?raw'
+import svelteSource from '../sources/popover/Popover.svelte?raw'
+import vueUsage from '../snippets/popover/usage.vue?raw'
+import reactUsage from '../snippets/popover/usage.jsx?raw'
+import svelteUsage from '../snippets/popover/usage.svelte?raw'
 import observedSource from '../snippets/popover/observed.vue?raw'
 import productSource from '../snippets/popover/products.vue?raw'
 
@@ -85,7 +89,17 @@ Run the same command in Vue, React, or Svelte. Klean detects the framework and c
 
 ## Usage
 
-<CopyCode :code="usageSource" label="usage.vue" />
+### Vue
+
+<CopyCode :code="vueUsage" label="Filters.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="Filters.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="Filters.svelte" />
 
 `popovertarget` and `id` are native HTML. A native button works too:
 
@@ -110,6 +124,20 @@ Use a real button because opening interface content is an action. An anchor rema
 Vue uses `v-model:open`, React uses `open` with `onOpenChange`, and Svelte uses `bind:open`. The native uncontrolled relationship remains the default in every framework.
 
 Placement and offset describe geometry, not appearance. Popover has no `variant`, `tone`, `size`, `radius`, `elevation`, or animation props.
+
+## Complete framework source
+
+### Vue
+
+<CopyCode :code="popoverSource" label="Popover.vue" />
+
+### React
+
+<CopyCode :code="reactSource" label="Popover.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteSource" label="Popover.svelte" />
 
 ## Closing the surface
 

--- a/docs/klean-ui/snippets/dialog/products.vue
+++ b/docs/klean-ui/snippets/dialog/products.vue
@@ -1,0 +1,103 @@
+<script setup>
+import Button from '~/components/ui/button/Button.vue'
+import Dialog from '~/components/ui/dialog/Dialog.vue'
+</script>
+
+<template>
+  <section class="bg-[#f7f3eb] p-8">
+    <p
+      class="mb-5 text-xs font-medium uppercase tracking-[0.18em] text-black/60"
+    >
+      Hagfish / invoice editor
+    </p>
+    <Button
+      commandfor="delete-invoice"
+      command="show-modal"
+      class="rounded-lg border-2 border-black bg-black text-white hover:bg-white hover:text-black hover:shadow-[4px_4px_0_0_rgba(0,0,0,1)]"
+    >
+      Delete draft
+    </Button>
+    <Dialog
+      id="delete-invoice"
+      aria-labelledby="delete-invoice-title"
+      aria-describedby="delete-invoice-description"
+      class="max-w-md rounded-2xl border-2 border-black p-6 shadow-[4px_4px_0_0_rgba(0,0,0,1)]"
+    >
+      <p class="text-xs font-medium uppercase tracking-wider text-red-700">
+        Permanent action
+      </p>
+      <h2 id="delete-invoice-title" class="mt-1 text-xl font-semibold">
+        Delete this draft invoice?
+      </h2>
+      <p
+        id="delete-invoice-description"
+        class="mt-4 text-sm leading-6 text-black/60"
+      >
+        INV-1042 and its public link will be permanently removed.
+      </p>
+      <form
+        method="dialog"
+        class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end"
+      >
+        <Button
+          type="submit"
+          value="cancel"
+          autofocus
+          class="border-2 border-black bg-white text-black hover:bg-black hover:text-white"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          value="delete"
+          class="border-2 border-red-700 bg-red-700 text-white hover:bg-white hover:text-red-700"
+        >
+          Delete invoice
+        </Button>
+      </form>
+    </Dialog>
+  </section>
+
+  <section class="dark bg-gray-950 p-8 text-white">
+    <p class="mb-5 font-mono text-xs uppercase tracking-[0.18em] text-gray-400">
+      Slipway / project settings
+    </p>
+    <Button
+      commandfor="delete-project"
+      command="show-modal"
+      class="min-h-9 min-w-0 bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700"
+    >
+      Delete project
+    </Button>
+    <Dialog
+      id="delete-project"
+      aria-labelledby="delete-project-title"
+      aria-describedby="delete-project-description"
+      class="max-w-sm border-gray-700 bg-gray-900 p-6 text-white shadow-xl"
+    >
+      <h2 id="delete-project-title" class="text-lg font-semibold">
+        Delete project?
+      </h2>
+      <p id="delete-project-description" class="mt-2 text-sm text-gray-400">
+        Recovery data remains unless you choose to purge it.
+      </p>
+      <form method="dialog" class="mt-5 flex justify-end gap-3">
+        <Button
+          type="submit"
+          value="cancel"
+          autofocus
+          class="min-h-9 min-w-0 border border-gray-600 bg-transparent px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-800"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          value="delete"
+          class="min-h-9 min-w-0 bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700"
+        >
+          Delete
+        </Button>
+      </form>
+    </Dialog>
+  </section>
+</template>

--- a/docs/klean-ui/snippets/popover/usage.jsx
+++ b/docs/klean-ui/snippets/popover/usage.jsx
@@ -1,0 +1,25 @@
+import Button from '~/components/ui/button/Button.jsx'
+import Popover from '~/components/ui/popover/Popover.jsx'
+
+export default function Filters() {
+  return (
+    <>
+      <Button popoverTarget="filters">Filters</Button>
+      <Popover id="filters" className="w-72">
+        {({ close }) => (
+          <section aria-labelledby="filters-title">
+            <h2 id="filters-title" className="font-semibold">
+              Visible records
+            </h2>
+            <p className="mt-1 text-sm leading-6 text-gray-600">
+              Choose which records appear in this view.
+            </p>
+            <Button onClick={close} className="mt-5 w-full">
+              Done
+            </Button>
+          </section>
+        )}
+      </Popover>
+    </>
+  )
+}

--- a/docs/klean-ui/snippets/popover/usage.svelte
+++ b/docs/klean-ui/snippets/popover/usage.svelte
@@ -1,0 +1,17 @@
+<script>
+  import Button from '$lib/components/ui/button/Button.svelte'
+  import Popover from '$lib/components/ui/popover/Popover.svelte'
+</script>
+
+{#snippet content({ close })}
+  <section aria-labelledby="filters-title">
+    <h2 id="filters-title" class="font-semibold">Visible records</h2>
+    <p class="mt-1 text-sm leading-6 text-gray-600">
+      Choose which records appear in this view.
+    </p>
+    <Button onclick={close} class="mt-5 w-full">Done</Button>
+  </section>
+{/snippet}
+
+<Button popovertarget="filters">Filters</Button>
+<Popover id="filters" class="w-72" children={content} />

--- a/docs/klean-ui/sources/popover/Popover.jsx
+++ b/docs/klean-ui/sources/popover/Popover.jsx
@@ -1,0 +1,309 @@
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset as floatingOffset,
+  shift
+} from '@floating-ui/dom'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES = [
+  'z-50 m-0 w-max max-w-[calc(100vw-1rem)] rounded-md border border-gray-200 bg-white p-4 text-gray-950 shadow-lg outline-none',
+  'dark:border-gray-700 dark:bg-gray-950 dark:text-white'
+]
+
+const Popover = forwardRef(function Popover(
+  {
+    id,
+    open: controlledOpen,
+    defaultOpen = false,
+    onOpenChange,
+    placement = 'bottom-start',
+    offset = 8,
+    className,
+    style,
+    'data-slot': dataSlot = 'popover-content',
+    children,
+    ...contentProps
+  },
+  forwardedRef
+) {
+  const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+  const contentId = id ?? `klean-popover-${generatedId}`
+  const contentRef = useRef(null)
+  const activeInvoker = useRef(null)
+  const [referenceVersion, setReferenceVersion] = useState(0)
+  const [internalOpen, setInternalOpen] = useState(defaultOpen)
+  const [supportsNative, setSupportsNative] = useState(false)
+  const [resolvedPlacement, setResolvedPlacement] = useState(placement)
+  const [positionStyle, setPositionStyle] = useState({
+    position: 'fixed',
+    left: 0,
+    top: 0
+  })
+  const isControlled = controlledOpen !== undefined
+  const isOpen = isControlled ? controlledOpen : internalOpen
+  const latestOpen = useRef(isOpen)
+  latestOpen.current = isOpen
+
+  const invokers = useCallback(() => {
+    const root = contentRef.current?.getRootNode?.() ?? document
+
+    return [...(root.querySelectorAll?.('[popovertarget]') ?? [])].filter(
+      (element) => element.getAttribute('popovertarget') === contentId
+    )
+  }, [contentId])
+
+  const eventPath = (event) =>
+    event.nativeEvent?.composedPath?.() ??
+    event.composedPath?.() ?? [event.target]
+
+  const resolveInvoker = useCallback(
+    (candidate) => {
+      if (candidate?.isConnected && activeInvoker.current !== candidate) {
+        activeInvoker.current = candidate
+        setReferenceVersion((version) => version + 1)
+      }
+
+      if (!activeInvoker.current?.isConnected) {
+        const fallback = invokers()[0]
+        if (activeInvoker.current !== fallback) {
+          activeInvoker.current = fallback
+          setReferenceVersion((version) => version + 1)
+        }
+      }
+
+      return activeInvoker.current
+    },
+    [contentId, invokers]
+  )
+
+  const syncInvokerAria = useCallback(() => {
+    for (const invoker of invokers()) {
+      invoker.setAttribute('aria-controls', contentId)
+      invoker.setAttribute('aria-expanded', String(latestOpen.current))
+    }
+  }, [contentId, invokers])
+
+  const popoverIsShowing = useCallback(() => {
+    if (!supportsNative || !contentRef.current) return false
+
+    try {
+      return contentRef.current.matches(':popover-open')
+    } catch {
+      return false
+    }
+  }, [supportsNative])
+
+  const syncNativePopover = useCallback(() => {
+    if (!supportsNative || !contentRef.current) return
+
+    const showing = popoverIsShowing()
+
+    try {
+      if (latestOpen.current && !showing) {
+        contentRef.current.showPopover({ source: resolveInvoker() })
+      } else if (!latestOpen.current && showing) {
+        contentRef.current.hidePopover()
+      }
+    } catch {
+      // A rapid native toggle can briefly make the requested state redundant.
+    }
+  }, [popoverIsShowing, resolveInvoker, supportsNative])
+
+  const requestOpen = useCallback(
+    (nextOpen, { restoreFocus = false } = {}) => {
+      if (!isControlled) setInternalOpen(nextOpen)
+      onOpenChange?.(nextOpen)
+
+      queueMicrotask(() => {
+        syncInvokerAria()
+        syncNativePopover()
+
+        const invoker = resolveInvoker()
+        if (!nextOpen && restoreFocus && invoker?.isConnected) {
+          invoker.focus({ preventScroll: true })
+        }
+      })
+    },
+    [
+      isControlled,
+      onOpenChange,
+      resolveInvoker,
+      syncInvokerAria,
+      syncNativePopover
+    ]
+  )
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({
+      content: contentRef.current,
+      open: (source) => {
+        resolveInvoker(source)
+        requestOpen(true)
+      },
+      close: ({ restoreFocus = latestOpen.current } = {}) =>
+        requestOpen(false, { restoreFocus })
+    }),
+    [requestOpen, resolveInvoker]
+  )
+
+  useEffect(() => {
+    const native =
+      typeof contentRef.current?.showPopover === 'function' &&
+      typeof contentRef.current?.hidePopover === 'function'
+    setSupportsNative(native)
+    resolveInvoker()
+    syncInvokerAria()
+
+    if (native) return
+
+    function handleFallbackInvokerClick(event) {
+      const candidate = eventPath(event).find(
+        (element) => element?.getAttribute?.('popovertarget') === contentId
+      )
+      if (candidate?.getAttribute('popovertarget') !== contentId) return
+
+      resolveInvoker(candidate)
+      const action = candidate.getAttribute('popovertargetaction') ?? 'toggle'
+
+      if (action === 'show') requestOpen(true)
+      else if (action === 'hide') {
+        requestOpen(false, { restoreFocus: true })
+      } else requestOpen(!latestOpen.current)
+    }
+
+    document.addEventListener('click', handleFallbackInvokerClick)
+    return () =>
+      document.removeEventListener('click', handleFallbackInvokerClick)
+  }, [contentId, requestOpen, resolveInvoker, syncInvokerAria])
+
+  useEffect(() => {
+    syncInvokerAria()
+    syncNativePopover()
+
+    const invoker = resolveInvoker()
+    if (!isOpen || !invoker || !contentRef.current) return
+
+    const updatePosition = async () => {
+      const result = await computePosition(invoker, contentRef.current, {
+        placement,
+        strategy: 'fixed',
+        middleware: [floatingOffset(offset), flip(), shift({ padding: 8 })]
+      })
+
+      setResolvedPlacement(result.placement)
+      setPositionStyle({ position: 'fixed', left: result.x, top: result.y })
+    }
+
+    return autoUpdate(invoker, contentRef.current, updatePosition)
+  }, [
+    isOpen,
+    offset,
+    placement,
+    referenceVersion,
+    resolveInvoker,
+    syncInvokerAria,
+    syncNativePopover
+  ])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleOutsidePointer(event) {
+      const path = eventPath(event)
+      const reference = resolveInvoker()
+
+      if (
+        path.includes(contentRef.current) ||
+        (reference &&
+          (path.includes(reference) || reference.contains?.(event.target))) ||
+        invokers().some(
+          (invoker) => path.includes(invoker) || invoker.contains(event.target)
+        )
+      ) {
+        return
+      }
+
+      requestOpen(false)
+    }
+
+    function handleEscape(event) {
+      if (event.key !== 'Escape') return
+
+      if (supportsNative) {
+        const openPopovers = [...document.querySelectorAll(':popover-open')]
+        if (openPopovers.at(-1) !== contentRef.current) return
+      }
+
+      event.preventDefault()
+      requestOpen(false, { restoreFocus: true })
+    }
+
+    document.addEventListener('keydown', handleEscape)
+    document.addEventListener('pointerdown', handleOutsidePointer, true)
+
+    return () => {
+      document.removeEventListener('pointerdown', handleOutsidePointer, true)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [isOpen, invokers, requestOpen, supportsNative])
+
+  function handleNativeToggle(event) {
+    const nativeEvent = event.nativeEvent
+    const nextOpen = nativeEvent.newState === 'open'
+    const shouldRestoreFocus =
+      !nextOpen &&
+      nativeEvent.source?.getAttribute?.('popovertargetaction') === 'hide'
+    if (nextOpen) resolveInvoker(nativeEvent.source)
+    if (nextOpen === latestOpen.current) return
+
+    if (!isControlled) setInternalOpen(nextOpen)
+    onOpenChange?.(nextOpen)
+    queueMicrotask(syncInvokerAria)
+
+    if (isControlled) queueMicrotask(syncNativePopover)
+
+    if (shouldRestoreFocus) {
+      queueMicrotask(() => {
+        const invoker = resolveInvoker()
+        if (invoker?.isConnected) invoker.focus({ preventScroll: true })
+      })
+    }
+  }
+
+  const close = ({ restoreFocus = latestOpen.current } = {}) =>
+    requestOpen(false, { restoreFocus })
+
+  return (
+    <div
+      {...contentProps}
+      ref={contentRef}
+      id={contentId}
+      popover="auto"
+      hidden={!supportsNative && !isOpen}
+      data-slot={dataSlot}
+      data-state={isOpen ? 'open' : 'closed'}
+      data-placement={resolvedPlacement}
+      className={twMerge(BASE_CLASSES, className)}
+      style={{ ...positionStyle, ...style }}
+      onToggle={handleNativeToggle}
+    >
+      {typeof children === 'function'
+        ? children({ open: isOpen, close })
+        : children}
+    </div>
+  )
+})
+
+export default Popover

--- a/docs/klean-ui/sources/popover/Popover.svelte
+++ b/docs/klean-ui/sources/popover/Popover.svelte
@@ -1,0 +1,274 @@
+<script>
+  import {
+    autoUpdate,
+    computePosition,
+    flip,
+    offset as floatingOffset,
+    shift,
+  } from "@floating-ui/dom";
+  import { onMount, untrack } from "svelte";
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES = [
+    "z-50 m-0 w-max max-w-[calc(100vw-1rem)] rounded-md border border-gray-200 bg-white p-4 text-gray-950 shadow-lg outline-none",
+    "dark:border-gray-700 dark:bg-gray-950 dark:text-white",
+  ];
+
+  let {
+    id,
+    open = $bindable(),
+    defaultOpen = false,
+    onOpenChange,
+    placement = "bottom-start",
+    offset = 8,
+    class: className = "",
+    style,
+    children,
+    ...contentProps
+  } = $props();
+
+  const componentId = $props.id();
+  const generatedId = `klean-popover-${componentId}`;
+  let internalOpen = $state(untrack(() => defaultOpen));
+  let contentElement = $state();
+  let activeInvoker = $state();
+  let supportsNative = $state(false);
+  let resolvedPlacement = $state(untrack(() => placement));
+  let positionStyle = $state({ position: "fixed", left: "0px", top: "0px" });
+  let isOpen = $derived(open ?? internalOpen);
+  let contentId = $derived(id ?? generatedId);
+  let mergedStyle = $derived(
+    [positionStyle, style]
+      .flatMap((value) => {
+        if (!value) return [];
+        if (typeof value === "string") return value;
+
+        return Object.entries(value)
+          .filter(([, propertyValue]) => propertyValue != null)
+          .map(([property, propertyValue]) => {
+            const cssProperty = property.replace(
+              /[A-Z]/g,
+              (letter) => `-${letter.toLowerCase()}`,
+            );
+            return `${cssProperty}:${propertyValue}`;
+          });
+      })
+      .join(";"),
+  );
+
+  function invokers() {
+    const root = contentElement?.getRootNode?.() ?? document;
+
+    return [...(root.querySelectorAll?.("[popovertarget]") ?? [])].filter(
+      (element) => element.getAttribute("popovertarget") === contentId,
+    );
+  }
+
+  function eventPath(event) {
+    return event.composedPath?.() ?? [event.target];
+  }
+
+  function resolveInvoker(candidate) {
+    if (candidate?.isConnected) {
+      activeInvoker = candidate;
+    }
+
+    if (!activeInvoker?.isConnected) activeInvoker = invokers()[0];
+    return activeInvoker;
+  }
+
+  function syncInvokerAria() {
+    for (const invoker of invokers()) {
+      invoker.setAttribute("aria-controls", contentId);
+      invoker.setAttribute("aria-expanded", String(isOpen));
+    }
+  }
+
+  function popoverIsShowing() {
+    if (!supportsNative || !contentElement) return false;
+
+    try {
+      return contentElement.matches(":popover-open");
+    } catch {
+      return false;
+    }
+  }
+
+  function syncNativePopover() {
+    if (!supportsNative || !contentElement) return;
+
+    const showing = popoverIsShowing();
+
+    try {
+      if (isOpen && !showing) {
+        contentElement.showPopover({ source: resolveInvoker() });
+      } else if (!isOpen && showing) {
+        contentElement.hidePopover();
+      }
+    } catch {
+      // A rapid native toggle can briefly make the requested state redundant.
+    }
+  }
+
+  function requestOpen(nextOpen, { restoreFocus = false } = {}) {
+    if (open === undefined) internalOpen = nextOpen;
+    else open = nextOpen;
+    onOpenChange?.(nextOpen);
+
+    queueMicrotask(() => {
+      syncInvokerAria();
+      syncNativePopover();
+
+      const invoker = resolveInvoker();
+      if (!nextOpen && restoreFocus && invoker?.isConnected) {
+        invoker.focus({ preventScroll: true });
+      }
+    });
+  }
+
+  export function close({ restoreFocus = isOpen } = {}) {
+    requestOpen(false, { restoreFocus });
+  }
+
+  export function show(source) {
+    resolveInvoker(source);
+    requestOpen(true);
+  }
+
+  export function getContent() {
+    return contentElement;
+  }
+
+  function handleNativeToggle(event) {
+    const nextOpen = event.newState === "open";
+    const shouldRestoreFocus =
+      !nextOpen &&
+      event.source?.getAttribute?.("popovertargetaction") === "hide";
+    if (nextOpen) resolveInvoker(event.source);
+    if (nextOpen === isOpen) return;
+
+    if (open === undefined) internalOpen = nextOpen;
+    else open = nextOpen;
+    onOpenChange?.(nextOpen);
+    queueMicrotask(syncInvokerAria);
+
+    if (shouldRestoreFocus) {
+      queueMicrotask(() => {
+        const invoker = resolveInvoker();
+        if (invoker?.isConnected) invoker.focus({ preventScroll: true });
+      });
+    }
+  }
+
+  onMount(() => {
+    supportsNative =
+      typeof contentElement?.showPopover === "function" &&
+      typeof contentElement?.hidePopover === "function";
+    resolveInvoker();
+    syncInvokerAria();
+
+    if (supportsNative) return;
+
+    function handleFallbackInvokerClick(event) {
+      const candidate = eventPath(event).find(
+        (element) => element?.getAttribute?.("popovertarget") === contentId,
+      );
+      if (candidate?.getAttribute("popovertarget") !== contentId) return;
+
+      resolveInvoker(candidate);
+      const action = candidate.getAttribute("popovertargetaction") ?? "toggle";
+
+      if (action === "show") requestOpen(true);
+      else if (action === "hide") {
+        requestOpen(false, { restoreFocus: true });
+      } else requestOpen(!isOpen);
+    }
+
+    document.addEventListener("click", handleFallbackInvokerClick);
+    return () =>
+      document.removeEventListener("click", handleFallbackInvokerClick);
+  });
+
+  $effect(() => {
+    syncInvokerAria();
+    syncNativePopover();
+
+    const invoker = resolveInvoker();
+    if (!isOpen || !invoker || !contentElement) return;
+
+    const updatePosition = async () => {
+      const result = await computePosition(invoker, contentElement, {
+        placement,
+        strategy: "fixed",
+        middleware: [floatingOffset(offset), flip(), shift({ padding: 8 })],
+      });
+
+      resolvedPlacement = result.placement;
+      positionStyle = {
+        position: "fixed",
+        left: `${result.x}px`,
+        top: `${result.y}px`,
+      };
+    };
+
+    return autoUpdate(invoker, contentElement, updatePosition);
+  });
+
+  $effect(() => {
+    if (!isOpen) return;
+
+    function handleOutsidePointer(event) {
+      const path = eventPath(event);
+      const reference = resolveInvoker();
+
+      if (
+        path.includes(contentElement) ||
+        (reference &&
+          (path.includes(reference) || reference.contains?.(event.target))) ||
+        invokers().some(
+          (invoker) => path.includes(invoker) || invoker.contains(event.target),
+        )
+      ) {
+        return;
+      }
+
+      requestOpen(false);
+    }
+
+    function handleEscape(event) {
+      if (event.key !== "Escape") return;
+
+      if (supportsNative) {
+        const openPopovers = [...document.querySelectorAll(":popover-open")];
+        if (openPopovers.at(-1) !== contentElement) return;
+      }
+
+      event.preventDefault();
+      requestOpen(false, { restoreFocus: true });
+    }
+
+    document.addEventListener("keydown", handleEscape);
+    document.addEventListener("pointerdown", handleOutsidePointer, true);
+
+    return () => {
+      document.removeEventListener("pointerdown", handleOutsidePointer, true);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  });
+</script>
+
+<div
+  {...contentProps}
+  bind:this={contentElement}
+  id={contentId}
+  popover="auto"
+  hidden={!supportsNative && !isOpen}
+  data-slot={contentProps["data-slot"] ?? "popover-content"}
+  data-state={isOpen ? "open" : "closed"}
+  data-placement={resolvedPlacement}
+  class={twMerge(BASE_CLASSES, className)}
+  style={mergedStyle}
+  ontoggle={handleNativeToggle}
+>
+  {@render children?.({ open: isOpen, close })}
+</div>


### PR DESCRIPTION
Closes #154

## What changed
- add Vue, React, and Svelte Popover usage plus complete copyable framework source
- add live Hagfish and Slipway Dialog recipes with caller-owned Tailwind
- preserve the existing native-first, zero-configuration, Durable UI guidance for Popover, Menu, and Dialog

## Verification
- `npm run build`
- focused Prettier check for every changed file
- `git diff --check`
- local docs acceptance: component sidebar entries, live pointer interaction, native semantics, framework usage/source, and copy controls

Note: the repository-wide Prettier check still reports three pre-existing unrelated files under `docs/boring-stack/`; no unrelated formatting was changed.