### PR TITLE
docs: add line chart and sparkline pages

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -131,6 +131,8 @@ function kleanUiGuide() {
         { text: 'Breadcrumb', link: '/klean-ui/components/breadcrumb' },
         { text: 'Tabs', link: '/klean-ui/components/tabs' },
         { text: 'Table', link: '/klean-ui/components/table' },
+        { text: 'Sparkline', link: '/klean-ui/components/sparkline' },
+        { text: 'Line Chart', link: '/klean-ui/components/line-chart' },
         { text: 'Pagination', link: '/klean-ui/components/pagination' },
         { text: 'Popover', link: '/klean-ui/components/popover' },
         { text: 'Menu', link: '/klean-ui/components/menu' },

--- a/docs/.vitepress/theme/components/klean/line-chart/LineChart.vue
+++ b/docs/.vitepress/theme/components/klean/line-chart/LineChart.vue
@@ -1,0 +1,157 @@
+<script setup>
+import { computed, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  data: { type: Array, default: () => [] },
+  caption: { type: String, required: true },
+  emptyLabel: { type: String, default: 'No data' },
+  formatValue: { type: Function, default: (value) => String(value) }
+})
+
+const attrs = useAttrs()
+const width = 640
+const height = 200
+const inset = 4
+
+function finiteValue(point) {
+  return Number.isFinite(point?.value) ? point.value : undefined
+}
+
+function geometry(data) {
+  const values = data.map(finiteValue).filter((value) => value !== undefined)
+  if (!values.length) return { segments: [], points: [] }
+
+  let minimum = Math.min(0, ...values)
+  let maximum = Math.max(0, ...values)
+  if (minimum === maximum) {
+    minimum -= 1
+    maximum += 1
+  }
+
+  const x = (index) =>
+    data.length === 1
+      ? width / 2
+      : inset + (index / (data.length - 1)) * (width - inset * 2)
+  const y = (value) =>
+    inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2)
+
+  const segments = []
+  const points = []
+  let segment = []
+
+  data.forEach((point, index) => {
+    const value = finiteValue(point)
+    if (value === undefined) {
+      if (segment.length) segments.push(segment)
+      segment = []
+      return
+    }
+
+    const coordinate = { x: x(index), y: y(value) }
+    points.push(coordinate)
+    segment.push(coordinate)
+  })
+  if (segment.length) segments.push(segment)
+
+  return { segments, points }
+}
+
+const chart = computed(() => geometry(props.data))
+const hasValues = computed(() => chart.value.points.length > 0)
+const firstLabel = computed(() => props.data[0]?.label ?? '')
+const lastLabel = computed(() =>
+  props.data.length > 1 ? (props.data.at(-1)?.label ?? '') : ''
+)
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+function coordinates(segment) {
+  return segment.map((point) => `${point.x},${point.y}`).join(' ')
+}
+
+function exactValue(point) {
+  if (point?.detail) return point.detail
+  const value = finiteValue(point)
+  return value === undefined ? props.emptyLabel : props.formatValue(value)
+}
+</script>
+
+<template>
+  <figure
+    v-bind="forwardedAttrs"
+    data-slot="line-chart"
+    :class="
+      twMerge(
+        'grid h-64 grid-rows-[auto_minmax(0,1fr)_auto] gap-3 text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <figcaption data-slot="line-chart-caption" class="text-sm font-semibold">
+      {{ caption }}
+    </figcaption>
+
+    <svg
+      v-if="hasValues"
+      data-slot="line-chart-graphic"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 640 200"
+      preserveAspectRatio="none"
+      fill="none"
+      class="h-full min-h-0 w-full overflow-visible"
+    >
+      <template v-for="(segment, index) in chart.segments" :key="index">
+        <polyline
+          v-if="segment.length > 1"
+          data-slot="line-chart-line"
+          :points="coordinates(segment)"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"
+        />
+        <circle
+          v-else
+          data-slot="line-chart-point"
+          :cx="segment[0].x"
+          :cy="segment[0].y"
+          r="3"
+          fill="currentColor"
+          vector-effect="non-scaling-stroke"
+        />
+      </template>
+    </svg>
+    <p
+      v-else
+      data-slot="line-chart-empty"
+      class="grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
+    >
+      {{ emptyLabel }}
+    </p>
+
+    <div
+      v-if="hasValues"
+      data-slot="line-chart-labels"
+      :class="[
+        'flex text-xs text-gray-500 tabular-nums dark:text-gray-400',
+        lastLabel ? 'justify-between' : 'justify-center'
+      ]"
+    >
+      <span>{{ firstLabel }}</span>
+      <span v-if="lastLabel">{{ lastLabel }}</span>
+    </div>
+
+    <ul data-slot="line-chart-values" class="sr-only">
+      <li v-for="(point, index) in data" :key="index">
+        {{ point?.label }}: {{ exactValue(point) }}
+      </li>
+    </ul>
+  </figure>
+</template>

--- a/docs/.vitepress/theme/components/klean/line-chart/LineChart.vue
+++ b/docs/.vitepress/theme/components/klean/line-chart/LineChart.vue
@@ -14,7 +14,9 @@ const props = defineProps({
 const attrs = useAttrs()
 const width = 640
 const height = 200
-const inset = 4
+const inset = 8
+const cornerRadius = 20
+const guides = [inset, height / 2, height - inset]
 
 function finiteValue(point) {
   return Number.isFinite(point?.value) ? point.value : undefined
@@ -22,13 +24,18 @@ function finiteValue(point) {
 
 function geometry(data) {
   const values = data.map(finiteValue).filter((value) => value !== undefined)
-  if (!values.length) return { segments: [], points: [] }
+  if (!values.length) {
+    return { segments: [], points: [], minimum: undefined, maximum: undefined }
+  }
 
-  let minimum = Math.min(0, ...values)
-  let maximum = Math.max(0, ...values)
-  if (minimum === maximum) {
-    minimum -= 1
-    maximum += 1
+  const minimum = Math.min(...values)
+  const maximum = Math.max(...values)
+  let domainMinimum = minimum
+  let domainMaximum = maximum
+  if (domainMinimum === domainMaximum) {
+    const padding = Math.max(Math.abs(domainMinimum) * 0.1, 1)
+    domainMinimum -= padding
+    domainMaximum += padding
   }
 
   const x = (index) =>
@@ -36,7 +43,9 @@ function geometry(data) {
       ? width / 2
       : inset + (index / (data.length - 1)) * (width - inset * 2)
   const y = (value) =>
-    inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2)
+    inset +
+    ((domainMaximum - value) / (domainMaximum - domainMinimum)) *
+      (height - inset * 2)
 
   const segments = []
   const points = []
@@ -50,34 +59,104 @@ function geometry(data) {
       return
     }
 
-    const coordinate = { x: x(index), y: y(value) }
+    const coordinate = { x: x(index), y: y(value), index }
     points.push(coordinate)
     segment.push(coordinate)
   })
   if (segment.length) segments.push(segment)
 
-  return { segments, points }
+  return { segments, points, minimum, maximum }
 }
 
 const chart = computed(() => geometry(props.data))
 const hasValues = computed(() => chart.value.points.length > 0)
 const firstLabel = computed(() => props.data[0]?.label ?? '')
+const middleLabel = computed(() =>
+  props.data.length > 2
+    ? (props.data[Math.floor((props.data.length - 1) / 2)]?.label ?? '')
+    : ''
+)
 const lastLabel = computed(() =>
   props.data.length > 1 ? (props.data.at(-1)?.label ?? '') : ''
 )
+const currentPoint = computed(() => chart.value.points.at(-1))
 const forwardedAttrs = computed(() => {
   const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
   return rest
 })
 
-function coordinates(segment) {
-  return segment.map((point) => `${point.x},${point.y}`).join(' ')
+function compact(value) {
+  return Number(value.toFixed(2))
+}
+
+function roundedPath(segment) {
+  if (segment.length < 2) return ''
+
+  let path = `M ${compact(segment[0].x)} ${compact(segment[0].y)}`
+
+  for (let index = 1; index < segment.length - 1; index += 1) {
+    const previous = segment[index - 1]
+    const point = segment[index]
+    const next = segment[index + 1]
+    const previousDistance = Math.hypot(
+      point.x - previous.x,
+      point.y - previous.y
+    )
+    const nextDistance = Math.hypot(next.x - point.x, next.y - point.y)
+    const radius = Math.min(
+      cornerRadius,
+      previousDistance / 3,
+      nextDistance / 3
+    )
+    const before = {
+      x: point.x + ((previous.x - point.x) / previousDistance) * radius,
+      y: point.y + ((previous.y - point.y) / previousDistance) * radius
+    }
+    const after = {
+      x: point.x + ((next.x - point.x) / nextDistance) * radius,
+      y: point.y + ((next.y - point.y) / nextDistance) * radius
+    }
+
+    path += ` L ${compact(before.x)} ${compact(before.y)} Q ${compact(point.x)} ${compact(point.y)} ${compact(after.x)} ${compact(after.y)}`
+  }
+
+  const last = segment.at(-1)
+  return `${path} L ${compact(last.x)} ${compact(last.y)}`
 }
 
 function exactValue(point) {
   if (point?.detail) return point.detail
   const value = finiteValue(point)
   return value === undefined ? props.emptyLabel : props.formatValue(value)
+}
+
+function pointLabel(point) {
+  const value = exactValue(point)
+  return point?.detail || !point?.label ? value : `${point.label}: ${value}`
+}
+
+function pointStyle(point) {
+  return {
+    left: `${(point.x / width) * 100}%`,
+    top: `${(point.y / height) * 100}%`
+  }
+}
+
+function tipPosition(point) {
+  const horizontal =
+    point.x <= width * 0.2
+      ? 'left-1/2'
+      : point.x >= width * 0.8
+        ? 'right-1/2'
+        : 'left-1/2 -translate-x-1/2'
+  const vertical =
+    point.y <= height * 0.32 ? 'top-full mt-1.5' : 'bottom-full mb-1.5'
+
+  return [
+    'pointer-events-none absolute z-10 w-max max-w-52 rounded-md bg-gray-950 px-2.5 py-1.5 text-xs font-medium text-white opacity-0 shadow-lg group-hover:opacity-100 group-focus:opacity-100 dark:bg-white dark:text-gray-950',
+    horizontal,
+    vertical
+  ]
 }
 </script>
 
@@ -87,51 +166,152 @@ function exactValue(point) {
     data-slot="line-chart"
     :class="
       twMerge(
-        'grid h-64 grid-rows-[auto_minmax(0,1fr)_auto] gap-3 text-gray-950 dark:text-white',
+        'grid h-56 grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto] gap-x-3 gap-y-2 text-gray-950 dark:text-white',
         attrs.class
       )
     "
   >
-    <figcaption data-slot="line-chart-caption" class="text-sm font-semibold">
+    <figcaption
+      data-slot="line-chart-caption"
+      class="col-span-2 text-sm font-semibold"
+    >
       {{ caption }}
     </figcaption>
 
-    <svg
+    <div
       v-if="hasValues"
-      data-slot="line-chart-graphic"
-      aria-hidden="true"
-      focusable="false"
-      viewBox="0 0 640 200"
-      preserveAspectRatio="none"
-      fill="none"
-      class="h-full min-h-0 w-full overflow-visible"
+      data-slot="line-chart-scale"
+      :class="[
+        'row-start-2 grid min-w-8 text-right text-[11px] leading-none text-gray-500 tabular-nums dark:text-gray-400',
+        chart.minimum === chart.maximum
+          ? 'place-items-center'
+          : 'content-between'
+      ]"
     >
-      <template v-for="(segment, index) in chart.segments" :key="index">
-        <polyline
-          v-if="segment.length > 1"
-          data-slot="line-chart-line"
-          :points="coordinates(segment)"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          vector-effect="non-scaling-stroke"
-        />
+      <span>{{ formatValue(chart.maximum) }}</span>
+      <span v-if="chart.minimum !== chart.maximum">
+        {{ formatValue(chart.minimum) }}
+      </span>
+    </div>
+
+    <div
+      v-if="hasValues"
+      data-slot="line-chart-plot"
+      class="relative col-start-2 row-start-2 min-h-0"
+    >
+      <svg
+        data-slot="line-chart-graphic"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 640 200"
+        preserveAspectRatio="none"
+        fill="none"
+        class="h-full w-full overflow-visible"
+      >
+        <g
+          data-slot="line-chart-guides"
+          class="text-gray-200 dark:text-gray-800"
+        >
+          <line
+            v-for="guide in guides"
+            :key="guide"
+            data-slot="line-chart-guide"
+            :x1="inset"
+            :x2="width - inset"
+            :y1="guide"
+            :y2="guide"
+            stroke="currentColor"
+            stroke-width="1"
+            vector-effect="non-scaling-stroke"
+          />
+        </g>
+        <template v-for="(segment, index) in chart.segments" :key="index">
+          <path
+            v-if="segment.length > 1"
+            data-slot="line-chart-line"
+            :d="roundedPath(segment)"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            vector-effect="non-scaling-stroke"
+          />
+        </template>
         <circle
-          v-else
+          v-for="point in chart.points"
+          :key="point.index"
           data-slot="line-chart-point"
-          :cx="segment[0].x"
-          :cy="segment[0].y"
-          r="3"
+          :cx="point.x"
+          :cy="point.y"
+          r="2.25"
           fill="currentColor"
+          opacity="0.38"
           vector-effect="non-scaling-stroke"
         />
-      </template>
-    </svg>
+        <template v-if="currentPoint">
+          <circle
+            data-slot="line-chart-current-halo"
+            :cx="currentPoint.x"
+            :cy="currentPoint.y"
+            r="7"
+            fill="currentColor"
+            opacity="0.14"
+            vector-effect="non-scaling-stroke"
+          />
+          <circle
+            data-slot="line-chart-current"
+            :cx="currentPoint.x"
+            :cy="currentPoint.y"
+            r="3.5"
+            fill="currentColor"
+            vector-effect="non-scaling-stroke"
+          />
+        </template>
+      </svg>
+
+      <div
+        data-slot="line-chart-values"
+        role="list"
+        :aria-label="`${caption} values`"
+        class="pointer-events-none absolute inset-0"
+      >
+        <span v-for="point in chart.points" :key="point.index" role="listitem">
+          <button
+            type="button"
+            data-slot="line-chart-hit"
+            :aria-label="`Inspect ${pointLabel(data[point.index])}`"
+            :style="pointStyle(point)"
+            class="group pointer-events-auto absolute size-7 -translate-x-1/2 -translate-y-1/2 cursor-crosshair rounded-full outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-950"
+          >
+            <span
+              data-slot="line-chart-hover-point"
+              aria-hidden="true"
+              class="absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current opacity-0 ring-2 ring-white group-hover:opacity-100 group-focus:opacity-100 dark:ring-gray-950"
+            />
+            <span
+              data-slot="line-chart-tip"
+              aria-hidden="true"
+              :class="tipPosition(point)"
+            >
+              {{ pointLabel(data[point.index]) }}
+            </span>
+          </button>
+        </span>
+        <template v-for="(point, index) in data" :key="`missing-${index}`">
+          <span
+            v-if="finiteValue(point) === undefined"
+            role="listitem"
+            class="sr-only"
+          >
+            {{ pointLabel(point) }}
+          </span>
+        </template>
+      </div>
+    </div>
     <p
       v-else
       data-slot="line-chart-empty"
-      class="grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
+      class="col-span-2 grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
     >
       {{ emptyLabel }}
     </p>
@@ -140,18 +320,13 @@ function exactValue(point) {
       v-if="hasValues"
       data-slot="line-chart-labels"
       :class="[
-        'flex text-xs text-gray-500 tabular-nums dark:text-gray-400',
+        'col-start-2 row-start-3 flex text-xs text-gray-500 tabular-nums dark:text-gray-400',
         lastLabel ? 'justify-between' : 'justify-center'
       ]"
     >
       <span>{{ firstLabel }}</span>
+      <span v-if="middleLabel">{{ middleLabel }}</span>
       <span v-if="lastLabel">{{ lastLabel }}</span>
     </div>
-
-    <ul data-slot="line-chart-values" class="sr-only">
-      <li v-for="(point, index) in data" :key="index">
-        {{ point?.label }}: {{ exactValue(point) }}
-      </li>
-    </ul>
   </figure>
 </template>

--- a/docs/.vitepress/theme/components/klean/sparkline/Sparkline.vue
+++ b/docs/.vitepress/theme/components/klean/sparkline/Sparkline.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { computed, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  data: { type: Array, default: () => [] },
+  label: { type: String, default: undefined }
+})
+
+const attrs = useAttrs()
+const width = 120
+const height = 24
+const inset = 1.5
+
+function finiteValue(point) {
+  return Number.isFinite(point?.value) ? point.value : undefined
+}
+
+function geometry(data) {
+  const values = data.map(finiteValue).filter((value) => value !== undefined)
+  if (!values.length) return { segments: [], points: [] }
+
+  let minimum = Math.min(0, ...values)
+  let maximum = Math.max(0, ...values)
+  if (minimum === maximum) {
+    minimum -= 1
+    maximum += 1
+  }
+
+  const x = (index) =>
+    data.length === 1
+      ? width / 2
+      : inset + (index / (data.length - 1)) * (width - inset * 2)
+  const y = (value) =>
+    inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2)
+
+  const segments = []
+  const points = []
+  let segment = []
+
+  data.forEach((point, index) => {
+    const value = finiteValue(point)
+    if (value === undefined) {
+      if (segment.length) segments.push(segment)
+      segment = []
+      return
+    }
+
+    const coordinate = { x: x(index), y: y(value) }
+    points.push(coordinate)
+    segment.push(coordinate)
+  })
+  if (segment.length) segments.push(segment)
+
+  return { segments, points }
+}
+
+const chart = computed(() => geometry(props.data))
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-label': _ariaLabel,
+    'aria-hidden': _ariaHidden,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function coordinates(segment) {
+  return segment.map((point) => `${point.x},${point.y}`).join(' ')
+}
+</script>
+
+<template>
+  <svg
+    v-bind="forwardedAttrs"
+    data-slot="sparkline"
+    :role="label ? 'img' : undefined"
+    :aria-label="label"
+    :aria-hidden="label ? undefined : 'true'"
+    focusable="false"
+    viewBox="0 0 120 24"
+    preserveAspectRatio="none"
+    fill="none"
+    :class="twMerge('h-6 w-30 overflow-visible', attrs.class)"
+  >
+    <template v-for="(segment, index) in chart.segments" :key="index">
+      <polyline
+        v-if="segment.length > 1"
+        data-slot="sparkline-line"
+        :points="coordinates(segment)"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        vector-effect="non-scaling-stroke"
+      />
+      <circle
+        v-else
+        data-slot="sparkline-point"
+        :cx="segment[0].x"
+        :cy="segment[0].y"
+        r="1.75"
+        fill="currentColor"
+        vector-effect="non-scaling-stroke"
+      />
+    </template>
+  </svg>
+</template>

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -77,6 +77,14 @@ Accessible peer panels with roving focus, automatic or manual activation, dynami
 
 A native table with a neutral baseline, caller-written captions, sections, headers, rows, cells, and actions, plus an explicit boundary before stateful Data Table behavior.
 
+### [Sparkline](/klean-ui/components/sparkline)
+
+A compact trend beside an exact value, with truthful decorative defaults, honest missing-data gaps, and caller-owned Tailwind styling.
+
+### [Line Chart](/klean-ui/components/line-chart)
+
+A calm captioned trend with exact accessible values from the same data, resilient empty and missing states, and caller-owned Tailwind styling.
+
 ### [Pagination](/klean-ui/components/pagination)
 
 Durable server-list navigation with framework-native Inertia links, canonical page URLs, truthful edges, compact mobile output, and application-owned query state.

--- a/docs/klean-ui/components/line-chart.md
+++ b/docs/klean-ui/components/line-chart.md
@@ -1,0 +1,172 @@
+---
+title: Line Chart
+titleTemplate: Klean UI
+description: A calm captioned trend with exact accessible values and caller-owned Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanLineChart from '../../.vitepress/theme/components/klean/line-chart/LineChart.vue'
+import lineChartSource from '../../.vitepress/theme/components/klean/line-chart/LineChart.vue?raw'
+import reactSource from '../sources/line-chart/LineChart.jsx?raw'
+import svelteSource from '../sources/line-chart/LineChart.svelte?raw'
+import vueUsage from '../snippets/line-chart/usage.vue?raw'
+import reactUsage from '../snippets/line-chart/usage.jsx?raw'
+import svelteUsage from '../snippets/line-chart/usage.svelte?raw'
+
+const signups = [
+  { label: 'Fri', value: 4, detail: 'Friday, 4 signups' },
+  { label: 'Sat', value: 4, detail: 'Saturday, 4 signups' },
+  { label: 'Sun', value: 7, detail: 'Sunday, 7 signups' },
+  { label: 'Mon', value: 7, detail: 'Monday, 7 signups' },
+  { label: 'Tue', value: 4, detail: 'Tuesday, 4 signups' },
+  { label: 'Wed', value: 4, detail: 'Wednesday, 4 signups' },
+  { label: 'Thu', value: 5, detail: 'Thursday, 5 signups' }
+]
+
+const formatPercent = (value) => `${value}%`
+</script>
+
+# Line Chart
+
+Line Chart gives one ordered trend a visible caption, a calm responsive line, and the exact same values for assistive technology. It is deliberately small enough for real application dashboards without bringing a charting system into the product.
+
+<KleanPreview id="line-chart-source" :source="lineChartSource" filename="LineChart.vue">
+  <template #preview>
+    <section class="w-full max-w-xl rounded-xl border border-gray-200 bg-white p-6 text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-white">
+      <KleanLineChart :data="signups" caption="Signups — last 7 days" class="h-72" />
+    </section>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/line-chart/LineChart.vue
+
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and copies the matching one-file component into the conventional UI directory:
+
+<KleanInstallation
+  id="line-chart-installation"
+  component="line-chart"
+  :source="lineChartSource"
+  filename="LineChart.vue"
+  destination="assets/js/components/ui/line-chart/LineChart.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+## When to use
+
+Use Line Chart for one small ordered series such as signups over seven days, deployment duration over recent releases, or CPU usage over the last hour.
+
+Use [Sparkline](/klean-ui/components/sparkline) when an adjacent visible number is primary and space is tight. Use [Table](/klean-ui/components/table) when people need to compare or retrieve many exact values. A dense analytical workspace with axes, zooming, brushing, stacked series, or statistical transforms deserves a purpose-built application chart—not more props on Line Chart.
+
+## Usage
+
+### Vue
+
+<CopyCode :code="vueUsage" label="SignupChart.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="SignupChart.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="SignupChart.svelte" />
+
+## API
+
+| Input                    | Default   | Purpose                                                                                     |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------------- |
+| `data`                   | `[]`      | Ordered `{ label, value, detail? }` points. Non-finite values create honest gaps.           |
+| `caption`                | required  | Visible name for the figure.                                                                |
+| `emptyLabel`             | `No data` | Visible and announced wording when no finite values exist.                                  |
+| `formatValue`            | `String`  | Formats exact values for assistive technology when a point does not supply `detail`.        |
+| `class` / `className`    | —         | Ordinary Tailwind merged after the neutral responsive frame. Color follows `currentColor`.  |
+| native/global attributes | —         | IDs, data hooks, event hooks, and framework-native figure references when genuinely needed. |
+
+The stable datum contract is intentionally boring:
+
+```js
+{
+  label: 'Mon',
+  value: 7,
+  detail: 'Monday, 7 signups'
+}
+```
+
+`detail` is optional. Use it when the exact accessible sentence needs more context than `formatValue(value)` can provide.
+
+## Accessible values
+
+The visible caption names a native figure. The visual line is decorative to assistive technology, while an exact list generated from the same `data` is available to screen readers. There is no second dataset to drift out of sync.
+
+The default exact value is `String(value)`. Format units or locale-sensitive numbers at the call site:
+
+```vue
+<KleanLineChart
+  :data="cpu"
+  caption="CPU usage — last hour"
+  :format-value="formatPercent"
+/>
+```
+
+Use `Intl.NumberFormat`, `Intl.DateTimeFormat`, or application-owned formatting before data reaches the component when locale changes the meaning. The chart does not guess locale, timezone, or units.
+
+If sighted users need every exact value too, render a visible [Table](/klean-ui/components/table) from the same array next to the chart. Do not make hover the only route to data.
+
+## Empty, missing, and live data
+
+- Empty or entirely invalid data shows `emptyLabel`.
+- One finite value renders a point rather than inventing a trend.
+- Flat, zero, negative, and very large values remain finite and stable.
+- Missing values break the line instead of implying continuity.
+- Replacing `data` updates the figure; polling, realtime transport, and loading policy remain application state.
+- Time range, metric selection, and filters belong in the URL only when they should survive refresh, history, or sharing.
+
+## Styling with Tailwind
+
+Height, width, color, caption treatment, labels, empty state, and line treatment stay in caller Tailwind. Stable `data-slot` hooks make targeted styling explicit:
+
+```vue
+<LineChart
+  :data="memory"
+  caption="Memory — last hour"
+  class="h-80 text-sky-600 **:data-[slot=line-chart-caption]:text-gray-950 **:data-[slot=line-chart-line]:stroke-[3]"
+/>
+```
+
+There is no `variant`, palette, theme object, legend system, animation setting, or global chart provider. Repeated application treatment belongs in a small local wrapper around the copied component.
+
+## Slipway and Hagfish
+
+Slipway can replace its Lookout line geometry with Line Chart while retaining its exact current readings, dark operational styling, polling, and metric controls in application markup. Its compact CPU and memory rows use [Sparkline](/klean-ui/components/sparkline).
+
+Hagfish can use the same primitive for small invoice or payment trends without inheriting Slipway colors or dashboard assumptions. Tailwind preserves each product's visual language; the data and accessibility contract stays the same.
+
+## Related components
+
+- [Sparkline](/klean-ui/components/sparkline) — a compact trend beside an exact visible number.
+- [Table](/klean-ui/components/table) — visible exact values and comparison.
+- [Card](/klean-ui/components/card) — a semantic surface for one chart and its supporting content.
+- [Tooltip](/klean-ui/components/tooltip) — supplementary explanation, never the only source of chart data.
+
+## Complete framework source
+
+### Vue
+
+<CopyCode :code="lineChartSource" label="LineChart.vue" />
+
+### React
+
+<CopyCode :code="reactSource" label="LineChart.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteSource" label="LineChart.svelte" />

--- a/docs/klean-ui/components/line-chart.md
+++ b/docs/klean-ui/components/line-chart.md
@@ -32,12 +32,23 @@ const formatPercent = (value) => `${value}%`
 
 # Line Chart
 
-Line Chart gives one ordered trend a visible caption, a calm responsive line, and the exact same values for assistive technology. It is deliberately small enough for real application dashboards without bringing a charting system into the product.
+Line Chart gives one ordered trend a visible caption, a readable scale, calm responsive geometry, and points that disclose the same exact values on hover, touch, or keyboard focus. It is deliberately small enough for real application dashboards without bringing a charting system into the product.
 
 <KleanPreview id="line-chart-source" :source="lineChartSource" filename="LineChart.vue">
   <template #preview>
-    <section class="w-full max-w-xl rounded-xl border border-gray-200 bg-white p-6 text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-white">
-      <KleanLineChart :data="signups" caption="Signups — last 7 days" class="h-72" />
+    <section class="w-full max-w-xl rounded-2xl bg-white p-6 text-gray-950 shadow-sm dark:bg-gray-950 dark:text-white dark:shadow-black/30">
+      <header class="flex items-end justify-between gap-6">
+        <div>
+          <p class="text-sm text-gray-500 dark:text-gray-400">Last 7 days</p>
+          <p class="mt-1 text-4xl font-semibold tracking-tight tabular-nums">38</p>
+        </div>
+        <p class="pb-1 text-right text-sm text-gray-500 dark:text-gray-400">+8 from<br />the week before</p>
+      </header>
+      <KleanLineChart
+        :data="signups"
+        caption="Daily signups"
+        class="mt-8 h-56 text-gray-950 dark:text-gray-100"
+      />
     </section>
   </template>
   <template #source>
@@ -82,14 +93,14 @@ Use [Sparkline](/klean-ui/components/sparkline) when an adjacent visible number 
 
 ## API
 
-| Input                    | Default   | Purpose                                                                                     |
-| ------------------------ | --------- | ------------------------------------------------------------------------------------------- |
-| `data`                   | `[]`      | Ordered `{ label, value, detail? }` points. Non-finite values create honest gaps.           |
-| `caption`                | required  | Visible name for the figure.                                                                |
-| `emptyLabel`             | `No data` | Visible and announced wording when no finite values exist.                                  |
-| `formatValue`            | `String`  | Formats exact values for assistive technology when a point does not supply `detail`.        |
-| `class` / `className`    | —         | Ordinary Tailwind merged after the neutral responsive frame. Color follows `currentColor`.  |
-| native/global attributes | —         | IDs, data hooks, event hooks, and framework-native figure references when genuinely needed. |
+| Input                    | Default   | Purpose                                                                                      |
+| ------------------------ | --------- | -------------------------------------------------------------------------------------------- |
+| `data`                   | `[]`      | Ordered `{ label, value, detail? }` points. Non-finite values create honest gaps.            |
+| `caption`                | required  | Visible name for the figure.                                                                 |
+| `emptyLabel`             | `No data` | Visible and announced wording when no finite values exist.                                   |
+| `formatValue`            | `String`  | Formats the visible scale and exact accessible values when a point does not supply `detail`. |
+| `class` / `className`    | —         | Ordinary Tailwind merged after the neutral responsive frame. Color follows `currentColor`.   |
+| native/global attributes | —         | IDs, data hooks, event hooks, and framework-native figure references when genuinely needed.  |
 
 The stable datum contract is intentionally boring:
 
@@ -103,9 +114,11 @@ The stable datum contract is intentionally boring:
 
 `detail` is optional. Use it when the exact accessible sentence needs more context than `formatValue(value)` can provide.
 
-## Accessible values
+## Inspecting exact values
 
-The visible caption names a native figure. The visual line is decorative to assistive technology, while an exact list generated from the same `data` is available to screen readers. There is no second dataset to drift out of sync.
+The visible caption names a native figure. Hover, tap, or focus any finite sample to inspect its exact label and value. Edge points place their readout inward and high points place it below, so the callout stays with the chart in narrow containers.
+
+The visual line, guides, and SVG markers remain decorative to assistive technology. The inspectable points form an exact labelled list generated from the same `data`, including unavailable samples. There is no second dataset to drift out of sync and hover is never the only route to the data.
 
 The default exact value is `String(value)`. Format units or locale-sensitive numbers at the call site:
 
@@ -119,20 +132,21 @@ The default exact value is `String(value)`. Format units or locale-sensitive num
 
 Use `Intl.NumberFormat`, `Intl.DateTimeFormat`, or application-owned formatting before data reaches the component when locale changes the meaning. The chart does not guess locale, timezone, or units.
 
-If sighted users need every exact value too, render a visible [Table](/klean-ui/components/table) from the same array next to the chart. Do not make hover the only route to data.
+Render a visible [Table](/klean-ui/components/table) from the same array when people need persistent comparison or retrieval rather than one-at-a-time inspection.
 
 ## Empty, missing, and live data
 
 - Empty or entirely invalid data shows `emptyLabel`.
 - One finite value renders a point rather than inventing a trend.
 - Flat, zero, negative, and very large values remain finite and stable.
+- The finite minimum and maximum stay visible, so the tighter vertical range remains honest.
 - Missing values break the line instead of implying continuity.
 - Replacing `data` updates the figure; polling, realtime transport, and loading policy remain application state.
 - Time range, metric selection, and filters belong in the URL only when they should survive refresh, history, or sharing.
 
 ## Styling with Tailwind
 
-Height, width, color, caption treatment, labels, empty state, and line treatment stay in caller Tailwind. Stable `data-slot` hooks make targeted styling explicit:
+Height, width, color, caption treatment, labels, empty state, line treatment, and point readouts stay in caller Tailwind. Stable `data-slot` hooks make targeted styling explicit:
 
 ```vue
 <LineChart

--- a/docs/klean-ui/components/sparkline.md
+++ b/docs/klean-ui/components/sparkline.md
@@ -1,0 +1,144 @@
+---
+title: Sparkline
+titleTemplate: Klean UI
+description: A compact trend beside an exact value, with truthful accessible defaults and caller-owned Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import KleanSparkline from '../../.vitepress/theme/components/klean/sparkline/Sparkline.vue'
+import sparklineSource from '../../.vitepress/theme/components/klean/sparkline/Sparkline.vue?raw'
+import reactSource from '../sources/sparkline/Sparkline.jsx?raw'
+import svelteSource from '../sources/sparkline/Sparkline.svelte?raw'
+import vueUsage from '../snippets/sparkline/usage.vue?raw'
+import reactUsage from '../snippets/sparkline/usage.jsx?raw'
+import svelteUsage from '../snippets/sparkline/usage.svelte?raw'
+
+const cpu = [
+  { label: '12:00', value: 18 },
+  { label: '12:05', value: 24 },
+  { label: '12:10', value: 21 },
+  { label: '12:15', value: 39 },
+  { label: '12:20', value: 31 },
+  { label: '12:25', value: 42 }
+]
+</script>
+
+# Sparkline
+
+Sparkline is the small trend that sits beside an exact value. The number remains the truth; the line adds quick direction and shape without turning a compact status row into a chart dashboard.
+
+<KleanPreview id="sparkline-source" :source="sparklineSource" filename="Sparkline.vue">
+  <template #preview>
+    <section class="grid w-full max-w-sm gap-3 rounded-xl border border-gray-200 bg-white p-5 text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-white">
+      <p class="text-sm text-gray-600 dark:text-gray-400">CPU usage</p>
+      <p class="flex items-end justify-between gap-5">
+        <strong class="text-3xl tabular-nums">42%</strong>
+        <KleanSparkline :data="cpu" class="mb-1 h-7 w-32 text-emerald-600 dark:text-emerald-400" />
+      </p>
+    </section>
+  </template>
+  <template #source>
+
+<<< ../../.vitepress/theme/components/klean/sparkline/Sparkline.vue
+
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and copies the matching one-file component into the conventional UI directory:
+
+<KleanInstallation
+  id="sparkline-installation"
+  component="sparkline"
+  :source="sparklineSource"
+  filename="Sparkline.vue"
+  destination="assets/js/components/ui/sparkline/Sparkline.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+## When to use
+
+Use Sparkline in operational summaries, small metric cards, table cells, and dense side panels where a nearby visible number already states the current value.
+
+Use [Line Chart](/klean-ui/components/line-chart) when the trend deserves its own caption, time span, and exact accessible values. Use [Table](/klean-ui/components/table) when comparison and lookup matter more than shape.
+
+## Usage
+
+### Vue
+
+<CopyCode :code="vueUsage" label="CpuUsage.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="CpuUsage.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="CpuUsage.svelte" />
+
+## API
+
+| Input                    | Default | Purpose                                                                                  |
+| ------------------------ | ------- | ---------------------------------------------------------------------------------------- |
+| `data`                   | `[]`    | Ordered `{ label, value }` points. Non-finite values create honest gaps in the line.     |
+| `label`                  | —       | Makes the graphic informative and supplies its accessible name.                          |
+| `class` / `className`    | —       | Ordinary Tailwind merged after the compact neutral size. Color follows `currentColor`.   |
+| native/global attributes | —       | IDs, data hooks, event hooks, and framework-native element references when truly needed. |
+
+There is no variant, color scale, tooltip, provider, animation, or chart configuration object.
+
+## Accessible by default
+
+Without `label`, Sparkline is decorative and stays out of the accessibility tree. This is the normal choice when an adjacent number and visible text already communicate the metric.
+
+Add `label` only when the shape itself contributes information that is not otherwise present:
+
+```vue
+<Sparkline :data="cpu" label="CPU usage rose from 18 to 42 percent" />
+```
+
+A tooltip is never the only source of a value. Pointer hover, keyboard focus, touch, screenshots, print, and assistive technology all need the same truthful information.
+
+## Data behavior
+
+- Empty data renders an empty graphic without fabricated values.
+- One finite point renders a visible point.
+- Flat, zero, negative, and very large values remain finite and stable.
+- A missing or non-finite point breaks the line instead of drawing through unknown data.
+- The component is deterministic during server rendering.
+
+## Styling with Tailwind
+
+The line uses the element's text color, so ordinary Tailwind owns size and color:
+
+```vue
+<Sparkline :data="memory" class="h-8 w-40 text-sky-600 dark:text-sky-400" />
+```
+
+For repeated product treatment, keep a small application-owned wrapper. Sparkline does not acquire product tones or semantic variants.
+
+## Related components
+
+- [Line Chart](/klean-ui/components/line-chart) — a captioned trend with exact accessible values.
+- [Table](/klean-ui/components/table) — exact comparison and lookup across rows and columns.
+- [Tooltip](/klean-ui/components/tooltip) — supplementary help, never the only source of chart data.
+- [Card](/klean-ui/components/card) — a semantic surface that can contain a compact metric.
+
+## Complete framework source
+
+### Vue
+
+<CopyCode :code="sparklineSource" label="Sparkline.vue" />
+
+### React
+
+<CopyCode :code="reactSource" label="Sparkline.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteSource" label="Sparkline.svelte" />

--- a/docs/klean-ui/snippets/line-chart/usage.jsx
+++ b/docs/klean-ui/snippets/line-chart/usage.jsx
@@ -15,7 +15,7 @@ export default function SignupChart() {
     <LineChart
       data={signups}
       caption="Signups — last 7 days"
-      className="h-72 text-gray-950"
+      className="h-56 text-gray-950"
     />
   )
 }

--- a/docs/klean-ui/snippets/line-chart/usage.jsx
+++ b/docs/klean-ui/snippets/line-chart/usage.jsx
@@ -1,0 +1,21 @@
+import LineChart from '@/components/ui/line-chart/LineChart.jsx'
+
+const signups = [
+  { label: 'Fri', value: 4, detail: 'Friday, 4 signups' },
+  { label: 'Sat', value: 4, detail: 'Saturday, 4 signups' },
+  { label: 'Sun', value: 7, detail: 'Sunday, 7 signups' },
+  { label: 'Mon', value: 7, detail: 'Monday, 7 signups' },
+  { label: 'Tue', value: 4, detail: 'Tuesday, 4 signups' },
+  { label: 'Wed', value: 4, detail: 'Wednesday, 4 signups' },
+  { label: 'Thu', value: 5, detail: 'Thursday, 5 signups' }
+]
+
+export default function SignupChart() {
+  return (
+    <LineChart
+      data={signups}
+      caption="Signups — last 7 days"
+      className="h-72 text-gray-950"
+    />
+  )
+}

--- a/docs/klean-ui/snippets/line-chart/usage.svelte
+++ b/docs/klean-ui/snippets/line-chart/usage.svelte
@@ -15,5 +15,5 @@
 <LineChart
   data={signups}
   caption="Signups — last 7 days"
-  class="h-72 text-gray-950"
+  class="h-56 text-gray-950"
 />

--- a/docs/klean-ui/snippets/line-chart/usage.svelte
+++ b/docs/klean-ui/snippets/line-chart/usage.svelte
@@ -1,0 +1,19 @@
+<script>
+  import LineChart from '@/components/ui/line-chart/LineChart.svelte'
+
+  const signups = [
+    { label: 'Fri', value: 4, detail: 'Friday, 4 signups' },
+    { label: 'Sat', value: 4, detail: 'Saturday, 4 signups' },
+    { label: 'Sun', value: 7, detail: 'Sunday, 7 signups' },
+    { label: 'Mon', value: 7, detail: 'Monday, 7 signups' },
+    { label: 'Tue', value: 4, detail: 'Tuesday, 4 signups' },
+    { label: 'Wed', value: 4, detail: 'Wednesday, 4 signups' },
+    { label: 'Thu', value: 5, detail: 'Thursday, 5 signups' }
+  ]
+</script>
+
+<LineChart
+  data={signups}
+  caption="Signups — last 7 days"
+  class="h-72 text-gray-950"
+/>

--- a/docs/klean-ui/snippets/line-chart/usage.vue
+++ b/docs/klean-ui/snippets/line-chart/usage.vue
@@ -1,0 +1,21 @@
+<script setup>
+import LineChart from '@/components/ui/line-chart/LineChart.vue'
+
+const signups = [
+  { label: 'Fri', value: 4, detail: 'Friday, 4 signups' },
+  { label: 'Sat', value: 4, detail: 'Saturday, 4 signups' },
+  { label: 'Sun', value: 7, detail: 'Sunday, 7 signups' },
+  { label: 'Mon', value: 7, detail: 'Monday, 7 signups' },
+  { label: 'Tue', value: 4, detail: 'Tuesday, 4 signups' },
+  { label: 'Wed', value: 4, detail: 'Wednesday, 4 signups' },
+  { label: 'Thu', value: 5, detail: 'Thursday, 5 signups' }
+]
+</script>
+
+<template>
+  <LineChart
+    :data="signups"
+    caption="Signups — last 7 days"
+    class="h-72 text-gray-950"
+  />
+</template>

--- a/docs/klean-ui/snippets/line-chart/usage.vue
+++ b/docs/klean-ui/snippets/line-chart/usage.vue
@@ -16,6 +16,6 @@ const signups = [
   <LineChart
     :data="signups"
     caption="Signups — last 7 days"
-    class="h-72 text-gray-950"
+    class="h-56 text-gray-950"
   />
 </template>

--- a/docs/klean-ui/snippets/sparkline/usage.jsx
+++ b/docs/klean-ui/snippets/sparkline/usage.jsx
@@ -1,0 +1,19 @@
+import Sparkline from '@/components/ui/sparkline/Sparkline.jsx'
+
+const cpu = [
+  { label: '12:00', value: 18 },
+  { label: '12:05', value: 24 },
+  { label: '12:10', value: 21 },
+  { label: '12:15', value: 39 },
+  { label: '12:20', value: 31 },
+  { label: '12:25', value: 42 }
+]
+
+export default function CpuUsage() {
+  return (
+    <p className="flex items-end gap-3">
+      <strong className="text-2xl tabular-nums">42%</strong>
+      <Sparkline data={cpu} className="mb-1 h-6 w-24 text-emerald-600" />
+    </p>
+  )
+}

--- a/docs/klean-ui/snippets/sparkline/usage.svelte
+++ b/docs/klean-ui/snippets/sparkline/usage.svelte
@@ -1,0 +1,17 @@
+<script>
+  import Sparkline from '@/components/ui/sparkline/Sparkline.svelte'
+
+  const cpu = [
+    { label: '12:00', value: 18 },
+    { label: '12:05', value: 24 },
+    { label: '12:10', value: 21 },
+    { label: '12:15', value: 39 },
+    { label: '12:20', value: 31 },
+    { label: '12:25', value: 42 }
+  ]
+</script>
+
+<p class="flex items-end gap-3">
+  <strong class="text-2xl tabular-nums">42%</strong>
+  <Sparkline data={cpu} class="mb-1 h-6 w-24 text-emerald-600" />
+</p>

--- a/docs/klean-ui/snippets/sparkline/usage.vue
+++ b/docs/klean-ui/snippets/sparkline/usage.vue
@@ -1,0 +1,19 @@
+<script setup>
+import Sparkline from '@/components/ui/sparkline/Sparkline.vue'
+
+const cpu = [
+  { label: '12:00', value: 18 },
+  { label: '12:05', value: 24 },
+  { label: '12:10', value: 21 },
+  { label: '12:15', value: 39 },
+  { label: '12:20', value: 31 },
+  { label: '12:25', value: 42 }
+]
+</script>
+
+<template>
+  <p class="flex items-end gap-3">
+    <strong class="text-2xl tabular-nums">42%</strong>
+    <Sparkline :data="cpu" class="mb-1 h-6 w-24 text-emerald-600" />
+  </p>
+</template>

--- a/docs/klean-ui/sources/line-chart/LineChart.jsx
+++ b/docs/klean-ui/sources/line-chart/LineChart.jsx
@@ -3,7 +3,9 @@ import { twMerge } from 'tailwind-merge'
 
 const width = 640
 const height = 200
-const inset = 4
+const inset = 8
+const cornerRadius = 20
+const guides = [inset, height / 2, height - inset]
 
 function finiteValue(point) {
   return Number.isFinite(point?.value) ? point.value : undefined
@@ -11,13 +13,18 @@ function finiteValue(point) {
 
 function geometry(data) {
   const values = data.map(finiteValue).filter((value) => value !== undefined)
-  if (!values.length) return { segments: [], points: [] }
+  if (!values.length) {
+    return { segments: [], points: [], minimum: undefined, maximum: undefined }
+  }
 
-  let minimum = Math.min(0, ...values)
-  let maximum = Math.max(0, ...values)
-  if (minimum === maximum) {
-    minimum -= 1
-    maximum += 1
+  const minimum = Math.min(...values)
+  const maximum = Math.max(...values)
+  let domainMinimum = minimum
+  let domainMaximum = maximum
+  if (domainMinimum === domainMaximum) {
+    const padding = Math.max(Math.abs(domainMinimum) * 0.1, 1)
+    domainMinimum -= padding
+    domainMaximum += padding
   }
 
   const x = (index) =>
@@ -25,7 +32,9 @@ function geometry(data) {
       ? width / 2
       : inset + (index / (data.length - 1)) * (width - inset * 2)
   const y = (value) =>
-    inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2)
+    inset +
+    ((domainMaximum - value) / (domainMaximum - domainMinimum)) *
+      (height - inset * 2)
 
   const segments = []
   const points = []
@@ -39,17 +48,76 @@ function geometry(data) {
       return
     }
 
-    const coordinate = { x: x(index), y: y(value) }
+    const coordinate = { x: x(index), y: y(value), index }
     points.push(coordinate)
     segment.push(coordinate)
   })
   if (segment.length) segments.push(segment)
 
-  return { segments, points }
+  return { segments, points, minimum, maximum }
 }
 
-function coordinates(segment) {
-  return segment.map((point) => `${point.x},${point.y}`).join(' ')
+function compact(value) {
+  return Number(value.toFixed(2))
+}
+
+function roundedPath(segment) {
+  if (segment.length < 2) return ''
+
+  let path = `M ${compact(segment[0].x)} ${compact(segment[0].y)}`
+
+  for (let index = 1; index < segment.length - 1; index += 1) {
+    const previous = segment[index - 1]
+    const point = segment[index]
+    const next = segment[index + 1]
+    const previousDistance = Math.hypot(
+      point.x - previous.x,
+      point.y - previous.y
+    )
+    const nextDistance = Math.hypot(next.x - point.x, next.y - point.y)
+    const radius = Math.min(
+      cornerRadius,
+      previousDistance / 3,
+      nextDistance / 3
+    )
+    const before = {
+      x: point.x + ((previous.x - point.x) / previousDistance) * radius,
+      y: point.y + ((previous.y - point.y) / previousDistance) * radius
+    }
+    const after = {
+      x: point.x + ((next.x - point.x) / nextDistance) * radius,
+      y: point.y + ((next.y - point.y) / nextDistance) * radius
+    }
+
+    path += ` L ${compact(before.x)} ${compact(before.y)} Q ${compact(point.x)} ${compact(point.y)} ${compact(after.x)} ${compact(after.y)}`
+  }
+
+  const last = segment.at(-1)
+  return `${path} L ${compact(last.x)} ${compact(last.y)}`
+}
+
+function pointStyle(point) {
+  return {
+    left: `${(point.x / width) * 100}%`,
+    top: `${(point.y / height) * 100}%`
+  }
+}
+
+function tipPosition(point) {
+  const horizontal =
+    point.x <= width * 0.2
+      ? 'left-1/2'
+      : point.x >= width * 0.8
+        ? 'right-1/2'
+        : 'left-1/2 -translate-x-1/2'
+  const vertical =
+    point.y <= height * 0.32 ? 'top-full mt-1.5' : 'bottom-full mb-1.5'
+
+  return twMerge(
+    'pointer-events-none absolute z-10 w-max max-w-52 rounded-md bg-gray-950 px-2.5 py-1.5 text-xs font-medium text-white opacity-0 shadow-lg group-hover:opacity-100 group-focus:opacity-100 dark:bg-white dark:text-gray-950',
+    horizontal,
+    vertical
+  )
 }
 
 const LineChart = forwardRef(function LineChart(
@@ -67,11 +135,20 @@ const LineChart = forwardRef(function LineChart(
   const chart = geometry(data)
   const hasValues = chart.points.length > 0
   const firstLabel = data[0]?.label ?? ''
+  const middleLabel =
+    data.length > 2
+      ? (data[Math.floor((data.length - 1) / 2)]?.label ?? '')
+      : ''
   const lastLabel = data.length > 1 ? (data.at(-1)?.label ?? '') : ''
+  const currentPoint = chart.points.at(-1)
   const exactValue = (point) => {
     if (point?.detail) return point.detail
     const value = finiteValue(point)
     return value === undefined ? emptyLabel : formatValue(value)
+  }
+  const pointLabel = (point) => {
+    const value = exactValue(point)
+    return point?.detail || !point?.label ? value : `${point.label}: ${value}`
   }
 
   return (
@@ -80,56 +157,162 @@ const LineChart = forwardRef(function LineChart(
       ref={ref}
       data-slot="line-chart"
       className={twMerge(
-        'grid h-64 grid-rows-[auto_minmax(0,1fr)_auto] gap-3 text-gray-950 dark:text-white',
+        'grid h-56 grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto] gap-x-3 gap-y-2 text-gray-950 dark:text-white',
         className
       )}
     >
       <figcaption
         data-slot="line-chart-caption"
-        className="text-sm font-semibold"
+        className="col-span-2 text-sm font-semibold"
       >
         {caption}
       </figcaption>
 
       {hasValues ? (
-        <svg
-          data-slot="line-chart-graphic"
-          aria-hidden="true"
-          focusable="false"
-          viewBox="0 0 640 200"
-          preserveAspectRatio="none"
-          fill="none"
-          className="h-full min-h-0 w-full overflow-visible"
-        >
-          {chart.segments.map((segment, index) =>
-            segment.length > 1 ? (
-              <polyline
-                key={index}
-                data-slot="line-chart-line"
-                points={coordinates(segment)}
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                vectorEffect="non-scaling-stroke"
-              />
-            ) : (
-              <circle
-                key={index}
-                data-slot="line-chart-point"
-                cx={segment[0].x}
-                cy={segment[0].y}
-                r="3"
-                fill="currentColor"
-                vectorEffect="non-scaling-stroke"
-              />
-            )
+        <div
+          data-slot="line-chart-scale"
+          className={twMerge(
+            'row-start-2 grid min-w-8 text-right text-[11px] leading-none text-gray-500 tabular-nums dark:text-gray-400',
+            chart.minimum === chart.maximum
+              ? 'place-items-center'
+              : 'content-between'
           )}
-        </svg>
+        >
+          <span>{formatValue(chart.maximum)}</span>
+          {chart.minimum !== chart.maximum ? (
+            <span>{formatValue(chart.minimum)}</span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {hasValues ? (
+        <div
+          data-slot="line-chart-plot"
+          className="relative col-start-2 row-start-2 min-h-0"
+        >
+          <svg
+            data-slot="line-chart-graphic"
+            aria-hidden="true"
+            focusable="false"
+            viewBox="0 0 640 200"
+            preserveAspectRatio="none"
+            fill="none"
+            className="h-full w-full overflow-visible"
+          >
+            <g
+              data-slot="line-chart-guides"
+              className="text-gray-200 dark:text-gray-800"
+            >
+              {guides.map((guide) => (
+                <line
+                  key={guide}
+                  data-slot="line-chart-guide"
+                  x1={inset}
+                  x2={width - inset}
+                  y1={guide}
+                  y2={guide}
+                  stroke="currentColor"
+                  strokeWidth="1"
+                  vectorEffect="non-scaling-stroke"
+                />
+              ))}
+            </g>
+            {chart.segments.map((segment, index) =>
+              segment.length > 1 ? (
+                <path
+                  key={index}
+                  data-slot="line-chart-line"
+                  d={roundedPath(segment)}
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  vectorEffect="non-scaling-stroke"
+                />
+              ) : null
+            )}
+            {chart.points.map((point) => (
+              <circle
+                key={point.index}
+                data-slot="line-chart-point"
+                cx={point.x}
+                cy={point.y}
+                r="2.25"
+                fill="currentColor"
+                opacity="0.38"
+                vectorEffect="non-scaling-stroke"
+              />
+            ))}
+            {currentPoint ? (
+              <>
+                <circle
+                  data-slot="line-chart-current-halo"
+                  cx={currentPoint.x}
+                  cy={currentPoint.y}
+                  r="7"
+                  fill="currentColor"
+                  opacity="0.14"
+                  vectorEffect="non-scaling-stroke"
+                />
+                <circle
+                  data-slot="line-chart-current"
+                  cx={currentPoint.x}
+                  cy={currentPoint.y}
+                  r="3.5"
+                  fill="currentColor"
+                  vectorEffect="non-scaling-stroke"
+                />
+              </>
+            ) : null}
+          </svg>
+
+          <div
+            data-slot="line-chart-values"
+            role="list"
+            aria-label={`${caption} values`}
+            className="pointer-events-none absolute inset-0"
+          >
+            {chart.points.map((point) => (
+              <span key={point.index} role="listitem">
+                <button
+                  type="button"
+                  data-slot="line-chart-hit"
+                  aria-label={`Inspect ${pointLabel(data[point.index])}`}
+                  style={pointStyle(point)}
+                  className="group pointer-events-auto absolute size-7 -translate-x-1/2 -translate-y-1/2 cursor-crosshair rounded-full outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-950"
+                >
+                  <span
+                    data-slot="line-chart-hover-point"
+                    aria-hidden="true"
+                    className="absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current opacity-0 ring-2 ring-white group-hover:opacity-100 group-focus:opacity-100 dark:ring-gray-950"
+                  />
+                  <span
+                    data-slot="line-chart-tip"
+                    aria-hidden="true"
+                    className={tipPosition(point)}
+                  >
+                    {pointLabel(data[point.index])}
+                  </span>
+                </button>
+              </span>
+            ))}
+            {data.map((point, index) =>
+              finiteValue(point) === undefined ? (
+                <span
+                  key={`missing-${index}`}
+                  role="listitem"
+                  className="sr-only"
+                >
+                  {pointLabel(point)}
+                </span>
+              ) : null
+            )}
+          </div>
+        </div>
       ) : (
         <p
           data-slot="line-chart-empty"
-          className="grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
+          className="col-span-2 grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
         >
           {emptyLabel}
         </p>
@@ -139,22 +322,15 @@ const LineChart = forwardRef(function LineChart(
         <div
           data-slot="line-chart-labels"
           className={twMerge(
-            'flex text-xs text-gray-500 tabular-nums dark:text-gray-400',
+            'col-start-2 row-start-3 flex text-xs text-gray-500 tabular-nums dark:text-gray-400',
             lastLabel ? 'justify-between' : 'justify-center'
           )}
         >
           <span>{firstLabel}</span>
+          {middleLabel ? <span>{middleLabel}</span> : null}
           {lastLabel ? <span>{lastLabel}</span> : null}
         </div>
       ) : null}
-
-      <ul data-slot="line-chart-values" className="sr-only">
-        {data.map((point, index) => (
-          <li key={index}>
-            {point?.label}: {exactValue(point)}
-          </li>
-        ))}
-      </ul>
     </figure>
   )
 })

--- a/docs/klean-ui/sources/line-chart/LineChart.jsx
+++ b/docs/klean-ui/sources/line-chart/LineChart.jsx
@@ -1,0 +1,162 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const width = 640
+const height = 200
+const inset = 4
+
+function finiteValue(point) {
+  return Number.isFinite(point?.value) ? point.value : undefined
+}
+
+function geometry(data) {
+  const values = data.map(finiteValue).filter((value) => value !== undefined)
+  if (!values.length) return { segments: [], points: [] }
+
+  let minimum = Math.min(0, ...values)
+  let maximum = Math.max(0, ...values)
+  if (minimum === maximum) {
+    minimum -= 1
+    maximum += 1
+  }
+
+  const x = (index) =>
+    data.length === 1
+      ? width / 2
+      : inset + (index / (data.length - 1)) * (width - inset * 2)
+  const y = (value) =>
+    inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2)
+
+  const segments = []
+  const points = []
+  let segment = []
+
+  data.forEach((point, index) => {
+    const value = finiteValue(point)
+    if (value === undefined) {
+      if (segment.length) segments.push(segment)
+      segment = []
+      return
+    }
+
+    const coordinate = { x: x(index), y: y(value) }
+    points.push(coordinate)
+    segment.push(coordinate)
+  })
+  if (segment.length) segments.push(segment)
+
+  return { segments, points }
+}
+
+function coordinates(segment) {
+  return segment.map((point) => `${point.x},${point.y}`).join(' ')
+}
+
+const LineChart = forwardRef(function LineChart(
+  {
+    data = [],
+    caption,
+    emptyLabel = 'No data',
+    formatValue = String,
+    className,
+    'data-slot': _dataSlot,
+    ...props
+  },
+  ref
+) {
+  const chart = geometry(data)
+  const hasValues = chart.points.length > 0
+  const firstLabel = data[0]?.label ?? ''
+  const lastLabel = data.length > 1 ? (data.at(-1)?.label ?? '') : ''
+  const exactValue = (point) => {
+    if (point?.detail) return point.detail
+    const value = finiteValue(point)
+    return value === undefined ? emptyLabel : formatValue(value)
+  }
+
+  return (
+    <figure
+      {...props}
+      ref={ref}
+      data-slot="line-chart"
+      className={twMerge(
+        'grid h-64 grid-rows-[auto_minmax(0,1fr)_auto] gap-3 text-gray-950 dark:text-white',
+        className
+      )}
+    >
+      <figcaption
+        data-slot="line-chart-caption"
+        className="text-sm font-semibold"
+      >
+        {caption}
+      </figcaption>
+
+      {hasValues ? (
+        <svg
+          data-slot="line-chart-graphic"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 640 200"
+          preserveAspectRatio="none"
+          fill="none"
+          className="h-full min-h-0 w-full overflow-visible"
+        >
+          {chart.segments.map((segment, index) =>
+            segment.length > 1 ? (
+              <polyline
+                key={index}
+                data-slot="line-chart-line"
+                points={coordinates(segment)}
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            ) : (
+              <circle
+                key={index}
+                data-slot="line-chart-point"
+                cx={segment[0].x}
+                cy={segment[0].y}
+                r="3"
+                fill="currentColor"
+                vectorEffect="non-scaling-stroke"
+              />
+            )
+          )}
+        </svg>
+      ) : (
+        <p
+          data-slot="line-chart-empty"
+          className="grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
+        >
+          {emptyLabel}
+        </p>
+      )}
+
+      {hasValues ? (
+        <div
+          data-slot="line-chart-labels"
+          className={twMerge(
+            'flex text-xs text-gray-500 tabular-nums dark:text-gray-400',
+            lastLabel ? 'justify-between' : 'justify-center'
+          )}
+        >
+          <span>{firstLabel}</span>
+          {lastLabel ? <span>{lastLabel}</span> : null}
+        </div>
+      ) : null}
+
+      <ul data-slot="line-chart-values" className="sr-only">
+        {data.map((point, index) => (
+          <li key={index}>
+            {point?.label}: {exactValue(point)}
+          </li>
+        ))}
+      </ul>
+    </figure>
+  )
+})
+
+export default LineChart

--- a/docs/klean-ui/sources/line-chart/LineChart.svelte
+++ b/docs/klean-ui/sources/line-chart/LineChart.svelte
@@ -1,0 +1,151 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  let {
+    data = [],
+    caption,
+    emptyLabel = "No data",
+    formatValue = String,
+    class: className,
+    "data-slot": _dataSlot,
+    ...props
+  } = $props();
+
+  const width = 640;
+  const height = 200;
+  const inset = 4;
+
+  function finiteValue(point) {
+    return Number.isFinite(point?.value) ? point.value : undefined;
+  }
+
+  function geometry(points) {
+    const values = points
+      .map(finiteValue)
+      .filter((value) => value !== undefined);
+    if (!values.length) return { segments: [], points: [] };
+
+    let minimum = Math.min(0, ...values);
+    let maximum = Math.max(0, ...values);
+    if (minimum === maximum) {
+      minimum -= 1;
+      maximum += 1;
+    }
+
+    const x = (index) =>
+      points.length === 1
+        ? width / 2
+        : inset + (index / (points.length - 1)) * (width - inset * 2);
+    const y = (value) =>
+      inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2);
+
+    const segments = [];
+    const chartPoints = [];
+    let segment = [];
+
+    points.forEach((point, index) => {
+      const value = finiteValue(point);
+      if (value === undefined) {
+        if (segment.length) segments.push(segment);
+        segment = [];
+        return;
+      }
+
+      const coordinate = { x: x(index), y: y(value) };
+      chartPoints.push(coordinate);
+      segment.push(coordinate);
+    });
+    if (segment.length) segments.push(segment);
+
+    return { segments, points: chartPoints };
+  }
+
+  function coordinates(segment) {
+    return segment.map((point) => `${point.x},${point.y}`).join(" ");
+  }
+
+  function exactValue(point) {
+    if (point?.detail) return point.detail;
+    const value = finiteValue(point);
+    return value === undefined ? emptyLabel : formatValue(value);
+  }
+
+  let chart = $derived(geometry(data));
+  let hasValues = $derived(chart.points.length > 0);
+  let firstLabel = $derived(data[0]?.label ?? "");
+  let lastLabel = $derived(data.length > 1 ? (data.at(-1)?.label ?? "") : "");
+</script>
+
+<figure
+  {...props}
+  data-slot="line-chart"
+  class={twMerge(
+    "grid h-64 grid-rows-[auto_minmax(0,1fr)_auto] gap-3 text-gray-950 dark:text-white",
+    className,
+  )}
+>
+  <figcaption data-slot="line-chart-caption" class="text-sm font-semibold">
+    {caption}
+  </figcaption>
+
+  {#if hasValues}
+    <svg
+      data-slot="line-chart-graphic"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 640 200"
+      preserveAspectRatio="none"
+      fill="none"
+      class="h-full min-h-0 w-full overflow-visible"
+    >
+      {#each chart.segments as segment, index (index)}
+        {#if segment.length > 1}
+          <polyline
+            data-slot="line-chart-line"
+            points={coordinates(segment)}
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            vector-effect="non-scaling-stroke"
+          />
+        {:else}
+          <circle
+            data-slot="line-chart-point"
+            cx={segment[0].x}
+            cy={segment[0].y}
+            r="3"
+            fill="currentColor"
+            vector-effect="non-scaling-stroke"
+          />
+        {/if}
+      {/each}
+    </svg>
+  {:else}
+    <p
+      data-slot="line-chart-empty"
+      class="grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
+    >
+      {emptyLabel}
+    </p>
+  {/if}
+
+  {#if hasValues}
+    <div
+      data-slot="line-chart-labels"
+      class={twMerge(
+        "flex text-xs text-gray-500 tabular-nums dark:text-gray-400",
+        lastLabel ? "justify-between" : "justify-center",
+      )}
+    >
+      <span>{firstLabel}</span>
+      {#if lastLabel}<span>{lastLabel}</span>{/if}
+    </div>
+  {/if}
+
+  <ul data-slot="line-chart-values" class="sr-only">
+    {#each data as point, index (index)}
+      <li>{point?.label}: {exactValue(point)}</li>
+    {/each}
+  </ul>
+</figure>

--- a/docs/klean-ui/sources/line-chart/LineChart.svelte
+++ b/docs/klean-ui/sources/line-chart/LineChart.svelte
@@ -13,7 +13,9 @@
 
   const width = 640;
   const height = 200;
-  const inset = 4;
+  const inset = 8;
+  const cornerRadius = 20;
+  const guides = [inset, height / 2, height - inset];
 
   function finiteValue(point) {
     return Number.isFinite(point?.value) ? point.value : undefined;
@@ -23,13 +25,23 @@
     const values = points
       .map(finiteValue)
       .filter((value) => value !== undefined);
-    if (!values.length) return { segments: [], points: [] };
+    if (!values.length) {
+      return {
+        segments: [],
+        points: [],
+        minimum: undefined,
+        maximum: undefined,
+      };
+    }
 
-    let minimum = Math.min(0, ...values);
-    let maximum = Math.max(0, ...values);
-    if (minimum === maximum) {
-      minimum -= 1;
-      maximum += 1;
+    const minimum = Math.min(...values);
+    const maximum = Math.max(...values);
+    let domainMinimum = minimum;
+    let domainMaximum = maximum;
+    if (domainMinimum === domainMaximum) {
+      const padding = Math.max(Math.abs(domainMinimum) * 0.1, 1);
+      domainMinimum -= padding;
+      domainMaximum += padding;
     }
 
     const x = (index) =>
@@ -37,7 +49,9 @@
         ? width / 2
         : inset + (index / (points.length - 1)) * (width - inset * 2);
     const y = (value) =>
-      inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2);
+      inset +
+      ((domainMaximum - value) / (domainMaximum - domainMinimum)) *
+        (height - inset * 2);
 
     const segments = [];
     const chartPoints = [];
@@ -51,17 +65,52 @@
         return;
       }
 
-      const coordinate = { x: x(index), y: y(value) };
+      const coordinate = { x: x(index), y: y(value), index };
       chartPoints.push(coordinate);
       segment.push(coordinate);
     });
     if (segment.length) segments.push(segment);
 
-    return { segments, points: chartPoints };
+    return { segments, points: chartPoints, minimum, maximum };
   }
 
-  function coordinates(segment) {
-    return segment.map((point) => `${point.x},${point.y}`).join(" ");
+  function compact(value) {
+    return Number(value.toFixed(2));
+  }
+
+  function roundedPath(segment) {
+    if (segment.length < 2) return "";
+
+    let path = `M ${compact(segment[0].x)} ${compact(segment[0].y)}`;
+
+    for (let index = 1; index < segment.length - 1; index += 1) {
+      const previous = segment[index - 1];
+      const point = segment[index];
+      const next = segment[index + 1];
+      const previousDistance = Math.hypot(
+        point.x - previous.x,
+        point.y - previous.y,
+      );
+      const nextDistance = Math.hypot(next.x - point.x, next.y - point.y);
+      const radius = Math.min(
+        cornerRadius,
+        previousDistance / 3,
+        nextDistance / 3,
+      );
+      const before = {
+        x: point.x + ((previous.x - point.x) / previousDistance) * radius,
+        y: point.y + ((previous.y - point.y) / previousDistance) * radius,
+      };
+      const after = {
+        x: point.x + ((next.x - point.x) / nextDistance) * radius,
+        y: point.y + ((next.y - point.y) / nextDistance) * radius,
+      };
+
+      path += ` L ${compact(before.x)} ${compact(before.y)} Q ${compact(point.x)} ${compact(point.y)} ${compact(after.x)} ${compact(after.y)}`;
+    }
+
+    const last = segment.at(-1);
+    return `${path} L ${compact(last.x)} ${compact(last.y)}`;
   }
 
   function exactValue(point) {
@@ -70,61 +119,193 @@
     return value === undefined ? emptyLabel : formatValue(value);
   }
 
+  function pointLabel(point) {
+    const value = exactValue(point);
+    return point?.detail || !point?.label ? value : `${point.label}: ${value}`;
+  }
+
+  function pointStyle(point) {
+    return `left: ${(point.x / width) * 100}%; top: ${(point.y / height) * 100}%`;
+  }
+
+  function tipPosition(point) {
+    const horizontal =
+      point.x <= width * 0.2
+        ? "left-1/2"
+        : point.x >= width * 0.8
+          ? "right-1/2"
+          : "left-1/2 -translate-x-1/2";
+    const vertical =
+      point.y <= height * 0.32 ? "top-full mt-1.5" : "bottom-full mb-1.5";
+
+    return twMerge(
+      "pointer-events-none absolute z-10 w-max max-w-52 rounded-md bg-gray-950 px-2.5 py-1.5 text-xs font-medium text-white opacity-0 shadow-lg group-hover:opacity-100 group-focus:opacity-100 dark:bg-white dark:text-gray-950",
+      horizontal,
+      vertical,
+    );
+  }
+
   let chart = $derived(geometry(data));
   let hasValues = $derived(chart.points.length > 0);
   let firstLabel = $derived(data[0]?.label ?? "");
+  let middleLabel = $derived(
+    data.length > 2
+      ? (data[Math.floor((data.length - 1) / 2)]?.label ?? "")
+      : "",
+  );
   let lastLabel = $derived(data.length > 1 ? (data.at(-1)?.label ?? "") : "");
+  let currentPoint = $derived(chart.points.at(-1));
 </script>
 
 <figure
   {...props}
   data-slot="line-chart"
   class={twMerge(
-    "grid h-64 grid-rows-[auto_minmax(0,1fr)_auto] gap-3 text-gray-950 dark:text-white",
+    "grid h-56 grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto] gap-x-3 gap-y-2 text-gray-950 dark:text-white",
     className,
   )}
 >
-  <figcaption data-slot="line-chart-caption" class="text-sm font-semibold">
+  <figcaption
+    data-slot="line-chart-caption"
+    class="col-span-2 text-sm font-semibold"
+  >
     {caption}
   </figcaption>
 
   {#if hasValues}
-    <svg
-      data-slot="line-chart-graphic"
-      aria-hidden="true"
-      focusable="false"
-      viewBox="0 0 640 200"
-      preserveAspectRatio="none"
-      fill="none"
-      class="h-full min-h-0 w-full overflow-visible"
+    <div
+      data-slot="line-chart-scale"
+      class={twMerge(
+        "row-start-2 grid min-w-8 text-right text-[11px] leading-none text-gray-500 tabular-nums dark:text-gray-400",
+        chart.minimum === chart.maximum
+          ? "place-items-center"
+          : "content-between",
+      )}
     >
-      {#each chart.segments as segment, index (index)}
-        {#if segment.length > 1}
-          <polyline
-            data-slot="line-chart-line"
-            points={coordinates(segment)}
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            vector-effect="non-scaling-stroke"
-          />
-        {:else}
+      <span>{formatValue(chart.maximum)}</span>
+      {#if chart.minimum !== chart.maximum}
+        <span>{formatValue(chart.minimum)}</span>
+      {/if}
+    </div>
+  {/if}
+
+  {#if hasValues}
+    <div
+      data-slot="line-chart-plot"
+      class="relative col-start-2 row-start-2 min-h-0"
+    >
+      <svg
+        data-slot="line-chart-graphic"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 640 200"
+        preserveAspectRatio="none"
+        fill="none"
+        class="h-full w-full overflow-visible"
+      >
+        <g
+          data-slot="line-chart-guides"
+          class="text-gray-200 dark:text-gray-800"
+        >
+          {#each guides as guide (guide)}
+            <line
+              data-slot="line-chart-guide"
+              x1={inset}
+              x2={width - inset}
+              y1={guide}
+              y2={guide}
+              stroke="currentColor"
+              stroke-width="1"
+              vector-effect="non-scaling-stroke"
+            />
+          {/each}
+        </g>
+        {#each chart.segments as segment, index (index)}
+          {#if segment.length > 1}
+            <path
+              data-slot="line-chart-line"
+              d={roundedPath(segment)}
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              vector-effect="non-scaling-stroke"
+            />
+          {/if}
+        {/each}
+        {#each chart.points as point (point.index)}
           <circle
             data-slot="line-chart-point"
-            cx={segment[0].x}
-            cy={segment[0].y}
-            r="3"
+            cx={point.x}
+            cy={point.y}
+            r="2.25"
+            fill="currentColor"
+            opacity="0.38"
+            vector-effect="non-scaling-stroke"
+          />
+        {/each}
+        {#if currentPoint}
+          <circle
+            data-slot="line-chart-current-halo"
+            cx={currentPoint.x}
+            cy={currentPoint.y}
+            r="7"
+            fill="currentColor"
+            opacity="0.14"
+            vector-effect="non-scaling-stroke"
+          />
+          <circle
+            data-slot="line-chart-current"
+            cx={currentPoint.x}
+            cy={currentPoint.y}
+            r="3.5"
             fill="currentColor"
             vector-effect="non-scaling-stroke"
           />
         {/if}
-      {/each}
-    </svg>
+      </svg>
+
+      <div
+        data-slot="line-chart-values"
+        role="list"
+        aria-label={`${caption} values`}
+        class="pointer-events-none absolute inset-0"
+      >
+        {#each chart.points as point (point.index)}
+          <span role="listitem">
+            <button
+              type="button"
+              data-slot="line-chart-hit"
+              aria-label={`Inspect ${pointLabel(data[point.index])}`}
+              style={pointStyle(point)}
+              class="group pointer-events-auto absolute size-7 -translate-x-1/2 -translate-y-1/2 cursor-crosshair rounded-full outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-950"
+            >
+              <span
+                data-slot="line-chart-hover-point"
+                aria-hidden="true"
+                class="absolute left-1/2 top-1/2 size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current opacity-0 ring-2 ring-white group-hover:opacity-100 group-focus:opacity-100 dark:ring-gray-950"
+              ></span>
+              <span
+                data-slot="line-chart-tip"
+                aria-hidden="true"
+                class={tipPosition(point)}
+              >
+                {pointLabel(data[point.index])}
+              </span>
+            </button>
+          </span>
+        {/each}
+        {#each data as point, index (index)}
+          {#if finiteValue(point) === undefined}
+            <span role="listitem" class="sr-only">{pointLabel(point)}</span>
+          {/if}
+        {/each}
+      </div>
+    </div>
   {:else}
     <p
       data-slot="line-chart-empty"
-      class="grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
+      class="col-span-2 grid min-h-32 place-items-center text-sm text-gray-500 dark:text-gray-400"
     >
       {emptyLabel}
     </p>
@@ -134,18 +315,13 @@
     <div
       data-slot="line-chart-labels"
       class={twMerge(
-        "flex text-xs text-gray-500 tabular-nums dark:text-gray-400",
+        "col-start-2 row-start-3 flex text-xs text-gray-500 tabular-nums dark:text-gray-400",
         lastLabel ? "justify-between" : "justify-center",
       )}
     >
       <span>{firstLabel}</span>
+      {#if middleLabel}<span>{middleLabel}</span>{/if}
       {#if lastLabel}<span>{lastLabel}</span>{/if}
     </div>
   {/if}
-
-  <ul data-slot="line-chart-values" class="sr-only">
-    {#each data as point, index (index)}
-      <li>{point?.label}: {exactValue(point)}</li>
-    {/each}
-  </ul>
 </figure>

--- a/docs/klean-ui/sources/sparkline/Sparkline.jsx
+++ b/docs/klean-ui/sources/sparkline/Sparkline.jsx
@@ -1,0 +1,112 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const width = 120
+const height = 24
+const inset = 1.5
+
+function finiteValue(point) {
+  return Number.isFinite(point?.value) ? point.value : undefined
+}
+
+function geometry(data) {
+  const values = data.map(finiteValue).filter((value) => value !== undefined)
+  if (!values.length) return { segments: [], points: [] }
+
+  let minimum = Math.min(0, ...values)
+  let maximum = Math.max(0, ...values)
+  if (minimum === maximum) {
+    minimum -= 1
+    maximum += 1
+  }
+
+  const x = (index) =>
+    data.length === 1
+      ? width / 2
+      : inset + (index / (data.length - 1)) * (width - inset * 2)
+  const y = (value) =>
+    inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2)
+
+  const segments = []
+  const points = []
+  let segment = []
+
+  data.forEach((point, index) => {
+    const value = finiteValue(point)
+    if (value === undefined) {
+      if (segment.length) segments.push(segment)
+      segment = []
+      return
+    }
+
+    const coordinate = { x: x(index), y: y(value) }
+    points.push(coordinate)
+    segment.push(coordinate)
+  })
+  if (segment.length) segments.push(segment)
+
+  return { segments, points }
+}
+
+function coordinates(segment) {
+  return segment.map((point) => `${point.x},${point.y}`).join(' ')
+}
+
+const Sparkline = forwardRef(function Sparkline(
+  {
+    data = [],
+    label,
+    className,
+    role: _role,
+    'aria-label': _ariaLabel,
+    'aria-hidden': _ariaHidden,
+    'data-slot': _dataSlot,
+    ...props
+  },
+  ref
+) {
+  const chart = geometry(data)
+
+  return (
+    <svg
+      {...props}
+      ref={ref}
+      data-slot="sparkline"
+      role={label ? 'img' : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+      focusable="false"
+      viewBox="0 0 120 24"
+      preserveAspectRatio="none"
+      fill="none"
+      className={twMerge('h-6 w-30 overflow-visible', className)}
+    >
+      {chart.segments.map((segment, index) =>
+        segment.length > 1 ? (
+          <polyline
+            key={index}
+            data-slot="sparkline-line"
+            points={coordinates(segment)}
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        ) : (
+          <circle
+            key={index}
+            data-slot="sparkline-point"
+            cx={segment[0].x}
+            cy={segment[0].y}
+            r="1.75"
+            fill="currentColor"
+            vectorEffect="non-scaling-stroke"
+          />
+        )
+      )}
+    </svg>
+  )
+})
+
+export default Sparkline

--- a/docs/klean-ui/sources/sparkline/Sparkline.svelte
+++ b/docs/klean-ui/sources/sparkline/Sparkline.svelte
@@ -1,0 +1,105 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  let {
+    data = [],
+    label,
+    class: className,
+    role: _role,
+    "aria-label": _ariaLabel,
+    "aria-hidden": _ariaHidden,
+    "data-slot": _dataSlot,
+    ...props
+  } = $props();
+
+  const width = 120;
+  const height = 24;
+  const inset = 1.5;
+
+  function finiteValue(point) {
+    return Number.isFinite(point?.value) ? point.value : undefined;
+  }
+
+  function geometry(points) {
+    const values = points
+      .map(finiteValue)
+      .filter((value) => value !== undefined);
+    if (!values.length) return { segments: [], points: [] };
+
+    let minimum = Math.min(0, ...values);
+    let maximum = Math.max(0, ...values);
+    if (minimum === maximum) {
+      minimum -= 1;
+      maximum += 1;
+    }
+
+    const x = (index) =>
+      points.length === 1
+        ? width / 2
+        : inset + (index / (points.length - 1)) * (width - inset * 2);
+    const y = (value) =>
+      inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2);
+
+    const segments = [];
+    const chartPoints = [];
+    let segment = [];
+
+    points.forEach((point, index) => {
+      const value = finiteValue(point);
+      if (value === undefined) {
+        if (segment.length) segments.push(segment);
+        segment = [];
+        return;
+      }
+
+      const coordinate = { x: x(index), y: y(value) };
+      chartPoints.push(coordinate);
+      segment.push(coordinate);
+    });
+    if (segment.length) segments.push(segment);
+
+    return { segments, points: chartPoints };
+  }
+
+  function coordinates(segment) {
+    return segment.map((point) => `${point.x},${point.y}`).join(" ");
+  }
+
+  let chart = $derived(geometry(data));
+</script>
+
+<svg
+  {...props}
+  data-slot="sparkline"
+  role={label ? "img" : undefined}
+  aria-label={label}
+  aria-hidden={label ? undefined : "true"}
+  focusable="false"
+  viewBox="0 0 120 24"
+  preserveAspectRatio="none"
+  fill="none"
+  class={twMerge("h-6 w-30 overflow-visible", className)}
+>
+  {#each chart.segments as segment, index (index)}
+    {#if segment.length > 1}
+      <polyline
+        data-slot="sparkline-line"
+        points={coordinates(segment)}
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        vector-effect="non-scaling-stroke"
+      />
+    {:else}
+      <circle
+        data-slot="sparkline-point"
+        cx={segment[0].x}
+        cy={segment[0].y}
+        r="1.75"
+        fill="currentColor"
+        vector-effect="non-scaling-stroke"
+      />
+    {/if}
+  {/each}
+</svg>


### PR DESCRIPTION
Closes #216\n\nAdds the canonical Klean UI Sparkline and Line Chart documentation.\n\n- live isolated previews with exact point inspection\n- zero-configuration installation commands\n- copyable Vue, React, and Svelte usage and source\n- accessibility, responsive data-state, and Tailwind guidance\n- clear Line Chart versus Sparkline guidance and related components\n- Slipway and Hagfish adoption guidance\n- catalog and sidebar entries