### PR TITLE
docs: document Klean UI Separator

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -123,6 +123,7 @@ function kleanUiGuide() {
         { text: 'Checkbox', link: '/klean-ui/components/checkbox' },
         { text: 'Radio', link: '/klean-ui/components/radio' },
         { text: 'Switch', link: '/klean-ui/components/switch' },
+        { text: 'Separator', link: '/klean-ui/components/separator' },
         { text: 'Spinner', link: '/klean-ui/components/spinner' },
         { text: 'Tooltip', link: '/klean-ui/components/tooltip' },
         { text: 'Breadcrumb', link: '/klean-ui/components/breadcrumb' },

--- a/docs/.vitepress/theme/components/klean/separator/Separator.vue
+++ b/docs/.vitepress/theme/components/klean/separator/Separator.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  orientation: {
+    type: String,
+    default: 'horizontal',
+    validator: (value) => ['horizontal', 'vertical'].includes(value)
+  }
+})
+
+const attrs = useAttrs()
+const element = ref()
+const isVertical = computed(() => props.orientation === 'vertical')
+const baseClasses = computed(() =>
+  isVertical.value ? 'w-px self-stretch' : 'h-px w-full'
+)
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-orientation': _ariaOrientation,
+    'data-orientation': _dataOrientation,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <component
+    :is="isVertical ? 'div' : 'hr'"
+    ref="element"
+    v-bind="forwardedAttrs"
+    data-slot="separator"
+    :data-orientation="isVertical ? 'vertical' : 'horizontal'"
+    :role="isVertical ? 'separator' : undefined"
+    :aria-orientation="isVertical ? 'vertical' : undefined"
+    :class="
+      twMerge(
+        'shrink-0 border-0 bg-gray-200 forced-colors:bg-current dark:bg-gray-800',
+        baseClasses,
+        attrs.class
+      )
+    "
+  />
+</template>

--- a/docs/.vitepress/theme/components/klean/separator/SeparatorRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/separator/SeparatorRecipes.vue
@@ -1,0 +1,102 @@
+<script setup>
+import Separator from './Separator.vue'
+
+function keepPreview(event) {
+  event.preventDefault()
+}
+</script>
+
+<template>
+  <div class="grid w-full gap-8 xl:grid-cols-2">
+    <article class="space-y-3">
+      <p
+        class="m-0! font-mono text-[11px] text-gray-500 uppercase tracking-[0.18em]"
+      >
+        Hagfish / account menu
+      </p>
+      <div
+        class="border-2 border-black bg-white p-2 shadow-[6px_6px_0_0_#000] dark:border-white dark:bg-gray-950 dark:shadow-[6px_6px_0_0_#fff]"
+      >
+        <a
+          href="#profile"
+          class="block px-4 py-3 font-medium text-gray-950 no-underline dark:text-white"
+          @click="keepPreview"
+        >
+          Profile
+        </a>
+        <a
+          href="#billing"
+          class="block px-4 py-3 font-medium text-gray-950 no-underline dark:text-white"
+          @click="keepPreview"
+        >
+          Billing
+        </a>
+        <Separator
+          aria-hidden="true"
+          class="my-1 bg-black/10 dark:bg-white/10"
+        />
+        <button
+          type="button"
+          class="w-full cursor-pointer border-0 bg-transparent px-4 py-3 text-left font-medium text-red-700 dark:text-red-400"
+        >
+          Sign out
+        </button>
+      </div>
+    </article>
+
+    <article class="space-y-3">
+      <p
+        class="m-0! font-mono text-[11px] text-gray-500 uppercase tracking-[0.18em]"
+      >
+        Slipway / command surface
+      </p>
+      <div
+        class="overflow-hidden rounded-xl bg-white shadow-sm dark:bg-gray-950"
+      >
+        <div class="p-4">
+          <p class="m-0! text-sm font-medium">Deploy production</p>
+          <p class="m-0! mt-1! text-xs text-gray-500 dark:text-gray-400">
+            main · Lagos · 3 replicas
+          </p>
+        </div>
+        <Separator aria-hidden="true" class="bg-gray-100 dark:bg-gray-800" />
+        <footer
+          class="flex items-center justify-between gap-4 px-4 py-3 text-xs text-gray-500 dark:text-gray-400"
+        >
+          <span>Enter to deploy</span>
+          <span>Esc to close</span>
+        </footer>
+      </div>
+
+      <div
+        role="toolbar"
+        aria-label="Log actions"
+        class="mt-5 flex h-10 items-stretch rounded-lg bg-gray-100 p-1 dark:bg-gray-900"
+      >
+        <button
+          type="button"
+          class="cursor-pointer rounded-md border-0 bg-transparent px-3 text-sm hover:bg-white dark:hover:bg-gray-800"
+        >
+          Pause
+        </button>
+        <button
+          type="button"
+          class="cursor-pointer rounded-md border-0 bg-transparent px-3 text-sm hover:bg-white dark:hover:bg-gray-800"
+        >
+          Clear
+        </button>
+        <Separator
+          orientation="vertical"
+          aria-hidden="true"
+          class="mx-1 h-6 self-center bg-gray-300 dark:bg-gray-700"
+        />
+        <button
+          type="button"
+          class="cursor-pointer rounded-md border-0 bg-transparent px-3 text-sm hover:bg-white dark:hover:bg-gray-800"
+        >
+          Download
+        </button>
+      </div>
+    </article>
+  </div>
+</template>

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -53,6 +53,10 @@ A native-first mutually exclusive choice for short visible lists. Shared names, 
 
 A native-first boolean setting that takes effect immediately, with real checked state, browser keyboard and form behavior, honest optimistic rollback recipes, and caller-owned Tailwind styling.
 
+### [Separator](/klean-ui/components/separator)
+
+One native-first semantic boundary: a native horizontal rule, a correct vertical ARIA bridge, and caller-owned Tailwind for the rare places where spacing is not enough.
+
 ### [Spinner](/klean-ui/components/spinner)
 
 A calm decorative mark for indeterminate work, with caller-owned Tailwind styling and truthful busy and status semantics left in visible application markup.

--- a/docs/klean-ui/components/separator.md
+++ b/docs/klean-ui/components/separator.md
@@ -1,0 +1,230 @@
+---
+title: Separator
+titleTemplate: Klean UI
+description: One native-first semantic boundary with a native horizontal rule, a correct vertical ARIA bridge, and caller-owned Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanSeparator from '../../.vitepress/theme/components/klean/separator/Separator.vue'
+import SeparatorRecipes from '../../.vitepress/theme/components/klean/separator/SeparatorRecipes.vue'
+import separatorSource from '../../.vitepress/theme/components/klean/separator/Separator.vue?raw'
+import reactSource from '../sources/separator/Separator.jsx?raw'
+import svelteSource from '../sources/separator/Separator.svelte?raw'
+import vueUsage from '../snippets/separator/usage.vue?raw'
+import reactUsage from '../snippets/separator/usage.jsx?raw'
+import svelteUsage from '../snippets/separator/usage.svelte?raw'
+import verticalSource from '../snippets/separator/vertical.vue?raw'
+</script>
+
+# Separator
+
+Separator is one honest boundary for the rare places where spacing is not enough. It renders a native `hr` horizontally and supplies the semantics HTML does not have when the boundary is vertical.
+
+Use ordinary Tailwind for length, thickness, color, spacing, opacity, and responsive behavior. Separator has no visual variants and should not replace every border in an application.
+
+<KleanPreview id="separator-source" :source="separatorSource" filename="Separator.vue">
+  <template #preview>
+    <div class="w-full max-w-lg">
+      <section aria-labelledby="separator-profile-title">
+        <h2 id="separator-profile-title" class="m-0! text-lg font-semibold">Profile</h2>
+        <p class="m-0! mt-2! text-sm text-gray-600 dark:text-gray-300">Personal account details.</p>
+      </section>
+      <KleanSeparator class="my-8" />
+      <section aria-labelledby="separator-security-title">
+        <h2 id="separator-security-title" class="m-0! text-lg font-semibold">Security</h2>
+        <p class="m-0! mt-2! text-sm text-gray-600 dark:text-gray-300">Sign-in and recovery settings.</p>
+      </section>
+    </div>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/separator/Separator.vue
+
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and writes the matching one-file source into the conventional component directory:
+
+<KleanInstallation
+  id="separator-installation"
+  component="separator"
+  :source="separatorSource"
+  filename="Separator.vue"
+  destination="assets/js/components/ui/separator/Separator.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+There is no initializer, provider, `klean-ui.json`, class helper, barrel file, orientation package, or runtime Klean dependency.
+
+## Usage
+
+Use Separator between adjacent regions only when the boundary carries meaning that spacing alone does not communicate.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="AccountSettings.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="AccountSettings.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="AccountSettings.svelte" />
+
+## API
+
+| Input                 | Default      | Purpose                                                                                          |
+| --------------------- | ------------ | ------------------------------------------------------------------------------------------------ |
+| `orientation`         | `horizontal` | Semantic direction. Horizontal renders `hr`; vertical renders the correct ARIA separator bridge. |
+| `class` / `className` | —            | Ordinary Tailwind classes merged after the neutral monochrome baseline.                          |
+| native attributes     | —            | IDs, titles, `aria-hidden`, data attributes, test hooks, and other ordinary attributes.          |
+| element reference     | —            | Framework-native access to the actual `hr` or vertical separator when genuinely needed.          |
+
+There is no `variant`, `tone`, `color`, `size`, `thickness`, `length`, `decorative`, `inset`, or theme API. Those decisions are Tailwind classes or native attributes at the call site.
+
+`orientation` is not a visual variant. It determines which semantic element and accessibility attributes are correct.
+
+## Why this is a component
+
+A horizontal rule alone would not justify an abstraction: native `hr` already has implicit separator semantics and a horizontal orientation.
+
+The component earns its small API by safely joining two representations:
+
+```html
+<!-- Separator renders this horizontally -->
+<hr />
+
+<!-- Separator renders this vertically -->
+<div role="separator" aria-orientation="vertical"></div>
+```
+
+The vertical case is easy to make visually correct while forgetting `role="separator"` or `aria-orientation="vertical"`. Klean protects that semantic boundary consistently in Vue, React, and Svelte while still letting the browser own the horizontal case.
+
+## Horizontal and vertical boundaries
+
+The horizontal default is a real thematic break. Do not add a redundant explicit role or `aria-orientation` to it.
+
+Use `orientation="vertical"` only inside a layout with a real vertical boundary. The component changes to a `div`, owns `role="separator"`, and fixes `aria-orientation="vertical"` so caller attributes cannot accidentally contradict it.
+
+<KleanPreview id="separator-vertical" :source="verticalSource" filename="DocumentToolbar.vue">
+  <template #preview>
+    <div role="toolbar" aria-label="Document actions" class="flex h-10 items-stretch rounded-lg bg-gray-100 p-1 dark:bg-gray-900">
+      <button type="button" class="cursor-pointer rounded-md border-0 bg-transparent px-3 text-sm hover:bg-white dark:hover:bg-gray-800">Undo</button>
+      <button type="button" class="cursor-pointer rounded-md border-0 bg-transparent px-3 text-sm hover:bg-white dark:hover:bg-gray-800">Redo</button>
+      <KleanSeparator orientation="vertical" aria-hidden="true" class="mx-1 h-6 self-center bg-gray-300 dark:bg-gray-700" />
+      <button type="button" class="cursor-pointer rounded-md border-0 bg-transparent px-3 text-sm hover:bg-white dark:hover:bg-gray-800">Share</button>
+    </div>
+  </template>
+</KleanPreview>
+
+The example is decorative because the toolbar's buttons are already understandable without the line. A vertical separator that conveys a meaningful grouping can remain exposed to accessibility APIs by omitting `aria-hidden`.
+
+## Semantic or decorative
+
+Separator is semantic by default. Use it when the break helps describe a change in topic or grouping.
+
+When the line is visual reinforcement only, use the native attribute:
+
+```vue
+<Separator aria-hidden="true" class="my-4" />
+```
+
+Klean intentionally has no `decorative` prop. `aria-hidden` is already the platform vocabulary, remains visible in the markup, and works identically across the supported frameworks.
+
+Do not use `role="presentation"` to override Separator. The component protects its orientation semantics; use `aria-hidden="true"` when the entire line should leave the accessibility tree.
+
+## Styling with Tailwind
+
+The neutral baseline is one monochrome pixel. Caller classes merge after it and can replace every visual decision:
+
+```vue
+<Separator class="my-8 h-0.5 bg-black dark:bg-white" />
+
+<Separator
+  orientation="vertical"
+  class="mx-3 h-8 w-0.5 self-center bg-emerald-500"
+/>
+```
+
+Repeated application treatments can become an application-owned wrapper or shared class recipe. They do not become Klean variants.
+
+## Hagfish and Slipway recipes
+
+Hagfish can replace its PrimeVue-backed Divider with native Klean source and preserve its expressive contrast. Slipway can keep compact command and operational boundaries. Most existing borders in both applications should remain ordinary Tailwind markup.
+
+<KleanPreview id="separator-products" :source="separatorSource" filename="Separator.vue">
+  <template #preview>
+    <SeparatorRecipes />
+  </template>
+  <template #caption>
+    <span>The same semantic seam accepts both product voices. The account and command layouts remain application markup.</span>
+  </template>
+</KleanPreview>
+
+The component is not a migration target for every `border-t`, `border-b`, `divide-y`, table row, field underline, card edge, or Tabs indicator. Those lines belong to the element whose shape they describe.
+
+## Accessibility
+
+- Prefer native HTML. Horizontal Separator is an `hr` and keeps its implicit separator role.
+- Do not redundantly add `role="separator"` or `aria-orientation="horizontal"` to the native `hr`.
+- Vertical Separator renders `role="separator"` with `aria-orientation="vertical"` because HTML has no native vertical rule.
+- Add `aria-hidden="true"` only when the boundary is entirely decorative.
+- Do not put Separator in the tab order. A static separator is not a resizer, slider, or other control.
+- Do not rely on the line alone to label regions. Keep real headings, landmarks, lists, fieldsets, and other document structure.
+- Caller colors should remain visible in light, dark, and forced-colors modes.
+
+## Durable behavior
+
+Separator owns no client state and needs none. It has no mount-time state, storage, URL parameter, event listener, animation, focus work, or cleanup lifecycle.
+
+Its durability is structural: server rendering and hydration produce the same native element and orientation semantics. State belongs to the surrounding Tabs, Menu, toolbar, page region, or application feature—not to the line between them.
+
+## When to use
+
+Use Separator for:
+
+- a real thematic change between adjacent content regions;
+- a dense menu or command surface where a visual group boundary remains useful;
+- a vertical boundary whose ARIA orientation should not be reimplemented at every call site;
+- removing a styled-divider dependency while preserving correct semantics and caller-owned design.
+
+## When not to use
+
+- Prefer spacing when proximity already makes the groups clear.
+- Use a background change when large page regions need stronger visual separation.
+- Keep ordinary borders on headers, footers, cards, inputs, tables, and rows when the line describes that element's edge.
+- Keep `divide-y` on dense lists or table bodies when it is the clearest row treatment.
+- Use [Tabs](/klean-ui/components/tabs) for peer views; its active indicator is not a Separator.
+- Use [Menu](/klean-ui/components/menu) for actions and destinations; Separator adds no menu behavior.
+- Do not use Separator as a draggable pane resizer or slider. Those are interactive controls with different keyboard and value semantics.
+
+## Complete framework source
+
+Copy, inspect, and change the complete one-file source for your framework.
+
+### Vue source
+
+<CopyCode :code="separatorSource" label="Separator.vue" />
+
+### React source
+
+<CopyCode :code="reactSource" label="Separator.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteSource" label="Separator.svelte" />
+
+## Related components
+
+- [Menu](/klean-ui/components/menu) and [Command](/klean-ui/components/command) — may contain rare visual group boundaries while retaining their own keyboard behavior.
+- [Tabs](/klean-ui/components/tabs) — owns peer navigation and active indication rather than composing those from separators.
+- [Card](/klean-ui/components/card) — provides a surface boundary when a line alone is not enough.
+- [Table](/klean-ui/components/table) — preserves dense row and column relationships where native borders and divisions remain appropriate.
+- [Breadcrumb](/klean-ui/components/breadcrumb) — uses its own presentational path markers; those are not thematic separators.

--- a/docs/klean-ui/snippets/separator/usage.jsx
+++ b/docs/klean-ui/snippets/separator/usage.jsx
@@ -1,0 +1,19 @@
+import Separator from '@/components/ui/separator/Separator.jsx'
+
+export default function AccountSettings() {
+  return (
+    <article>
+      <section aria-labelledby="profile-title">
+        <h2 id="profile-title">Profile</h2>
+        <p>Personal account details.</p>
+      </section>
+
+      <Separator className="my-8" />
+
+      <section aria-labelledby="security-title">
+        <h2 id="security-title">Security</h2>
+        <p>Sign-in and recovery settings.</p>
+      </section>
+    </article>
+  )
+}

--- a/docs/klean-ui/snippets/separator/usage.svelte
+++ b/docs/klean-ui/snippets/separator/usage.svelte
@@ -1,0 +1,17 @@
+<script>
+  import Separator from '$lib/components/ui/separator/Separator.svelte'
+</script>
+
+<article>
+  <section aria-labelledby="profile-title">
+    <h2 id="profile-title">Profile</h2>
+    <p>Personal account details.</p>
+  </section>
+
+  <Separator class="my-8" />
+
+  <section aria-labelledby="security-title">
+    <h2 id="security-title">Security</h2>
+    <p>Sign-in and recovery settings.</p>
+  </section>
+</article>

--- a/docs/klean-ui/snippets/separator/usage.vue
+++ b/docs/klean-ui/snippets/separator/usage.vue
@@ -1,0 +1,19 @@
+<script setup>
+import Separator from '@/components/ui/separator/Separator.vue'
+</script>
+
+<template>
+  <article>
+    <section aria-labelledby="profile-title">
+      <h2 id="profile-title">Profile</h2>
+      <p>Personal account details.</p>
+    </section>
+
+    <Separator class="my-8" />
+
+    <section aria-labelledby="security-title">
+      <h2 id="security-title">Security</h2>
+      <p>Sign-in and recovery settings.</p>
+    </section>
+  </article>
+</template>

--- a/docs/klean-ui/snippets/separator/vertical.vue
+++ b/docs/klean-ui/snippets/separator/vertical.vue
@@ -1,0 +1,20 @@
+<script setup>
+import Separator from '@/components/ui/separator/Separator.vue'
+</script>
+
+<template>
+  <div
+    role="toolbar"
+    aria-label="Document actions"
+    class="flex h-10 items-stretch"
+  >
+    <button type="button">Undo</button>
+    <button type="button">Redo</button>
+    <Separator
+      orientation="vertical"
+      aria-hidden="true"
+      class="mx-2 h-6 self-center bg-gray-300 dark:bg-gray-700"
+    />
+    <button type="button">Share</button>
+  </div>
+</template>

--- a/docs/klean-ui/sources/separator/Separator.jsx
+++ b/docs/klean-ui/sources/separator/Separator.jsx
@@ -1,0 +1,39 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES =
+  'shrink-0 border-0 bg-gray-200 forced-colors:bg-current dark:bg-gray-800'
+
+const Separator = forwardRef(function Separator(
+  {
+    orientation = 'horizontal',
+    className,
+    role: _role,
+    'aria-orientation': _ariaOrientation,
+    'data-orientation': _dataOrientation,
+    'data-slot': _dataSlot,
+    ...props
+  },
+  ref
+) {
+  const isVertical = orientation === 'vertical'
+  const Component = isVertical ? 'div' : 'hr'
+
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      data-slot="separator"
+      data-orientation={isVertical ? 'vertical' : 'horizontal'}
+      role={isVertical ? 'separator' : undefined}
+      aria-orientation={isVertical ? 'vertical' : undefined}
+      className={twMerge(
+        BASE_CLASSES,
+        isVertical ? 'w-px self-stretch' : 'h-px w-full',
+        className
+      )}
+    />
+  )
+})
+
+export default Separator

--- a/docs/klean-ui/sources/separator/Separator.svelte
+++ b/docs/klean-ui/sources/separator/Separator.svelte
@@ -1,0 +1,42 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES =
+    "shrink-0 border-0 bg-gray-200 forced-colors:bg-current dark:bg-gray-800";
+
+  let {
+    orientation = "horizontal",
+    class: className,
+    role: _role,
+    "aria-orientation": _ariaOrientation,
+    "data-orientation": _dataOrientation,
+    "data-slot": _dataSlot,
+    ...props
+  } = $props();
+
+  let element = $state();
+
+  export function getElement() {
+    return element;
+  }
+</script>
+
+{#if orientation === "vertical"}
+  <div
+    {...props}
+    bind:this={element}
+    data-slot="separator"
+    data-orientation="vertical"
+    role="separator"
+    aria-orientation="vertical"
+    class={twMerge(BASE_CLASSES, "w-px self-stretch", className)}
+  ></div>
+{:else}
+  <hr
+    {...props}
+    bind:this={element}
+    data-slot="separator"
+    data-orientation="horizontal"
+    class={twMerge(BASE_CLASSES, "h-px w-full", className)}
+  />
+{/if}


### PR DESCRIPTION
## Summary

- add the canonical Klean UI Separator page with a live native-horizontal preview and correct vertical ARIA example
- document exactly why the component earns its existence without turning ordinary borders into component bureaucracy
- document semantic versus decorative use, spacing-first guidance, caller-owned Tailwind, Durable UI boundaries, and related components
- add copyable Vue, React, and Svelte usage plus complete framework source
- add Hagfish and Slipway recipes, zero-configuration installation, the component index entry, and sidebar navigation

## Verification

- `npm run build`
- Prettier check passes for every changed file
- `git diff --check`

Implementation: https://github.com/sailscastshq/klean-ui/pull/97

Closes #207
