### PR TITLE
docs(klean-ui): add Avatar

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -114,6 +114,7 @@ function kleanUiGuide() {
       items: [
         { text: 'Overview', link: '/klean-ui/components/' },
         { text: 'Alert', link: '/klean-ui/components/alert' },
+        { text: 'Avatar', link: '/klean-ui/components/avatar' },
         { text: 'Badge', link: '/klean-ui/components/badge' },
         { text: 'Button', link: '/klean-ui/components/button' },
         { text: 'Card', link: '/klean-ui/components/card' },

--- a/docs/.vitepress/theme/components/klean/avatar/Avatar.vue
+++ b/docs/.vitepress/theme/components/klean/avatar/Avatar.vue
@@ -1,0 +1,106 @@
+<script setup>
+import { computed, ref, useAttrs, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  src: { type: String, default: '' },
+  alt: { type: String, required: true }
+})
+
+const attrs = useAttrs()
+const element = ref()
+const failed = ref(false)
+
+const BASE_CLASSES =
+  'inline-flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gray-100 object-cover text-sm font-medium text-gray-700 select-none dark:bg-gray-800 dark:text-gray-300'
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    onError: _onError,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const fallbackAttrs = computed(() => {
+  const {
+    loading: _loading,
+    decoding: _decoding,
+    crossorigin: _crossorigin,
+    referrerpolicy: _referrerpolicy,
+    fetchpriority: _fetchpriority,
+    sizes: _sizes,
+    srcset: _srcset,
+    usemap: _usemap,
+    ismap: _ismap,
+    onLoad: _onLoad,
+    ...rest
+  } = forwardedAttrs.value
+  return rest
+})
+
+const hasCallerFallbackSemantics = computed(() =>
+  ['role', 'aria-label', 'aria-hidden'].some((name) => name in attrs)
+)
+
+const fallbackSemantics = computed(() => {
+  if (hasCallerFallbackSemantics.value) return {}
+  if (props.alt) return { role: 'img', 'aria-label': props.alt }
+  return { 'aria-hidden': 'true' }
+})
+
+const finalFallbackAttrs = computed(() => ({
+  ...fallbackAttrs.value,
+  ...fallbackSemantics.value
+}))
+
+watch(
+  () => props.src,
+  () => {
+    failed.value = false
+  },
+  { flush: 'sync' }
+)
+
+function handleError(event) {
+  failed.value = true
+
+  const listener = attrs.onError
+  if (Array.isArray(listener)) {
+    for (const callback of listener) callback(event)
+  } else if (typeof listener === 'function') {
+    listener(event)
+  }
+}
+
+defineExpose({ element })
+</script>
+
+<template>
+  <img
+    v-if="props.src && !failed"
+    ref="element"
+    v-bind="forwardedAttrs"
+    data-slot="avatar"
+    data-state="image"
+    :src="props.src"
+    :alt="props.alt"
+    :class="twMerge(BASE_CLASSES, attrs.class)"
+    @error="handleError"
+  />
+  <span
+    v-else
+    ref="element"
+    v-bind="finalFallbackAttrs"
+    data-slot="avatar"
+    data-state="fallback"
+    :class="twMerge(BASE_CLASSES, attrs.class)"
+  >
+    <slot />
+  </span>
+</template>

--- a/docs/.vitepress/theme/components/klean/avatar/AvatarRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/avatar/AvatarRecipes.vue
@@ -1,0 +1,208 @@
+<script setup>
+import Avatar from './Avatar.vue'
+import Button from '../Button.vue'
+import Spinner from '../spinner/Spinner.vue'
+
+function portrait({ background, shirt, skin, hair, accent }) {
+  const source = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+    <rect width="160" height="160" fill="${background}"/>
+    <circle cx="80" cy="69" r="35" fill="${skin}"/>
+    <path d="M35 160c4-34 20-53 45-53s41 19 45 53" fill="${shirt}"/>
+    <path d="M47 66c0-31 15-47 34-47 24 0 36 17 34 49-8-3-15-9-20-18-13 12-28 18-48 16Z" fill="${hair}"/>
+    <circle cx="68" cy="72" r="3" fill="#111827"/>
+    <circle cx="93" cy="72" r="3" fill="#111827"/>
+    <path d="M70 89c8 6 16 6 23 0" fill="none" stroke="${accent}" stroke-width="3" stroke-linecap="round"/>
+  </svg>`
+
+  return `data:image/svg+xml,${encodeURIComponent(source)}`
+}
+
+const kelvin = portrait({
+  background: '#dbeafe',
+  shirt: '#172554',
+  skin: '#70412f',
+  hair: '#0a0a0a',
+  accent: '#4c291f'
+})
+
+const maya = portrait({
+  background: '#ede9fe',
+  shirt: '#4c1d95',
+  skin: '#c47e5e',
+  hair: '#292524',
+  accent: '#854d3a'
+})
+
+const comments = [
+  {
+    name: 'Kelvin Omereshone',
+    initials: 'KO',
+    src: kelvin,
+    message: 'The schedule is ready to send.'
+  },
+  {
+    name: 'Ada Okafor',
+    initials: 'AO',
+    src: '',
+    message: 'Perfect. I checked the invoice dates.'
+  }
+]
+
+const teams = [
+  { name: 'Slipway', initials: 'SW', src: kelvin },
+  { name: 'Sailscasts', initials: 'SC', src: '' },
+  { name: 'Boring Stack', initials: 'BS', src: maya }
+]
+</script>
+
+<template>
+  <div class="grid gap-8 lg:grid-cols-2">
+    <article class="space-y-3">
+      <p
+        class="m-0! font-mono text-[11px] uppercase tracking-[0.18em] text-gray-500"
+      >
+        Hagfish / invoice discussion
+      </p>
+      <div
+        class="border-2 border-black bg-[#f7f3eb] p-5 shadow-[6px_6px_0_0_#000] dark:border-white dark:bg-gray-950 dark:shadow-[6px_6px_0_0_#fff]"
+      >
+        <a
+          href="#avatar-products"
+          class="flex items-center gap-3 border-b-2 border-black pb-4 no-underline dark:border-white"
+        >
+          <span class="relative inline-flex">
+            <Avatar
+              :src="kelvin"
+              alt=""
+              class="size-11 rounded-lg bg-black font-mono text-white dark:bg-white dark:text-black"
+              >KO</Avatar
+            >
+            <span
+              class="absolute -right-1 -bottom-1 grid size-3 rounded-sm border-2 border-[#f7f3eb] bg-emerald-500 dark:border-gray-950"
+            >
+              <span class="sr-only">Online</span>
+            </span>
+          </span>
+          <span>
+            <strong class="block text-sm">Kelvin Omereshone</strong>
+            <span class="text-xs text-gray-600 dark:text-gray-300"
+              >Invoice creator</span
+            >
+          </span>
+          <span aria-hidden="true" class="ml-auto">↗</span>
+        </a>
+
+        <ol class="m-0! mt-5! list-none! space-y-5 p-0!">
+          <li
+            v-for="comment in comments"
+            :key="comment.name"
+            class="m-0! flex items-start gap-3"
+          >
+            <Avatar
+              :src="comment.src"
+              alt=""
+              :class="[
+                'size-7 text-[10px] font-bold text-white',
+                comment.src ? '' : 'bg-gray-900'
+              ]"
+              >{{ comment.initials }}</Avatar
+            >
+            <div class="min-w-0">
+              <p class="m-0! text-xs font-semibold">{{ comment.name }}</p>
+              <p
+                class="m-0! mt-1! text-sm leading-6 text-gray-700 dark:text-gray-300"
+              >
+                {{ comment.message }}
+              </p>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </article>
+
+    <article class="space-y-3">
+      <p
+        class="m-0! font-mono text-[11px] uppercase tracking-[0.18em] text-gray-500"
+      >
+        Slipway / team identity
+      </p>
+      <div
+        class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-950"
+      >
+        <Button
+          type="button"
+          class="flex min-h-0 w-full justify-start gap-3 rounded-none border-0 bg-gray-50 px-4 py-3 text-gray-950 shadow-none hover:bg-gray-100 active:bg-gray-100 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800 dark:active:bg-gray-800"
+        >
+          <Avatar :src="kelvin" alt="" class="size-7 rounded-md">SW</Avatar>
+          <span class="text-sm font-medium">Slipway</span>
+          <svg
+            aria-hidden="true"
+            class="ml-auto size-4 text-gray-400"
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+          >
+            <path
+              d="m6 8 4 4 4-4"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </Button>
+        <ul
+          class="m-0! list-none! border-t border-gray-200 p-1.5! dark:border-gray-800"
+        >
+          <li v-for="team in teams" :key="team.name" class="m-0!">
+            <button
+              type="button"
+              class="flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-900"
+            >
+              <Avatar
+                :src="team.src"
+                alt=""
+                class="size-6 rounded-md bg-gray-900 text-[10px] text-white dark:bg-gray-100 dark:text-gray-950"
+                >{{ team.initials }}</Avatar
+              >
+              <span class="flex-1">{{ team.name }}</span>
+              <span
+                v-if="team.name === 'Slipway'"
+                aria-label="Current team"
+                class="text-emerald-600"
+                >✓</span
+              >
+            </button>
+          </li>
+        </ul>
+        <div class="border-t border-gray-200 p-4 dark:border-gray-800">
+          <p class="m-0! text-xs font-medium text-gray-500 dark:text-gray-400">
+            Profile preview
+          </p>
+          <div class="mt-3 flex items-center gap-4">
+            <span class="relative inline-flex">
+              <Avatar
+                :src="maya"
+                alt="Boring Stack team logo"
+                class="size-16 rounded-xl"
+                >BS</Avatar
+              >
+              <span
+                role="status"
+                class="absolute inset-0 grid place-items-center rounded-xl bg-black/55"
+              >
+                <Spinner class="size-5 text-white" />
+                <span class="sr-only">Uploading team logo</span>
+              </span>
+            </span>
+            <div>
+              <p class="m-0! text-sm font-medium">Boring Stack</p>
+              <p class="m-0! mt-1! text-xs text-gray-500 dark:text-gray-400">
+                Uploading a new logo…
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  </div>
+</template>

--- a/docs/klean-ui/components/avatar.md
+++ b/docs/klean-ui/components/avatar.md
@@ -1,0 +1,248 @@
+---
+title: Avatar
+titleTemplate: Klean UI
+description: One resilient identity image with an accessible fallback, browser-native image behavior, and caller-owned Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanAvatar from '../../.vitepress/theme/components/klean/avatar/Avatar.vue'
+import AvatarRecipes from '../../.vitepress/theme/components/klean/avatar/AvatarRecipes.vue'
+import avatarSource from '../../.vitepress/theme/components/klean/avatar/Avatar.vue?raw'
+import reactSource from '../sources/avatar/Avatar.jsx?raw'
+import svelteSource from '../sources/avatar/Avatar.svelte?raw'
+import vueUsage from '../snippets/avatar/usage.vue?raw'
+import reactUsage from '../snippets/avatar/usage.jsx?raw'
+import svelteUsage from '../snippets/avatar/usage.svelte?raw'
+import compositionSource from '../snippets/avatar/composition.vue?raw'
+import productSource from '../snippets/avatar/products.vue?raw'
+
+const portraitMarkup = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <rect width="160" height="160" fill="#dbeafe"/>
+  <circle cx="80" cy="69" r="35" fill="#70412f"/>
+  <path d="M35 160c4-34 20-53 45-53s41 19 45 53" fill="#172554"/>
+  <path d="M47 66c0-31 15-47 34-47 24 0 36 17 34 49-8-3-15-9-20-18-13 12-28 18-48 16Z" fill="#0a0a0a"/>
+  <circle cx="68" cy="72" r="3" fill="#111827"/>
+  <circle cx="93" cy="72" r="3" fill="#111827"/>
+  <path d="M70 89c8 6 16 6 23 0" fill="none" stroke="#4c291f" stroke-width="3" stroke-linecap="round"/>
+</svg>`
+const portrait = `data:image/svg+xml,${encodeURIComponent(portraitMarkup)}`
+</script>
+
+# Avatar
+
+Avatar represents one person, team, or other application identity. Give it a source, an explicit accessible name, and fallback content. It uses the image when available and the fallback when the source is absent or fails.
+
+That is the whole contract. Size, shape, color, typography, borders, rings, presence, grouping, and upload state remain visible Tailwind and application markup.
+
+<KleanPreview id="avatar-source" :source="avatarSource" filename="Avatar.vue">
+  <template #preview>
+    <div class="flex flex-wrap items-center justify-center gap-6">
+      <KleanAvatar :src="portrait" alt="Kelvin Omereshone" class="size-16">KO</KleanAvatar>
+      <KleanAvatar src="" alt="Ada Okafor" class="size-16 bg-violet-100 text-violet-900 dark:bg-violet-950 dark:text-violet-200">
+        AO
+      </KleanAvatar>
+      <KleanAvatar src="/missing-avatar.webp" alt="Slipway team" class="size-16 rounded-xl bg-gray-950 font-mono text-white dark:bg-white dark:text-gray-950">
+        SW
+      </KleanAvatar>
+    </div>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/avatar/Avatar.vue
+
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and writes the matching one-file source into the conventional component directory:
+
+<KleanInstallation
+  id="avatar-installation"
+  component="avatar"
+  :source="avatarSource"
+  filename="Avatar.vue"
+  destination="assets/js/components/ui/avatar/Avatar.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+There is no initializer, provider, `klean-ui.json`, class helper, barrel file, Avatar anatomy package, image service, or runtime Klean dependency.
+
+## Usage
+
+The fallback is ordinary slot or child content. It is visible only when the source is absent or unavailable.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="CreatorLink.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="CreatorLink.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="CreatorLink.svelte" />
+
+## API
+
+| Input                          | Default  | Purpose                                                                                          |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------ |
+| `src`                          | `''`     | Native image source. An absent or unavailable source reveals the fallback.                       |
+| `alt`                          | required | Accessible name for standalone identity, or `''` when nearby visible text already names it.      |
+| default slot / children        | —        | Initials, an icon, or other compact fallback content owned by the application.                   |
+| `class` / `className`          | —        | Ordinary Tailwind merged after the neutral circular baseline.                                    |
+| native image/global attributes | —        | `loading`, `decoding`, `srcset`, `sizes`, IDs, titles, data hooks, and native image event hooks. |
+| element reference              | —        | Framework-native access to the current image or fallback element when genuinely needed.          |
+
+There is no `AvatarImage`, `AvatarFallback`, `AvatarBadge`, `AvatarGroup`, `as`, `variant`, `tone`, `color`, `size`, `shape`, `radius`, `status`, `presence`, or delay API.
+
+The slot already is the fallback. Tailwind already expresses the visuals. A Button, anchor, or framework Link already expresses interaction. Adding more parts would only rename those tools.
+
+## Accessible identity
+
+Use an informative `alt` when the Avatar stands alone:
+
+```vue
+<Avatar :src="creator.avatarUrl" :alt="creator.name">
+  {{ creator.initials }}
+</Avatar>
+```
+
+When visible text next to the Avatar already names the subject, use `alt=""` so the name is not announced twice:
+
+```vue
+<a href="/settings/profile" class="flex items-center gap-3">
+  <Avatar :src="creator.avatarUrl" alt="">{{ creator.initials }}</Avatar>
+  <span>{{ creator.name }}</span>
+</a>
+```
+
+The same `alt` decision applies after image failure. An informative fallback is announced as one image with that name; a decorative fallback stays out of the accessibility tree.
+
+Do not use initials as the accessible name when the complete name is known. “KO” is useful visually; “Kelvin Omereshone” is useful to a screen reader.
+
+## Interaction belongs outside
+
+Avatar is not clickable. Put it inside the semantic owner:
+
+- use a real anchor or Boring Stack Link for a profile or team destination;
+- use a real Button for an account menu or team switcher;
+- keep the Avatar decorative with `alt=""` when that control already has visible naming text;
+- give an icon-only parent control a complete `aria-label` that describes its action.
+
+This preserves URLs, modified clicks, keyboard activation, focus rings, disabled state, and browser history without teaching Avatar about routing or commands.
+
+## Styling with Tailwind
+
+The default is intentionally neutral: `size-10`, circular, monochrome fallback, and `object-cover`. Replace any of it directly:
+
+```vue
+<Avatar
+  :src="team.logoUrl"
+  :alt="team.name"
+  class="size-16 rounded-xl border border-gray-200 bg-white object-contain p-1"
+>
+  {{ team.initials }}
+</Avatar>
+```
+
+Small comment marks, square team logos, bordered profile images, and high-contrast Hagfish initials are class recipes—not component variants. If a recipe repeats throughout one application, keep a tiny application-owned wrapper or shared class next to that product.
+
+## Presence and progress are composition
+
+Presence and upload progress describe application state around identity. They do not change what Avatar is.
+
+<KleanPreview id="avatar-composition" :source="compositionSource" filename="AvatarUpload.vue">
+  <template #preview>
+    <span class="relative inline-flex">
+      <KleanAvatar :src="portrait" alt="Kelvin Omereshone" class="size-20 rounded-xl">KO</KleanAvatar>
+      <span class="absolute -right-1 -bottom-1 grid size-5 place-items-center rounded-full border-2 border-white bg-emerald-500 dark:border-gray-950">
+        <span class="sr-only">Online</span>
+      </span>
+    </span>
+  </template>
+</KleanPreview>
+
+Use visible text or screen-reader text to name a meaningful presence mark. During upload, the application owns a `role="status"` region and [Spinner](/klean-ui/components/spinner); Avatar continues to show the current server value or local preview.
+
+## Hagfish and Slipway recipes
+
+These examples come from the actual adoption seams. They prove that one primitive can preserve both products without acquiring either product's vocabulary.
+
+<KleanPreview id="avatar-products" :source="productSource" filename="ProductAvatars.vue">
+  <template #preview>
+    <AvatarRecipes />
+  </template>
+  <template #caption>
+    <span>Hagfish owns comment color, density, and creator presence. Slipway owns team switching and upload progress. Avatar owns only resilient identity.</span>
+  </template>
+</KleanPreview>
+
+Hagfish can replace its Volt Avatar, creator mark, and repeated comment fallback branches while retaining its deterministic color classes and neo-brutalist treatment. Slipway can replace repeated team image-or-initial branches while retaining its quiet sidebar, current-team logic, and profile upload overlay.
+
+## Accessibility
+
+- Always pass `alt`. Choose a complete informative name or the deliberately empty string based on surrounding visible text.
+- Keep Avatar static and out of the tab order. The surrounding button or link owns focus and interaction.
+- Do not encode presence, role, account state, or notification count through image color alone.
+- Keep fallback text legible at every caller-selected size and preserve contrast in light, dark, and forced-colors modes.
+- Give upload and async state its own visible or screen-reader status text; the image itself is not a live region.
+- Avoid repeating the same identity name in the image, adjacent text, and parent accessible label.
+
+## Durable behavior
+
+Identity comes from server data or application state. It is not copied into local storage or query parameters. The same `src`, `alt`, and fallback content therefore reproduce the same identity on reload, navigation, SSR, and another device.
+
+Image availability is ephemeral: if a source fails, Avatar shows the supplied fallback; if the application supplies a different source, Avatar tries it. That transient browser outcome is not persisted because it can change independently of the identity record.
+
+The surrounding control owns any durable concern:
+
+- profile and team destinations stay real URLs in anchors or Inertia Links;
+- current team and creator data stay server-owned;
+- upload progress, optimistic preview, retry, and rollback stay with the upload flow;
+- menu open state remains ephemeral in Menu or Popover;
+- presence comes from the application's realtime or server truth.
+
+## When to use
+
+Use Avatar for compact identity in account controls, team switchers, member lists, comments, activity feeds, assignment rows, profile previews, and other places where an image can degrade to a recognizable fallback.
+
+Use it when the source and fallback should occupy the same visual space and share caller-owned styling.
+
+## When not to use
+
+- Use a plain `img` for editorial images, invoice logos, screenshots, illustrations, or content whose intrinsic ratio matters.
+- Use [Badge](/klean-ui/components/badge) for status or compact metadata beside identity.
+- Use [Spinner](/klean-ui/components/spinner) and a real status region for upload or loading feedback.
+- Use [Button](/klean-ui/components/button), [Menu](/klean-ui/components/menu), or a real Link for interaction around an Avatar.
+- Keep initials generation, deterministic colors, image URL transformation, privacy rules, cropping, and storage in the application.
+- Do not use Avatar as a file upload, image editor, presence service, or account menu.
+
+## Complete framework source
+
+Copy, inspect, and change the complete one-file source for your framework.
+
+### Vue source
+
+<CopyCode :code="avatarSource" label="Avatar.vue" />
+
+### React source
+
+<CopyCode :code="reactSource" label="Avatar.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteSource" label="Avatar.svelte" />
+
+## Related components
+
+- [Button](/klean-ui/components/button) and [Menu](/klean-ui/components/menu) — own account and team-switcher interaction around identity.
+- [Badge](/klean-ui/components/badge) — adds visible role, status, or count metadata beside an Avatar without changing it.
+- [Spinner](/klean-ui/components/spinner) — supplies the decorative mark inside an app-owned upload status overlay.
+- [Card](/klean-ui/components/card) and [Table](/klean-ui/components/table) — provide richer member, team, comment, and activity layouts.
+- [Popover](/klean-ui/components/popover) and [Tooltip](/klean-ui/components/tooltip) — add supplementary floating content to the real parent control, never to Avatar itself.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -17,6 +17,10 @@ Components do not share a visual variant API. Each page shows the behavioral con
 
 A shallow notice surface with silent defaults, explicit announcement semantics, native headings and lists, real actions, and caller-owned Tailwind styling.
 
+### [Avatar](/klean-ui/components/avatar)
+
+One resilient identity image with an accessible fallback, explicit informative or decorative naming, browser-native image behavior, and caller-owned Tailwind styling.
+
 ### [Badge](/klean-ui/components/badge)
 
 One static inline metadata span for visible labels, counts, and compact statuses, with caller-owned Tailwind and truthful notification composition.

--- a/docs/klean-ui/snippets/avatar/composition.vue
+++ b/docs/klean-ui/snippets/avatar/composition.vue
@@ -1,0 +1,27 @@
+<script setup>
+import Avatar from '@/components/ui/avatar/Avatar.vue'
+import Spinner from '@/components/ui/spinner/Spinner.vue'
+
+defineProps({ creator: Object, uploading: Boolean })
+</script>
+
+<template>
+  <span class="relative inline-flex">
+    <Avatar
+      :src="creator.avatarUrl"
+      :alt="creator.name"
+      class="size-16 rounded-xl"
+    >
+      {{ creator.initials }}
+    </Avatar>
+
+    <span
+      v-if="uploading"
+      role="status"
+      class="absolute inset-0 grid place-items-center rounded-xl bg-black/55"
+    >
+      <Spinner class="size-5 text-white" />
+      <span class="sr-only">Uploading profile image</span>
+    </span>
+  </span>
+</template>

--- a/docs/klean-ui/snippets/avatar/products.vue
+++ b/docs/klean-ui/snippets/avatar/products.vue
@@ -1,0 +1,38 @@
+<script setup>
+import Avatar from '@/components/ui/avatar/Avatar.vue'
+
+defineProps({ creator: Object, comments: Array, teams: Array })
+</script>
+
+<template>
+  <!-- Hagfish keeps comment color and density in application classes. -->
+  <article v-for="comment in comments" :key="comment.id" class="flex gap-3">
+    <Avatar
+      :src="comment.avatarUrl"
+      alt=""
+      :class="['size-7 text-[10px] font-bold text-white', comment.avatarClass]"
+    >
+      {{ comment.initials }}
+    </Avatar>
+    <p>
+      <strong>{{ comment.authorName }}</strong> {{ comment.body }}
+    </p>
+  </article>
+
+  <!-- Slipway's real button owns team switching and its accessible name. -->
+  <button
+    v-for="team in teams"
+    :key="team.id"
+    type="button"
+    class="flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2"
+  >
+    <Avatar
+      :src="team.logoUrl"
+      alt=""
+      class="size-6 rounded-md bg-gray-900 text-[10px] text-white"
+    >
+      {{ team.initials }}
+    </Avatar>
+    <span>{{ team.name }}</span>
+  </button>
+</template>

--- a/docs/klean-ui/snippets/avatar/usage.jsx
+++ b/docs/klean-ui/snippets/avatar/usage.jsx
@@ -1,0 +1,12 @@
+import Avatar from '@/components/ui/avatar/Avatar.jsx'
+
+export default function CreatorLink({ creator }) {
+  return (
+    <a href="/settings/profile" className="flex items-center gap-3">
+      <Avatar src={creator.avatarUrl} alt="" className="size-10 rounded-lg">
+        {creator.initials}
+      </Avatar>
+      <span>{creator.name}</span>
+    </a>
+  )
+}

--- a/docs/klean-ui/snippets/avatar/usage.svelte
+++ b/docs/klean-ui/snippets/avatar/usage.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Avatar from '$lib/components/ui/avatar/Avatar.svelte'
+
+  let { creator } = $props()
+</script>
+
+<a href="/settings/profile" class="flex items-center gap-3">
+  <Avatar src={creator.avatarUrl} alt="" class="size-10 rounded-lg">
+    {creator.initials}
+  </Avatar>
+  <span>{creator.name}</span>
+</a>

--- a/docs/klean-ui/snippets/avatar/usage.vue
+++ b/docs/klean-ui/snippets/avatar/usage.vue
@@ -1,0 +1,14 @@
+<script setup>
+import Avatar from '@/components/ui/avatar/Avatar.vue'
+
+defineProps({ creator: Object })
+</script>
+
+<template>
+  <a href="/settings/profile" class="flex items-center gap-3">
+    <Avatar :src="creator.avatarUrl" alt="" class="size-10 rounded-lg">
+      {{ creator.initials }}
+    </Avatar>
+    <span>{{ creator.name }}</span>
+  </a>
+</template>

--- a/docs/klean-ui/sources/avatar/Avatar.jsx
+++ b/docs/klean-ui/sources/avatar/Avatar.jsx
@@ -1,0 +1,91 @@
+import { forwardRef, useEffect, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES =
+  'inline-flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gray-100 object-cover text-sm font-medium text-gray-700 select-none dark:bg-gray-800 dark:text-gray-300'
+
+const Avatar = forwardRef(function Avatar(
+  {
+    src = '',
+    alt,
+    children,
+    className,
+    onError,
+    onLoad,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    ...props
+  },
+  ref
+) {
+  const [failedSource, setFailedSource] = useState(null)
+  const showImage = Boolean(src) && failedSource !== src
+  const classes = twMerge(BASE_CLASSES, className)
+
+  useEffect(() => {
+    setFailedSource(null)
+  }, [src])
+
+  function handleError(event) {
+    setFailedSource(src)
+    onError?.(event)
+  }
+
+  function handleLoad(event) {
+    setFailedSource(null)
+    onLoad?.(event)
+  }
+
+  if (showImage) {
+    return (
+      <img
+        {...props}
+        ref={ref}
+        data-slot="avatar"
+        data-state="image"
+        src={src}
+        alt={alt}
+        className={classes}
+        onError={handleError}
+        onLoad={handleLoad}
+      />
+    )
+  }
+
+  const {
+    loading: _loading,
+    decoding: _decoding,
+    crossOrigin: _crossOrigin,
+    referrerPolicy: _referrerPolicy,
+    fetchPriority: _fetchPriority,
+    sizes: _sizes,
+    srcSet: _srcSet,
+    useMap: _useMap,
+    isMap: _isMap,
+    ...fallbackProps
+  } = props
+  const hasCallerFallbackSemantics =
+    props.role !== undefined ||
+    props['aria-label'] !== undefined ||
+    props['aria-hidden'] !== undefined
+  const fallbackSemantics = hasCallerFallbackSemantics
+    ? {}
+    : alt
+      ? { role: 'img', 'aria-label': alt }
+      : { 'aria-hidden': true }
+
+  return (
+    <span
+      {...fallbackProps}
+      {...fallbackSemantics}
+      ref={ref}
+      data-slot="avatar"
+      data-state="fallback"
+      className={classes}
+    >
+      {children}
+    </span>
+  )
+})
+
+export default Avatar

--- a/docs/klean-ui/sources/avatar/Avatar.svelte
+++ b/docs/klean-ui/sources/avatar/Avatar.svelte
@@ -1,0 +1,101 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES =
+    "inline-flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gray-100 object-cover text-sm font-medium text-gray-700 select-none dark:bg-gray-800 dark:text-gray-300";
+  const IMAGE_ONLY_ATTRIBUTES = new Set([
+    "loading",
+    "decoding",
+    "crossorigin",
+    "referrerpolicy",
+    "fetchpriority",
+    "sizes",
+    "srcset",
+    "usemap",
+    "ismap",
+  ]);
+
+  let {
+    src = "",
+    alt,
+    children,
+    class: className,
+    onerror,
+    onload,
+    "data-slot": _dataSlot,
+    "data-state": _dataState,
+    ...props
+  } = $props();
+
+  let element = $state();
+  let failedSource = $state(null);
+  let showImage = $derived(Boolean(src) && failedSource !== src);
+
+  $effect(() => {
+    src;
+    failedSource = null;
+  });
+
+  let fallbackProps = $derived.by(() =>
+    Object.fromEntries(
+      Object.entries(props).filter(
+        ([name]) => !IMAGE_ONLY_ATTRIBUTES.has(name),
+      ),
+    ),
+  );
+  let hasCallerFallbackSemantics = $derived(
+    props.role !== undefined ||
+      props["aria-label"] !== undefined ||
+      props["aria-hidden"] !== undefined,
+  );
+  let fallbackRole = $derived(
+    hasCallerFallbackSemantics ? props.role : alt ? "img" : undefined,
+  );
+  let fallbackLabel = $derived(
+    hasCallerFallbackSemantics ? props["aria-label"] : alt || undefined,
+  );
+  let fallbackHidden = $derived(
+    hasCallerFallbackSemantics ? props["aria-hidden"] : alt ? undefined : true,
+  );
+
+  function handleError(event) {
+    failedSource = src;
+    onerror?.(event);
+  }
+
+  function handleLoad(event) {
+    failedSource = null;
+    onload?.(event);
+  }
+
+  export function getElement() {
+    return element;
+  }
+</script>
+
+{#if showImage}
+  <img
+    {...props}
+    bind:this={element}
+    data-slot="avatar"
+    data-state="image"
+    {src}
+    {alt}
+    class={twMerge(BASE_CLASSES, className)}
+    onerror={handleError}
+    onload={handleLoad}
+  />
+{:else}
+  <span
+    {...fallbackProps}
+    bind:this={element}
+    data-slot="avatar"
+    data-state="fallback"
+    role={fallbackRole}
+    aria-label={fallbackLabel}
+    aria-hidden={fallbackHidden}
+    class={twMerge(BASE_CLASSES, className)}
+  >
+    {@render children?.()}
+  </span>
+{/if}


### PR DESCRIPTION
## Summary
- add the canonical Avatar component page and sidebar entry
- document the zero-configuration install and Vue, React, and Svelte APIs
- make source, usage, composition, Hagfish, and Slipway recipes copyable
- document accessible identity, Tailwind ownership, and Durable UI boundaries

## Verification
- VitePress build passes
- all changed files pass Prettier
- live docs render without console errors

Closes #205