### PR TITLE
docs: add Hagfish product and API documentation

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -33,6 +33,7 @@ export default {
     search: { provider: 'local' },
     nav: nav(),
     sidebar: {
+      '/hagfish/': hagfishApiGuide(),
       '/slipway/': slipwayGuide(),
       '/captain-vane/': captainVaneGuide(),
       '/sounding/': soundingGuide(),
@@ -78,6 +79,33 @@ export default {
       copyright: 'Copyright © 2022-present The Sailscasts Company'
     }
   }
+}
+
+function hagfishApiGuide() {
+  return [
+    {
+      text: 'Hagfish API',
+      collapsed: false,
+      items: [
+        { text: 'Overview', link: '/hagfish/api/' },
+        { text: 'Getting started', link: '/hagfish/api/getting-started' },
+        {
+          text: 'Authentication and idempotency',
+          link: '/hagfish/api/authentication'
+        },
+        { text: 'Clients and invoices', link: '/hagfish/api/resources' },
+        {
+          text: 'Deliveries and billing',
+          link: '/hagfish/api/deliveries-and-billing'
+        },
+        { text: 'Webhooks', link: '/hagfish/api/webhooks' },
+        {
+          text: 'Errors and local testing',
+          link: '/hagfish/api/errors-and-local-testing'
+        }
+      ]
+    }
+  ]
 }
 
 function nav() {

--- a/docs/.vitepress/data/projects.data.js
+++ b/docs/.vitepress/data/projects.data.js
@@ -179,9 +179,8 @@ export default {
         {
           name: 'Hagfish',
           description:
-            'Hagfish helps professional creators send beautiful invoices, track expenses, and get paid faster.',
-          link: 'https://hagfish.app',
-          external: true
+            'Professional invoicing for creators, with an API and signed webhooks for products, automations, and agents.',
+          link: '/hagfish/'
         },
         {
           name: 'The African Engineer',

--- a/docs/commercial.md
+++ b/docs/commercial.md
@@ -9,6 +9,17 @@ layout: page
 import { data } from './.vitepress/data/projects.data.js'
 </script>
 
+# Commercial products
+
+## Hagfish: invoice the work, wherever it happens
+
+Hagfish gives professional creators a polished invoicing workspace and gives
+products, automations, and agents a reliable invoice transaction layer. Use the
+web app directly or create clients, invoices, deliveries, and signed webhook
+subscriptions through the same underlying system.
+
+[Explore Hagfish](/hagfish/) · [Use Hagfish](https://hagfish.app) · [Read the API docs](/hagfish/api/)
+
 <ProjectGrid
   :projects="data.commercial"
   type="commercial"

--- a/docs/hagfish/api/authentication.md
+++ b/docs/hagfish/api/authentication.md
@@ -1,0 +1,58 @@
+---
+title: Authentication and idempotency
+titleTemplate: Hagfish API
+description: Secure Hagfish API keys and make safe retryable mutations.
+prev: /hagfish/api/getting-started
+next: /hagfish/api/resources
+---
+
+# Authentication and idempotency
+
+## Bearer API keys
+
+Send a Hagfish API key in the `Authorization` header:
+
+```http
+Authorization: Bearer hf_live_...
+```
+
+API keys are server credentials. Do not embed them in browser JavaScript,
+mobile apps, Telegram clients, or repositories. Store them in a secret manager
+or encrypted environment variable and create a separate key per integration
+and environment.
+
+Available scopes are:
+
+- `clients:read` and `clients:write`
+- `invoices:read`, `invoices:write`, and `invoices:send`
+- `webhooks:read` and `webhooks:write`
+
+Use `GET /creator` to inspect the active key and its scopes. Revoking a key in
+Hagfish takes effect immediately.
+
+## Idempotency
+
+Every POST and PATCH request requires an `Idempotency-Key` header. Generate the
+key once for a logical operation and retain it when retrying that same request.
+
+```http
+Idempotency-Key: order_874_invoice_create
+```
+
+Hagfish retains the result for 24 hours:
+
+- Same key and same JSON body: the original status and response are replayed,
+  with `Idempotent-Replayed: true`.
+- Same key and different body: `409 idempotency_key_reused`.
+- A concurrent call while the first is processing: `409 request_in_progress`.
+
+Do not generate a fresh key merely because a request timed out; doing so turns
+a retry into a second operation.
+
+## Request IDs and rate limits
+
+Every response includes `X-Request-Id`, and JSON responses include
+`request_id`. Retain it in logs and support reports. API keys are currently
+limited to 600 requests per minute, with invoice delivery creation limited to
+60 per minute. Creator-wide limits prevent multiple keys from bypassing the
+guard. A `429` response includes `Retry-After`.

--- a/docs/hagfish/api/deliveries-and-billing.md
+++ b/docs/hagfish/api/deliveries-and-billing.md
@@ -1,0 +1,48 @@
+---
+title: Deliveries and billing
+titleTemplate: Hagfish API
+description: Understand asynchronous invoice delivery and atomic Hagfish billing.
+prev: /hagfish/api/resources
+next: /hagfish/api/webhooks
+---
+
+# Deliveries and billing
+
+Create a delivery with:
+
+```http
+POST /invoices/{id}/deliveries
+```
+
+An empty JSON body sends to the invoice's saved recipient immediately. Supply
+`recipient_emails` to override the recipients or an ISO 8601 `send_at` to
+schedule it.
+
+The `202 Accepted` response is an `invoice_delivery` resource containing its
+status, scheduled time, billing reservation, and invoice snapshot. It does not
+mean the email has already reached the recipient; use webhooks for the outcome.
+
+## Atomic entitlement checks
+
+The API and Hagfish web app use exactly the same billing helper. Creating a
+delivery atomically reserves, in order:
+
+1. Available quota from an active plan.
+2. An unlimited-plan entitlement, when applicable.
+3. The configured send-invoice credit cost.
+
+If none is available, Hagfish returns `402 billing_required` and leaves the
+invoice, quota, and credit ledger unchanged. Retrying with the same
+`Idempotency-Key` cannot reserve twice.
+
+A successful send consumes the reservation. If Hagfish exhausts its email
+attempts without completing delivery, it releases the reservation exactly once
+and emits `invoice.delivery.failed`.
+
+## PDF-only exports
+
+The first-paid-export idea is not part of API v1 yet. Its safe billing unit is a
+generated PDF artifact for one invoice content version: charge once when the
+artifact is first generated, allow repeat downloads of that immutable artifact,
+and create a new billable artifact only after invoice content changes. HTTP
+socket completion alone cannot prove that a person received a download.

--- a/docs/hagfish/api/errors-and-local-testing.md
+++ b/docs/hagfish/api/errors-and-local-testing.md
@@ -1,0 +1,76 @@
+---
+title: Errors and local testing
+titleTemplate: Hagfish API
+description: Handle Hagfish API problems and test the full integration locally.
+prev: /hagfish/api/webhooks
+---
+
+# Errors and local testing
+
+## Problem responses
+
+Hagfish uses RFC 9457 problem details:
+
+```json
+{
+  "type": "https://hagfish.app/problems/validation_failed",
+  "title": "Validation failed",
+  "status": 422,
+  "code": "validation_failed",
+  "detail": "The client_id field is required.",
+  "instance": "/api/v1/invoices",
+  "request_id": "...",
+  "errors": [{ "field": "client_id", "message": "is invalid" }]
+}
+```
+
+Common statuses are `401` for a missing/invalid key, `403` for a missing scope,
+`402` for insufficient billing entitlement, `404` for an absent or foreign
+resource, `409` for state/idempotency conflicts, `422` for invalid input, and
+`429` for rate limiting.
+
+## Run Hagfish locally
+
+```sh
+npm install
+npm run dev
+```
+
+Sign in at `http://localhost:1337`, open `/developers`, create a key, and call:
+
+```sh
+curl http://localhost:1337/api/v1/creator \
+  -H "Authorization: Bearer $HAGFISH_API_KEY"
+```
+
+The local OpenAPI document is at
+`http://localhost:1337/api/openapi.json`.
+
+## Test webhooks locally
+
+Run Hagfish's included loopback receiver in another terminal:
+
+```sh
+npm run dev:webhook-receiver
+```
+
+Register `http://127.0.0.1:4040` as an endpoint. Plain HTTP loopback
+destinations are enabled only in development/test; other private networks stay
+blocked. Restart it with the endpoint secret to verify signatures:
+
+```sh
+HAGFISH_WEBHOOK_SECRET=whsec_REPLACE_ME npm run dev:webhook-receiver
+```
+
+Queue a test event, watch the verified payload, then inspect it through
+`GET /webhook-deliveries`.
+
+## Run the integration suite
+
+```sh
+npm run test:api
+```
+
+It covers scopes, idempotency, tenant isolation, exact invoice totals, credit
+reservation, insufficient entitlement, outbound signatures, retries, rotation,
+and SSRF protection.

--- a/docs/hagfish/api/getting-started.md
+++ b/docs/hagfish/api/getting-started.md
@@ -1,0 +1,86 @@
+---
+title: Getting started
+titleTemplate: Hagfish API
+description: Create and deliver your first invoice through Hagfish.
+prev: /hagfish/api/
+next: /hagfish/api/authentication
+---
+
+# Getting started
+
+Create an API key from **Developers** in Hagfish. Choose only the scopes your
+integration needs and copy the token immediately; Hagfish stores its digest and
+cannot show the full token again.
+
+Set the token in your server environment:
+
+```sh
+export HAGFISH_API_KEY=hf_live_REPLACE_ME
+```
+
+## Confirm the identity and entitlement
+
+```sh
+curl https://hagfish.app/api/v1/creator \
+  -H "Authorization: Bearer $HAGFISH_API_KEY"
+```
+
+`GET /creator` returns the authenticated creator, the current plan/credit
+entitlement, and the scopes granted to this key.
+
+## Create a client
+
+```sh
+curl https://hagfish.app/api/v1/clients \
+  -X POST \
+  -H "Authorization: Bearer $HAGFISH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: client-acme-2026-08-19" \
+  -d '{
+    "name": "Acme Research",
+    "email": "billing@acme.example",
+    "address": "100 Market Street",
+    "city_state_postal": "San Francisco, CA 94105",
+    "country": "United States"
+  }'
+```
+
+Save the returned client `id`.
+
+## Create an invoice draft
+
+```sh
+curl https://hagfish.app/api/v1/invoices \
+  -X POST \
+  -H "Authorization: Bearer $HAGFISH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: invoice-acme-august-2026" \
+  -d '{
+    "client_id": "CLIENT_ID",
+    "invoice_number": "ACME-2026-08",
+    "currency": "USD",
+    "items": [
+      {"description": "Research sprint", "quantity": 2, "unit_price": "750.00"}
+    ],
+    "vat_rate": "0",
+    "notes": "Thank you for your business."
+  }'
+```
+
+Hagfish calculates line totals, subtotal, discount, VAT, WHT, and the final
+total. Never send a client-calculated total.
+
+## Deliver it
+
+```sh
+curl https://hagfish.app/api/v1/invoices/INVOICE_ID/deliveries \
+  -X POST \
+  -H "Authorization: Bearer $HAGFISH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: deliver-acme-august-2026" \
+  -d '{}'
+```
+
+A `202` response means Hagfish atomically reserved the applicable plan quota or
+credits and accepted the delivery. Register a webhook to receive the final
+`invoice.sent` or `invoice.delivery.failed` event.

--- a/docs/hagfish/api/index.md
+++ b/docs/hagfish/api/index.md
@@ -1,0 +1,50 @@
+---
+title: Hagfish API
+titleTemplate: Hagfish
+description: Build invoice workflows with the Hagfish REST API and signed webhooks.
+next:
+  text: Getting started
+  link: /hagfish/api/getting-started
+---
+
+# Hagfish API
+
+Hagfish is an invoice transaction layer for products, automations, and agents.
+Create a client, create an invoice, and ask Hagfish to deliver it without
+reimplementing invoice math, billing entitlement, PDF generation, or email.
+
+The same versioned resources are intended for ordinary backends today and for
+Telegram, WhatsApp, banking, and agent integrations later.
+
+## Base URL
+
+```text
+https://hagfish.app/api/v1
+```
+
+The [OpenAPI 3.1 document](https://hagfish.app/api/openapi.json) is the
+machine-readable reference for clients and tools.
+
+## Core workflow
+
+1. Create a scoped API key in Hagfish under **Developers**.
+2. `POST /clients` to save the payer.
+3. `POST /invoices` to create a draft with Hagfish-calculated totals.
+4. `POST /invoices/{id}/deliveries` to schedule or send it.
+5. Subscribe to signed webhooks such as `invoice.sent`.
+
+Every POST or PATCH uses `Idempotency-Key`, so a network retry cannot create a
+second resource or billing reservation.
+
+## Conventions
+
+- Requests and responses use JSON with `snake_case` fields.
+- Resource IDs are opaque strings. Store them; do not parse them.
+- Monetary amounts in responses are decimal strings in the invoice's major
+  currency unit.
+- Lists use cursor pagination with `limit` and `after`.
+- Errors use `application/problem+json` and include a `request_id`.
+- Invoice deliveries return `202 Accepted` because sending is asynchronous.
+
+Continue to [Getting started](/hagfish/api/getting-started) for a complete first
+invoice.

--- a/docs/hagfish/api/resources.md
+++ b/docs/hagfish/api/resources.md
@@ -1,0 +1,54 @@
+---
+title: Clients and invoices
+titleTemplate: Hagfish API
+description: Work with client and invoice resources through Hagfish.
+prev: /hagfish/api/authentication
+next: /hagfish/api/deliveries-and-billing
+---
+
+# Clients and invoices
+
+## Clients
+
+| Method  | Resource        | Purpose                 |
+| ------- | --------------- | ----------------------- |
+| `GET`   | `/clients`      | List and search clients |
+| `POST`  | `/clients`      | Create a client         |
+| `GET`   | `/clients/{id}` | Retrieve a client       |
+| `PATCH` | `/clients/{id}` | Update supplied fields  |
+
+Client and invoice IDs are tenant-bound. Hagfish returns `404` when the ID does
+not belong to the authenticated creator, rather than revealing another
+creator's resource.
+
+Lists accept `limit` from 1 to 100. Pass the previous response's
+`meta.next_cursor` as `after` until `meta.has_more` is false.
+
+## Invoice drafts
+
+| Method  | Resource         | Purpose                                   |
+| ------- | ---------------- | ----------------------------------------- |
+| `GET`   | `/invoices`      | List invoices; filter by status or client |
+| `POST`  | `/invoices`      | Create a draft                            |
+| `GET`   | `/invoices/{id}` | Retrieve an invoice                       |
+| `PATCH` | `/invoices/{id}` | Update a draft or failed invoice          |
+
+`client_id` is required when creating a draft. `issue_date` defaults to today,
+`due_date` defaults to 14 days later, and `currency` defaults to `USD`.
+
+Line-item `unit_price` values use the currency's major unit. Hagfish uses fixed
+point arithmetic internally and returns values such as `"1500.00"`. It
+calculates, in order:
+
+1. Line totals and subtotal.
+2. Percentage discount.
+3. VAT added to the discounted subtotal.
+4. WHT deducted when enabled.
+
+Invoice mutation supports `USD` and other valid ISO 4217 currencies, including
+currencies with zero fraction digits. The OpenAPI document is the full field
+and validation reference.
+
+Invoices created through the API have `created_via: "api"`. Future Telegram,
+WhatsApp, banking, and MCP adapters will use the same helper and identify their
+own source without changing the resource contract.

--- a/docs/hagfish/api/webhooks.md
+++ b/docs/hagfish/api/webhooks.md
@@ -1,0 +1,68 @@
+---
+title: Webhooks
+titleTemplate: Hagfish API
+description: Register, verify, rotate, inspect, and replay Hagfish webhooks.
+prev: /hagfish/api/deliveries-and-billing
+next: /hagfish/api/errors-and-local-testing
+---
+
+# Webhooks
+
+Hagfish operates its own outbound webhook server. Domain changes write an event
+and delivery record in the same database transaction; a separate worker signs
+and delivers it afterward. A slow or failing customer endpoint never blocks an
+invoice or billing transaction.
+
+## Endpoint resources
+
+| Method                     | Resource                                   | Purpose                    |
+| -------------------------- | ------------------------------------------ | -------------------------- |
+| `GET` / `POST`             | `/webhook-endpoints`                       | List or register endpoints |
+| `GET` / `PATCH` / `DELETE` | `/webhook-endpoints/{id}`                  | Manage one endpoint        |
+| `POST`                     | `/webhook-endpoints/{id}/secret-rotations` | Rotate its secret          |
+| `POST`                     | `/webhook-endpoints/{id}/test-events`      | Queue a signed test        |
+| `GET`                      | `/webhook-deliveries`                      | Inspect delivery history   |
+| `POST`                     | `/webhook-deliveries/{id}/replays`         | Replay an event            |
+
+Registration returns a `whsec_...` signing secret once. Production endpoints
+must use HTTPS and resolve only to public addresses. Hagfish re-resolves and
+pins the validated address for each attempt, does not follow redirects, and
+blocks internal/private destinations to prevent SSRF.
+
+## Events
+
+- `client.created` and `client.updated`
+- `invoice.created` and `invoice.updated`
+- `invoice.delivery.scheduled`
+- `invoice.sent`
+- `invoice.delivery.failed`
+- `webhook.test`
+
+Events are deliberately thin. Read the current resource through the API after
+receiving its ID.
+
+## Verify a delivery
+
+Hagfish implements the Standard Webhooks signature format and sends:
+
+```text
+webhook-id: evt_...
+webhook-timestamp: 1787097600
+webhook-signature: v1,BASE64_SIGNATURE
+```
+
+Using the exact raw request bytes, compute HMAC-SHA256 over:
+
+```text
+webhook-id.webhook-timestamp.raw-json-body
+```
+
+Decode the base64 part after `whsec_` as the HMAC key, compare signatures in
+constant time, reject timestamps more than five minutes old, and deduplicate on
+`webhook-id`. During the 24-hour rotation window the signature header contains
+two space-separated `v1,...` signatures; accept either current secret.
+
+Return any `2xx` promptly. Redirects are failures. `410 Gone` disables the
+endpoint. Other failures retry over roughly three days using the Standard
+Webhooks schedule, and `Retry-After` is honored within the retry cap. Exhausted
+deliveries remain visible and can be replayed after the endpoint is fixed.

--- a/docs/hagfish/index.md
+++ b/docs/hagfish/index.md
@@ -1,0 +1,69 @@
+---
+layout: home
+title: Hagfish
+titleTemplate: Sailscasts
+description: Professional invoicing for creators, with an API for products, automations, and agents.
+sidebar: false
+hero:
+  name: Hagfish
+  text: The invoice transaction layer for modern work.
+  tagline: Create polished invoices, track the business around them, and let your software handle the repetitive parts.
+  actions:
+    - theme: brand
+      text: Use Hagfish
+      link: https://hagfish.app
+    - theme: alt
+      text: Build with the API
+      link: /hagfish/api/
+features:
+  - icon: ✦
+    title: Invoice beautifully
+    details: Create professional invoices in global currencies, apply discounts, VAT, and withholding tax, then schedule or send them.
+  - icon: ◫
+    title: Know the business
+    details: Keep clients, expenses, payment information, recurring work, invoice status, and your send entitlement in one place.
+  - icon: ↗
+    title: Build it into your workflow
+    details: Use scoped API keys, idempotent REST resources, exact server-calculated totals, and signed webhooks for reliable integrations.
+  - icon: ⚡
+    title: Ready for conversational banking
+    details: The same transaction layer can power Telegram, WhatsApp, banking, and agent experiences without creating parallel invoice logic.
+---
+
+## One Hagfish, two ways to use it
+
+Hagfish is a complete invoicing product for professional creators and a
+transaction layer for software that needs to invoice on their behalf. The web
+app and public API share the same client records, invoice lifecycle, PDF and
+email delivery, plan quota, and credit ledger.
+
+### Run the work from Hagfish
+
+Use the product when you want a focused place to create clients and invoices,
+track expenses, schedule or send invoices, share public invoice links, manage
+recurring work, and follow payment status.
+
+[Open Hagfish →](https://hagfish.app)
+
+### Bring Hagfish into your product
+
+Use the REST API when a SaaS product, internal tool, workflow automation, bot,
+or agent should turn “invoice this client” into a safe transaction. Hagfish
+handles tenant isolation, fixed-point currency math, idempotency, billing
+reservation, asynchronous delivery, and signed outcome events.
+
+[Read the API documentation →](/hagfish/api/)
+
+## Built for retries, not demos
+
+Real integrations time out, submit twice, and receive events out of order.
+Hagfish requires idempotency keys for mutations, calculates totals on the
+server, reserves entitlement atomically, queues outbound work, and exposes
+delivery history and replay. That makes it useful behind a product interface,
+not only in a one-off script.
+
+## Start where you are
+
+- If you send invoices yourself, [start with Hagfish](https://hagfish.app).
+- If your application sends them, [create your first API invoice](/hagfish/api/getting-started).
+- If you need reliable status updates, [implement Hagfish webhooks](/hagfish/api/webhooks).


### PR DESCRIPTION
## Summary

- expand /commercial so Bridge clearly covers Hagfish as the commercial invoicing product
- add a dedicated /hagfish marketing page with product and API calls to action
- add the complete /hagfish/api documentation for setup, authentication, resources, deliveries and billing, webhooks, errors, and local testing
- route the Hagfish projects card to its owned marketing page

## Verification

- npm run build
- git diff --check

Closes sailscastshq/hagfish#270