### PR TITLE
docs(klean): document the native Table contract

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -123,6 +123,7 @@ function kleanUiGuide() {
         { text: 'Spinner', link: '/klean-ui/components/spinner' },
         { text: 'Tooltip', link: '/klean-ui/components/tooltip' },
         { text: 'Tabs', link: '/klean-ui/components/tabs' },
+        { text: 'Table', link: '/klean-ui/components/table' },
         { text: 'Popover', link: '/klean-ui/components/popover' },
         { text: 'Menu', link: '/klean-ui/components/menu' },
         { text: 'Select', link: '/klean-ui/components/select' },

--- a/docs/.vitepress/theme/components/klean/table/Table.vue
+++ b/docs/.vitepress/theme/components/klean/table/Table.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
+const element = ref()
+
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <table
+    ref="element"
+    v-bind="forwardedAttrs"
+    data-slot="table"
+    :class="
+      twMerge(
+        'w-full border-collapse text-left text-sm text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </table>
+</template>

--- a/docs/.vitepress/theme/components/klean/table/TableRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/table/TableRecipes.vue
@@ -1,0 +1,121 @@
+<script setup>
+import Table from './Table.vue'
+
+const queryRows = [
+  { id: 4012, email: 'kelvin@example.com', plan: 'Pro', total: '$48.00' },
+  { id: 4011, email: 'mira@example.com', plan: 'Team', total: '$120.00' },
+  { id: 4010, email: 'ada@example.com', plan: 'Pro', total: '$48.00' }
+]
+
+const invoiceRows = [
+  { item: 'Brand direction', quantity: 1, amount: '$1,600.00' },
+  { item: 'Landing page', quantity: 2, amount: '$2,400.00' },
+  { item: 'Launch support', quantity: 4, amount: '$800.00' }
+]
+</script>
+
+<template>
+  <div class="grid w-full gap-8 xl:grid-cols-2">
+    <article
+      class="overflow-hidden rounded-lg border border-gray-800 bg-gray-950 text-white"
+    >
+      <header class="px-5 py-4">
+        <p class="font-mono text-xs uppercase tracking-wider text-gray-500">
+          Slipway / SQL result
+        </p>
+        <h2 class="mt-1 text-lg font-semibold">customers · 3 rows</h2>
+      </header>
+      <div class="overflow-x-auto">
+        <Table class="min-w-128 text-gray-100 dark:text-gray-100">
+          <caption class="sr-only">
+            Latest customer query results
+          </caption>
+          <thead
+            class="border-y border-gray-800 bg-gray-900 font-mono text-xs uppercase tracking-wider text-gray-400"
+          >
+            <tr>
+              <th scope="col" class="px-5 py-3 font-medium">id</th>
+              <th scope="col" class="px-5 py-3 font-medium">email</th>
+              <th scope="col" class="px-5 py-3 font-medium">plan</th>
+              <th scope="col" class="px-5 py-3 text-right font-medium">
+                total
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-900 font-mono text-xs">
+            <tr v-for="row in queryRows" :key="row.id" class="hover:bg-white/5">
+              <td class="px-5 py-3 text-gray-400 tabular-nums">{{ row.id }}</td>
+              <td class="px-5 py-3">{{ row.email }}</td>
+              <td class="px-5 py-3">{{ row.plan }}</td>
+              <td class="px-5 py-3 text-right tabular-nums">{{ row.total }}</td>
+            </tr>
+          </tbody>
+        </Table>
+      </div>
+    </article>
+
+    <article
+      class="overflow-hidden border-2 border-black bg-[#f7f3eb] p-6 text-black shadow-[6px_6px_0_0_#000]"
+    >
+      <p class="font-mono text-xs uppercase tracking-wider text-black/55">
+        Hagfish / report ledger
+      </p>
+      <h2 class="mt-2 text-2xl font-semibold tracking-tight">
+        Invoice INV-1042
+      </h2>
+      <div class="mt-6 overflow-x-auto">
+        <Table
+          class="min-w-112 border-separate border-spacing-0 text-black dark:text-black"
+        >
+          <caption class="sr-only">
+            Invoice INV-1042 line item report
+          </caption>
+          <thead
+            class="font-mono text-xs uppercase tracking-wider text-black/55"
+          >
+            <tr>
+              <th
+                scope="col"
+                class="border-b-2 border-black py-3 pr-6 font-medium"
+              >
+                Work
+              </th>
+              <th
+                scope="col"
+                class="border-b-2 border-black px-6 py-3 text-right font-medium"
+              >
+                Qty
+              </th>
+              <th
+                scope="col"
+                class="border-b-2 border-black py-3 pl-6 text-right font-medium"
+              >
+                Amount
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in invoiceRows" :key="row.item">
+              <th
+                scope="row"
+                class="border-b border-black/20 py-4 pr-6 font-medium"
+              >
+                {{ row.item }}
+              </th>
+              <td
+                class="border-b border-black/20 px-6 py-4 text-right tabular-nums"
+              >
+                {{ row.quantity }}
+              </td>
+              <td
+                class="border-b border-black/20 py-4 pl-6 text-right font-semibold tabular-nums"
+              >
+                {{ row.amount }}
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      </div>
+    </article>
+  </div>
+</template>

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -53,6 +53,10 @@ Short supplementary text for one semantic button or link, with accessible hover,
 
 Accessible peer panels with roving focus, automatic or manual activation, dynamic removal, overflow reveal, and caller-owned native buttons and Tailwind styling.
 
+### [Table](/klean-ui/components/table)
+
+A native table with a neutral baseline, caller-written captions, sections, headers, rows, cells, and actions, plus an explicit boundary before stateful Data Table behavior.
+
 ### [Popover](/klean-ui/components/popover)
 
 A native-first non-modal floating surface with light dismissal, focus return, collision-aware positioning, and ordinary semantic content. A real button invokes it through the browser's `popovertarget` relationship.

--- a/docs/klean-ui/components/table.md
+++ b/docs/klean-ui/components/table.md
@@ -1,0 +1,207 @@
+---
+title: Table
+titleTemplate: Klean UI
+description: A native table with a neutral baseline, caller-owned semantic children, and ordinary Tailwind styling across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanTable from '../../.vitepress/theme/components/klean/table/Table.vue'
+import TableRecipes from '../../.vitepress/theme/components/klean/table/TableRecipes.vue'
+import tableSource from '../../.vitepress/theme/components/klean/table/Table.vue?raw'
+import reactSource from '../sources/table/Table.jsx?raw'
+import svelteSource from '../sources/table/Table.svelte?raw'
+import vueUsage from '../snippets/table/usage.vue?raw'
+import reactUsage from '../snippets/table/usage.jsx?raw'
+import svelteUsage from '../snippets/table/usage.svelte?raw'
+import productSource from '../snippets/table/products.vue?raw'
+
+const services = [
+  { name: 'api', dependency: 'PostgreSQL 17', status: 'Healthy', memory: '384 MB' },
+  { name: 'worker', dependency: 'Redis 8', status: 'Deploying', memory: '192 MB' },
+  { name: 'web', dependency: '—', status: 'Healthy', memory: '256 MB' }
+]
+
+</script>
+
+# Table
+
+Table is a thin native `<table>` with a neutral typographic baseline. The application writes the caption, column and row headers, sections, cells, actions, responsive wrapper, and every product-specific Tailwind class directly.
+
+That is the complete API. Klean does not replace the browser's table model with an item schema, render callbacks, anatomy components, or visual variants.
+
+<KleanPreview id="table-source" :source="tableSource" filename="Table.vue">
+  <template #preview>
+    <div
+      class="w-full max-w-3xl overflow-x-auto rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950"
+    >
+      <KleanTable class="min-w-160">
+        <caption class="caption-top px-4 py-3 text-left text-base font-semibold">
+          Production services
+        </caption>
+        <thead class="bg-gray-50 text-xs uppercase tracking-wider text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+          <tr>
+            <th scope="col" class="px-4 py-3 font-medium">Service</th>
+            <th scope="col" class="px-4 py-3 font-medium">Dependency</th>
+            <th scope="col" class="px-4 py-3 font-medium">Status</th>
+            <th scope="col" class="px-4 py-3 text-right font-medium">Memory</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+          <tr v-for="service in services" :key="service.name">
+            <th scope="row" class="px-4 py-3 font-mono font-medium">
+              {{ service.name }}
+            </th>
+            <td class="px-4 py-3 text-gray-600 dark:text-gray-300">
+              {{ service.dependency }}
+            </td>
+            <td class="px-4 py-3">{{ service.status }}</td>
+            <td class="px-4 py-3 text-right tabular-nums">{{ service.memory }}</td>
+          </tr>
+        </tbody>
+      </KleanTable>
+    </div>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/table/Table.vue
+
+  </template>
+  <template #caption>
+    The wrapper owns overflow. The browser still exposes one native captioned table.
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and writes one framework-native source file into the conventional component directory:
+
+<KleanInstallation
+  id="table-installation"
+  component="table"
+  :source="tableSource"
+  filename="Table.vue"
+  destination="assets/js/components/ui/table/Table.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+There is no initializer, configuration file, provider, `TableHeader`, `TableRow`, `TableCell`, barrel file, or runtime package.
+
+## Usage
+
+Use Table for the root and write ordinary HTML beneath it. This keeps semantics visible in reviews and puts Tailwind exactly where the visual decision belongs.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="ServicesTable.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="ServicesTable.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="ServicesTable.svelte" />
+
+## API
+
+| Input                 | Default | Purpose                                                                   |
+| --------------------- | ------- | ------------------------------------------------------------------------- |
+| `class` / `className` | —       | Ordinary Tailwind classes merged after the neutral table baseline.        |
+| native attributes     | —       | IDs, test hooks, ARIA attributes, and other native table attributes.      |
+| default content       | —       | Native caption, sections, rows, headers, cells, links, buttons, and text. |
+
+Table forwards a framework-native element reference. It owns no rows, sorting, filtering, selection, pagination, loading, or empty state.
+
+## Write the table you mean
+
+Native elements already express the relationships a data grid needs:
+
+- give the table an accessible name with a visible `<caption>` or a visually hidden one when nearby visible context already names it;
+- use `<thead>`, `<tbody>`, and `<tfoot>` to group rows when those sections exist;
+- use `<th scope="col">` for column headers and `<th scope="row">` for row headers;
+- put buttons around sortable header labels only when sorting exists, then update `aria-sort` on the sorted header;
+- give repeated row actions a specific accessible name, such as “Inspect api”, even if the visible label is only “Inspect”.
+
+Do not add ARIA table roles to native table elements. Do not use Table for layout.
+
+## Responsive tables
+
+Tables describe two-dimensional relationships. Preserve that structure at narrow widths and let an explicit wrapper scroll:
+
+```html
+<p id="services-scroll-help" class="text-sm text-gray-600">
+  Scroll horizontally to see every service field.
+</p>
+<div
+  class="overflow-x-auto"
+  tabindex="0"
+  aria-describedby="services-scroll-help"
+>
+  <table class="min-w-160">
+    <!-- native table content -->
+  </table>
+</div>
+```
+
+The focusable wrapper makes keyboard scrolling available where the browser does not already expose it. Do not turn rows or cells into `display: block`; that can obscure the relationships that made a table appropriate.
+
+## Slipway and Hagfish recipes
+
+The same Table can carry Slipway's dense operational results and Hagfish's editorial reporting voice because neither treatment is hidden behind a product variant.
+
+<KleanPreview id="table-products" :source="productSource" filename="ProductTables.vue">
+  <template #preview>
+    <TableRecipes />
+
+  </template>
+  <template #caption>
+    Hagfish's editable invoice items remain a responsive form/list. A report ledger is tabular; a collection of editable controls is not.
+  </template>
+</KleanPreview>
+
+## Table or Data Table?
+
+Use Table when the application already has rows to render and native markup expresses the experience. It is enough for reports, invoices, query results, audit history, comparison matrices, and small operational lists.
+
+A future Data Table will compose Table when users need a coordinated stateful system: sorting, filtering, column visibility, selection, pagination, or server-backed loading. That state should be durable in the URL when it changes what the user is looking at, so reload, sharing, Back/Forward, and server rendering preserve the same view.
+
+Keeping the layers separate avoids making every small table configure features it does not use. Moving from Table to Data Table should preserve the native rows and cells rather than require a new visual language.
+
+## When to use
+
+Use Table when rows and columns have relationships that users need to compare or scan: database results, deployments, invoices, audit events, billing records, permissions, and compact reports.
+
+## When not to use
+
+- Use a list when each item stands alone and column alignment adds no meaning.
+- Use cards when each item has a different content shape or a strong independent action hierarchy.
+- Keep editable invoice line items as a responsive form/list when controls must reflow naturally on small screens.
+- Wait for Data Table when the primary problem is coordinated sort, filter, selection, pagination, and server state rather than markup.
+
+## Complete framework source
+
+Copy, inspect, and change the complete one-file source for your framework.
+
+### Vue source
+
+<CopyCode :code="tableSource" label="Table.vue" />
+
+### React source
+
+<CopyCode :code="reactSource" label="Table.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteSource" label="Table.svelte" />
+
+## Related components
+
+- [Button](/klean-ui/components/button) — supplies truthful row and header actions.
+- [Checkbox](/klean-ui/components/checkbox) — supports explicit row selection when the application owns that state.
+- [Combobox](/klean-ui/components/combobox) — handles searchable filters outside the table.
+- [Tabs](/klean-ui/components/tabs) — separates related result views without changing table semantics.
+- Data Table — the planned stateful layer for durable sorting, filtering, selection, and pagination.

--- a/docs/klean-ui/snippets/table/products.vue
+++ b/docs/klean-ui/snippets/table/products.vue
@@ -1,0 +1,121 @@
+<script setup>
+import Table from '@/components/ui/table/Table.vue'
+
+const queryRows = [
+  { id: 4012, email: 'kelvin@example.com', plan: 'Pro', total: '$48.00' },
+  { id: 4011, email: 'mira@example.com', plan: 'Team', total: '$120.00' },
+  { id: 4010, email: 'ada@example.com', plan: 'Pro', total: '$48.00' }
+]
+
+const invoiceRows = [
+  { item: 'Brand direction', quantity: 1, amount: '$1,600.00' },
+  { item: 'Landing page', quantity: 2, amount: '$2,400.00' },
+  { item: 'Launch support', quantity: 4, amount: '$800.00' }
+]
+</script>
+
+<template>
+  <div class="grid gap-8 xl:grid-cols-2">
+    <article
+      class="overflow-hidden rounded-lg border border-gray-800 bg-gray-950 text-white"
+    >
+      <header class="px-5 py-4">
+        <p class="font-mono text-xs uppercase tracking-wider text-gray-500">
+          Slipway / SQL result
+        </p>
+        <h2 class="mt-1 text-lg font-semibold">customers · 3 rows</h2>
+      </header>
+      <div class="overflow-x-auto">
+        <Table class="min-w-128 text-gray-100 dark:text-gray-100">
+          <caption class="sr-only">
+            Latest customer query results
+          </caption>
+          <thead
+            class="border-y border-gray-800 bg-gray-900 font-mono text-xs uppercase tracking-wider text-gray-400"
+          >
+            <tr>
+              <th scope="col" class="px-5 py-3 font-medium">id</th>
+              <th scope="col" class="px-5 py-3 font-medium">email</th>
+              <th scope="col" class="px-5 py-3 font-medium">plan</th>
+              <th scope="col" class="px-5 py-3 text-right font-medium">
+                total
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-900 font-mono text-xs">
+            <tr v-for="row in queryRows" :key="row.id" class="hover:bg-white/5">
+              <td class="px-5 py-3 text-gray-400 tabular-nums">{{ row.id }}</td>
+              <td class="px-5 py-3">{{ row.email }}</td>
+              <td class="px-5 py-3">{{ row.plan }}</td>
+              <td class="px-5 py-3 text-right tabular-nums">{{ row.total }}</td>
+            </tr>
+          </tbody>
+        </Table>
+      </div>
+    </article>
+
+    <article
+      class="overflow-hidden border-2 border-black bg-[#f7f3eb] p-6 text-black shadow-[6px_6px_0_0_#000]"
+    >
+      <p class="font-mono text-xs uppercase tracking-wider text-black/55">
+        Hagfish / report ledger
+      </p>
+      <h2 class="mt-2 text-2xl font-semibold tracking-tight">
+        Invoice INV-1042
+      </h2>
+      <div class="mt-6 overflow-x-auto">
+        <Table
+          class="min-w-112 border-separate border-spacing-0 text-black dark:text-black"
+        >
+          <caption class="sr-only">
+            Invoice INV-1042 line item report
+          </caption>
+          <thead
+            class="font-mono text-xs uppercase tracking-wider text-black/55"
+          >
+            <tr>
+              <th
+                scope="col"
+                class="border-b-2 border-black py-3 pr-6 font-medium"
+              >
+                Work
+              </th>
+              <th
+                scope="col"
+                class="border-b-2 border-black px-6 py-3 text-right font-medium"
+              >
+                Qty
+              </th>
+              <th
+                scope="col"
+                class="border-b-2 border-black py-3 pl-6 text-right font-medium"
+              >
+                Amount
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in invoiceRows" :key="row.item">
+              <th
+                scope="row"
+                class="border-b border-black/20 py-4 pr-6 font-medium"
+              >
+                {{ row.item }}
+              </th>
+              <td
+                class="border-b border-black/20 px-6 py-4 text-right tabular-nums"
+              >
+                {{ row.quantity }}
+              </td>
+              <td
+                class="border-b border-black/20 py-4 pl-6 text-right font-semibold tabular-nums"
+              >
+                {{ row.amount }}
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      </div>
+    </article>
+  </div>
+</template>

--- a/docs/klean-ui/snippets/table/usage.jsx
+++ b/docs/klean-ui/snippets/table/usage.jsx
@@ -1,0 +1,45 @@
+import Table from '@/components/ui/table/Table.jsx'
+
+const services = [
+  { name: 'api', status: 'Healthy', memory: '384 MB' },
+  { name: 'worker', status: 'Deploying', memory: '192 MB' },
+  { name: 'web', status: 'Healthy', memory: '256 MB' }
+]
+
+export default function ServicesTable() {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200">
+      <Table className="min-w-128">
+        <caption className="caption-top px-4 py-3 text-left font-semibold">
+          Production services
+        </caption>
+        <thead className="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
+          <tr>
+            <th scope="col" className="px-4 py-3 font-medium">
+              Service
+            </th>
+            <th scope="col" className="px-4 py-3 font-medium">
+              Status
+            </th>
+            <th scope="col" className="px-4 py-3 text-right font-medium">
+              Memory
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {services.map((service) => (
+            <tr key={service.name}>
+              <th scope="row" className="px-4 py-3 font-mono font-medium">
+                {service.name}
+              </th>
+              <td className="px-4 py-3">{service.status}</td>
+              <td className="px-4 py-3 text-right tabular-nums">
+                {service.memory}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  )
+}

--- a/docs/klean-ui/snippets/table/usage.svelte
+++ b/docs/klean-ui/snippets/table/usage.svelte
@@ -1,0 +1,37 @@
+<script>
+  import Table from '$lib/components/ui/table/Table.svelte'
+
+  const services = [
+    { name: 'api', status: 'Healthy', memory: '384 MB' },
+    { name: 'worker', status: 'Deploying', memory: '192 MB' },
+    { name: 'web', status: 'Healthy', memory: '256 MB' }
+  ]
+</script>
+
+<div class="overflow-x-auto rounded-lg border border-gray-200">
+  <Table class="min-w-128">
+    <caption class="caption-top px-4 py-3 text-left font-semibold">
+      Production services
+    </caption>
+    <thead class="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
+      <tr>
+        <th scope="col" class="px-4 py-3 font-medium">Service</th>
+        <th scope="col" class="px-4 py-3 font-medium">Status</th>
+        <th scope="col" class="px-4 py-3 text-right font-medium">Memory</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100">
+      {#each services as service (service.name)}
+        <tr>
+          <th scope="row" class="px-4 py-3 font-mono font-medium">
+            {service.name}
+          </th>
+          <td class="px-4 py-3">{service.status}</td>
+          <td class="px-4 py-3 text-right tabular-nums">
+            {service.memory}
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </Table>
+</div>

--- a/docs/klean-ui/snippets/table/usage.vue
+++ b/docs/klean-ui/snippets/table/usage.vue
@@ -1,0 +1,37 @@
+<script setup>
+import Table from '@/components/ui/table/Table.vue'
+
+const services = [
+  { name: 'api', status: 'Healthy', memory: '384 MB' },
+  { name: 'worker', status: 'Deploying', memory: '192 MB' },
+  { name: 'web', status: 'Healthy', memory: '256 MB' }
+]
+</script>
+
+<template>
+  <div class="overflow-x-auto rounded-lg border border-gray-200">
+    <Table class="min-w-128">
+      <caption class="caption-top px-4 py-3 text-left font-semibold">
+        Production services
+      </caption>
+      <thead class="bg-gray-50 text-xs uppercase tracking-wider text-gray-600">
+        <tr>
+          <th scope="col" class="px-4 py-3 font-medium">Service</th>
+          <th scope="col" class="px-4 py-3 font-medium">Status</th>
+          <th scope="col" class="px-4 py-3 text-right font-medium">Memory</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100">
+        <tr v-for="service in services" :key="service.name">
+          <th scope="row" class="px-4 py-3 font-mono font-medium">
+            {{ service.name }}
+          </th>
+          <td class="px-4 py-3">{{ service.status }}</td>
+          <td class="px-4 py-3 text-right tabular-nums">
+            {{ service.memory }}
+          </td>
+        </tr>
+      </tbody>
+    </Table>
+  </div>
+</template>

--- a/docs/klean-ui/sources/table/Table.jsx
+++ b/docs/klean-ui/sources/table/Table.jsx
@@ -1,0 +1,21 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES =
+  'w-full border-collapse text-left text-sm text-gray-950 dark:text-white'
+
+const Table = forwardRef(function Table(
+  { className, 'data-slot': _dataSlot, ...props },
+  ref
+) {
+  return (
+    <table
+      {...props}
+      ref={ref}
+      data-slot="table"
+      className={twMerge(BASE_CLASSES, className)}
+    />
+  )
+})
+
+export default Table

--- a/docs/klean-ui/sources/table/Table.svelte
+++ b/docs/klean-ui/sources/table/Table.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  let {
+    children,
+    class: className,
+    "data-slot": _dataSlot,
+    ...props
+  } = $props();
+
+  let element;
+
+  export function getElement() {
+    return element;
+  }
+</script>
+
+<table
+  {...props}
+  bind:this={element}
+  data-slot="table"
+  class={twMerge(
+    "w-full border-collapse text-left text-sm text-gray-950 dark:text-white",
+    className,
+  )}
+>
+  {@render children?.()}
+</table>


### PR DESCRIPTION
Closes #195

## What changed

- adds Table to the Klean UI component navigation and catalog
- documents the one-component, native-child API across Vue, React, and Svelte
- provides live and copyable Slipway operational-result and Hagfish report-ledger recipes
- documents captions, header scopes, responsive overflow, and the boundary between Table and a future durable Data Table
- includes complete one-file framework source with no anatomy components or barrel files

## Verification

- `npm run build`
- focused Prettier check for every changed file
- `git diff --check`
- live VitePress browser verification of native table, caption, column-header, and row-header semantics
- verified the Preview/Source control exposes the Tailwind baseline