### PR TITLE
docs(klean-ui): add FileUpload component page

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -132,6 +132,7 @@ function kleanUiGuide() {
         { text: 'Tabs', link: '/klean-ui/components/tabs' },
         { text: 'Table', link: '/klean-ui/components/table' },
         { text: 'DataTable', link: '/klean-ui/components/data-table' },
+        { text: 'FileUpload', link: '/klean-ui/components/file-upload' },
         { text: 'Sparkline', link: '/klean-ui/components/sparkline' },
         { text: 'Line Chart', link: '/klean-ui/components/line-chart' },
         { text: 'Pagination', link: '/klean-ui/components/pagination' },

--- a/docs/.vitepress/theme/components/klean/file-upload/FileUpload.vue
+++ b/docs/.vitepress/theme/components/klean/file-upload/FileUpload.vue
@@ -1,0 +1,238 @@
+<script setup>
+import { computed, onBeforeUnmount, ref, useAttrs, watch } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  accept: { type: String, default: undefined },
+  capture: { type: [String, Boolean], default: undefined },
+  disabled: { type: Boolean, default: false },
+  validate: { type: Function, default: () => true }
+})
+
+const emit = defineEmits(['change', 'reject'])
+const file = defineModel({ default: null })
+const attrs = useAttrs()
+const root = ref()
+const input = ref()
+const previewUrl = ref('')
+const dragging = ref(false)
+let dragDepth = 0
+let previewFile
+
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-dragging': _dataDragging,
+    'data-disabled': _dataDisabled,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function resetInput() {
+  if (input.value) input.value.value = ''
+}
+
+function revokePreview() {
+  if (previewUrl.value && typeof URL.revokeObjectURL === 'function') {
+    URL.revokeObjectURL(previewUrl.value)
+  }
+  previewUrl.value = ''
+  previewFile = undefined
+}
+
+function syncPreview(candidate) {
+  if (Object.is(candidate, previewFile)) return
+  revokePreview()
+  previewFile = candidate
+
+  if (
+    candidate &&
+    typeof Blob !== 'undefined' &&
+    candidate instanceof Blob &&
+    typeof URL.createObjectURL === 'function'
+  ) {
+    previewUrl.value = URL.createObjectURL(candidate)
+  }
+}
+
+function acceptedByAttribute(candidate) {
+  const rules = props.accept
+    ?.split(',')
+    .map((rule) => rule.trim().toLowerCase())
+    .filter(Boolean)
+  if (!rules?.length) return true
+
+  const type = candidate.type?.toLowerCase() ?? ''
+  const name = candidate.name?.toLowerCase() ?? ''
+  return rules.some((rule) => {
+    if (rule.startsWith('.')) return name.endsWith(rule)
+    if (rule.endsWith('/*')) return type.startsWith(rule.slice(0, -1))
+    return type === rule
+  })
+}
+
+function reject(candidate, reason, message, files = undefined) {
+  const detail = { file: candidate ?? null, reason, message }
+  if (files) detail.files = files
+  emit('reject', detail)
+  resetInput()
+  return false
+}
+
+function setFile(candidate) {
+  file.value = candidate
+  emit('change', candidate)
+  resetInput()
+  return true
+}
+
+function select(files) {
+  if (props.disabled) return false
+  const candidates = Array.from(files ?? [])
+  if (!candidates.length) return false
+  if (candidates.length > 1) {
+    return reject(
+      candidates[0],
+      'multiple',
+      'Choose one file at a time.',
+      candidates
+    )
+  }
+
+  const candidate = candidates[0]
+  if (!acceptedByAttribute(candidate)) {
+    return reject(candidate, 'accept', 'That file type is not accepted.')
+  }
+
+  let result
+  try {
+    result = props.validate(candidate)
+  } catch {
+    return reject(candidate, 'validate', 'That file could not be validated.')
+  }
+
+  if (result !== true && result !== undefined) {
+    return reject(
+      candidate,
+      typeof result === 'object' && result?.reason ? result.reason : 'validate',
+      typeof result === 'string' && result
+        ? result
+        : typeof result === 'object' && result?.message
+          ? result.message
+          : 'That file is not valid.'
+    )
+  }
+
+  return setFile(candidate)
+}
+
+function choose() {
+  if (props.disabled || !input.value) return
+  resetInput()
+  if (typeof input.value.showPicker === 'function') {
+    try {
+      input.value.showPicker()
+      return
+    } catch {
+      // The native click path covers browsers that restrict showPicker().
+    }
+  }
+  input.value.click()
+}
+
+function clear() {
+  if (props.disabled) return
+  setFile(null)
+}
+
+function hasFiles(event) {
+  return Array.from(event.dataTransfer?.types ?? []).includes('Files')
+}
+
+function handleDragEnter(event) {
+  if (props.disabled || !hasFiles(event)) return
+  event.preventDefault()
+  dragDepth += 1
+  dragging.value = true
+}
+
+function handleDragOver(event) {
+  if (props.disabled || !hasFiles(event)) return
+  event.preventDefault()
+  if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+  dragging.value = true
+}
+
+function handleDragLeave(event) {
+  if (props.disabled || !hasFiles(event)) return
+  event.preventDefault()
+  dragDepth = Math.max(0, dragDepth - 1)
+  if (dragDepth === 0) dragging.value = false
+}
+
+function handleDrop(event) {
+  if (!hasFiles(event)) return
+  event.preventDefault()
+  dragDepth = 0
+  dragging.value = false
+  if (!props.disabled) select(event.dataTransfer?.files)
+}
+
+const dropzone = computed(() => ({
+  'data-dragging': dragging.value ? '' : undefined,
+  'data-disabled': props.disabled ? '' : undefined,
+  onDragenter: handleDragEnter,
+  onDragover: handleDragOver,
+  onDragleave: handleDragLeave,
+  onDrop: handleDrop
+}))
+
+watch(
+  file,
+  (candidate) => {
+    syncPreview(candidate)
+  },
+  { immediate: true, flush: 'sync' }
+)
+
+onBeforeUnmount(() => {
+  revokePreview()
+})
+
+defineExpose({ root, choose, clear })
+</script>
+
+<template>
+  <div
+    ref="root"
+    v-bind="rootAttrs"
+    data-slot="file-upload"
+    :data-state="file ? 'ready' : 'empty'"
+    :data-dragging="dragging ? '' : undefined"
+    :data-disabled="disabled ? '' : undefined"
+    :class="attrs.class"
+  >
+    <input
+      ref="input"
+      type="file"
+      hidden
+      data-part="input"
+      :accept="accept"
+      :capture="capture"
+      :disabled="disabled"
+      @change="select($event.currentTarget.files)"
+    />
+    <slot
+      :file="file"
+      :preview-url="previewUrl"
+      :dragging="dragging"
+      :choose="choose"
+      :clear="clear"
+      :dropzone="dropzone"
+    />
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/klean/file-upload/FileUploadRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/file-upload/FileUploadRecipes.vue
@@ -1,0 +1,271 @@
+<script setup>
+import { ref, shallowRef } from 'vue'
+import FileUpload from './FileUpload.vue'
+
+defineProps({ recipe: { type: String, default: 'basic' } })
+
+const basicFile = shallowRef(null)
+const basicError = ref('')
+const logo = shallowRef(null)
+const removeCurrentLogo = ref(false)
+const receipt = shallowRef(null)
+const receiptError = ref('')
+
+const portraitMarkup = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <rect width="160" height="160" fill="#dbeafe"/>
+  <circle cx="80" cy="69" r="35" fill="#70412f"/>
+  <path d="M35 160c4-34 20-53 45-53s41 19 45 53" fill="#172554"/>
+  <path d="M47 66c0-31 15-47 34-47 24 0 36 17 34 49-8-3-15-9-20-18-13 12-28 18-48 16Z" fill="#0a0a0a"/>
+  <circle cx="68" cy="72" r="3" fill="#111827"/>
+  <circle cx="93" cy="72" r="3" fill="#111827"/>
+  <path d="M70 89c8 6 16 6 23 0" fill="none" stroke="#4c291f" stroke-width="3" stroke-linecap="round"/>
+</svg>`
+const currentLogoUrl = `data:image/svg+xml,${encodeURIComponent(portraitMarkup)}`
+
+function formatSize(size) {
+  if (size < 1024) return `${size} B`
+  return `${(size / 1024).toFixed(1)} KB`
+}
+
+function validateBasic(candidate) {
+  return candidate.size <= 2 * 1024 * 1024 ? true : 'Choose a file under 2 MB.'
+}
+
+function validateReceipt(candidate) {
+  return candidate.size <= 5 * 1024 * 1024
+    ? true
+    : 'Receipts must be 5 MB or smaller.'
+}
+</script>
+
+<template>
+  <FileUpload
+    v-if="recipe === 'basic'"
+    v-model="basicFile"
+    accept="image/png,image/jpeg,.pdf"
+    :validate="validateBasic"
+    @change="basicError = ''"
+    @reject="basicError = $event.message"
+    v-slot="upload"
+    class="mx-auto w-full max-w-xl"
+  >
+    <div
+      v-bind="upload.dropzone"
+      :class="[
+        'rounded-2xl border border-dashed bg-white p-6 text-center shadow-sm transition-colors duration-150 dark:bg-gray-950 motion-reduce:transition-none sm:p-8',
+        upload.dragging
+          ? 'border-gray-950 bg-gray-50 dark:border-white dark:bg-gray-900'
+          : 'border-gray-300 dark:border-gray-700'
+      ]"
+    >
+      <div
+        class="mx-auto grid size-12 place-items-center rounded-xl bg-gray-100 text-gray-700 dark:bg-gray-900 dark:text-gray-200"
+      >
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          class="size-6"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path
+            d="M12 16V4m0 0L7.5 8.5M12 4l4.5 4.5M5 15v3.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V15"
+          />
+        </svg>
+      </div>
+      <h3 class="mt-4 text-lg font-semibold tracking-tight">
+        {{ upload.file ? 'Ready to upload' : 'Add a file' }}
+      </h3>
+      <p class="mt-2 text-sm leading-6 text-gray-500 dark:text-gray-400">
+        Drop one file here, or use the native picker.
+      </p>
+      <button
+        type="button"
+        class="mt-5 inline-flex min-h-11 cursor-pointer items-center justify-center rounded-lg bg-gray-950 px-4 text-sm font-medium text-white no-underline outline-none hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
+        @click="upload.choose"
+      >
+        {{ upload.file ? 'Replace file' : 'Choose file' }}
+      </button>
+
+      <div
+        v-if="upload.file"
+        class="mt-6 flex items-center gap-3 rounded-xl bg-gray-50 p-3 text-left dark:bg-gray-900"
+      >
+        <div
+          class="grid size-10 shrink-0 place-items-center rounded-lg bg-white text-gray-500 shadow-sm dark:bg-gray-950 dark:text-gray-400"
+        >
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            class="size-5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.75"
+          >
+            <path d="M7 3.75h7l3 3V20.25H7z" />
+            <path d="M14 3.75v3h3" />
+          </svg>
+        </div>
+        <div class="min-w-0 flex-1">
+          <p class="m-0 truncate text-sm font-medium">{{ upload.file.name }}</p>
+          <p class="m-0 mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            {{ formatSize(upload.file.size) }}
+          </p>
+        </div>
+        <button
+          type="button"
+          class="min-h-10 cursor-pointer rounded-lg px-3 text-sm text-gray-600 no-underline hover:bg-gray-200 hover:text-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white dark:focus-visible:outline-white"
+          @click="upload.clear"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+    <p
+      v-if="basicError"
+      role="alert"
+      class="mt-3 text-sm text-red-700 dark:text-red-400"
+    >
+      {{ basicError }}
+    </p>
+  </FileUpload>
+
+  <FileUpload
+    v-else-if="recipe === 'logo'"
+    v-model="logo"
+    accept="image/*"
+    v-slot="upload"
+  >
+    <div
+      class="mx-auto max-w-md border-2 border-black bg-[#f7f3eb] p-5 text-gray-950 shadow-[6px_6px_0_0_#000] sm:p-6"
+    >
+      <h3 class="m-0 text-xl font-semibold">Business logo</h3>
+      <p class="m-0 mt-2 text-sm leading-6 text-gray-600">
+        Shown on every invoice.
+      </p>
+      <div class="mt-6 flex items-center gap-4">
+        <div
+          class="grid size-20 shrink-0 place-items-center overflow-hidden rounded-xl border-2 border-black bg-white"
+        >
+          <img
+            v-if="upload.previewUrl || !removeCurrentLogo"
+            :src="upload.previewUrl || currentLogoUrl"
+            alt="Current business logo"
+            class="size-full object-cover"
+          />
+          <span v-else class="text-xl font-semibold">HF</span>
+        </div>
+        <div class="min-w-0">
+          <p class="m-0 truncate text-sm font-medium">
+            {{
+              upload.file?.name ||
+              (!removeCurrentLogo ? 'hagfish-studio.png' : 'No logo selected')
+            }}
+          </p>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              class="min-h-10 cursor-pointer border-2 border-black bg-black px-3 text-sm font-medium text-white no-underline hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
+              @click="upload.choose"
+            >
+              {{
+                upload.file || !removeCurrentLogo ? 'Replace' : 'Choose logo'
+              }}
+            </button>
+            <button
+              v-if="upload.file || !removeCurrentLogo"
+              type="button"
+              class="min-h-10 cursor-pointer border-2 border-black bg-white px-3 text-sm font-medium no-underline hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
+              @click="upload.file ? upload.clear() : (removeCurrentLogo = true)"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </FileUpload>
+
+  <FileUpload
+    v-else
+    v-model="receipt"
+    accept="image/jpeg,image/png,.pdf"
+    capture="environment"
+    :validate="validateReceipt"
+    @change="receiptError = ''"
+    @reject="receiptError = $event.message"
+    v-slot="upload"
+  >
+    <div
+      class="mx-auto max-w-xl border-2 border-black bg-[#f7f3eb] p-5 text-gray-950 shadow-[6px_6px_0_0_#000] sm:p-6"
+    >
+      <h3 class="m-0 text-xl font-semibold">Expense receipt</h3>
+      <p class="m-0 mt-2 text-sm leading-6 text-gray-600">
+        JPG, PNG, or PDF. Up to 5 MB.
+      </p>
+      <div
+        v-bind="upload.dropzone"
+        :class="[
+          'mt-6 border-2 border-dashed p-5 transition-colors duration-150 motion-reduce:transition-none',
+          upload.dragging
+            ? 'border-black bg-amber-50'
+            : 'border-gray-400 bg-white'
+        ]"
+      >
+        <div v-if="upload.file" class="flex items-center gap-4">
+          <img
+            v-if="upload.file.type.startsWith('image/')"
+            :src="upload.previewUrl"
+            alt="Selected receipt preview"
+            class="size-20 shrink-0 border-2 border-black object-cover"
+          />
+          <div
+            v-else
+            class="grid size-20 shrink-0 place-items-center border-2 border-black bg-white font-mono text-sm font-semibold"
+          >
+            PDF
+          </div>
+          <div class="min-w-0 flex-1">
+            <p class="m-0 truncate font-medium">{{ upload.file.name }}</p>
+            <p class="m-0 mt-1 text-sm text-gray-600">
+              {{ formatSize(upload.file.size) }}
+            </p>
+          </div>
+        </div>
+        <div v-else class="py-4 text-center">
+          <p class="m-0 font-medium">Drop a receipt here</p>
+          <p class="m-0 mt-1 text-sm text-gray-600">
+            The choose button remains the keyboard path.
+          </p>
+        </div>
+        <div class="mt-5 flex flex-wrap justify-center gap-2">
+          <button
+            type="button"
+            class="min-h-10 cursor-pointer border-2 border-black bg-black px-4 text-sm font-medium text-white no-underline hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
+            @click="upload.choose"
+          >
+            {{ upload.file ? 'Replace receipt' : 'Choose receipt' }}
+          </button>
+          <button
+            v-if="upload.file"
+            type="button"
+            class="min-h-10 cursor-pointer border-2 border-black bg-white px-4 text-sm font-medium no-underline hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
+            @click="upload.clear"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+      <p
+        v-if="receiptError"
+        role="alert"
+        class="m-0 mt-3 text-sm font-medium text-red-700"
+      >
+        {{ receiptError }}
+      </p>
+    </div>
+  </FileUpload>
+</template>

--- a/docs/klean-ui/components/file-upload.md
+++ b/docs/klean-ui/components/file-upload.md
@@ -1,0 +1,198 @@
+---
+title: FileUpload
+titleTemplate: Klean UI
+description: One native file-selection bridge with honest validation, previews, drop behavior, and caller-owned Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import FileUploadRecipes from '../../.vitepress/theme/components/klean/file-upload/FileUploadRecipes.vue'
+import fileUploadSource from '../../.vitepress/theme/components/klean/file-upload/FileUpload.vue?raw'
+import reactSource from '../sources/file-upload/FileUpload.jsx?raw'
+import svelteSource from '../sources/file-upload/FileUpload.svelte?raw'
+import vueUsage from '../snippets/file-upload/usage.vue?raw'
+import reactUsage from '../snippets/file-upload/usage.jsx?raw'
+import svelteUsage from '../snippets/file-upload/usage.svelte?raw'
+import logoSource from '../snippets/file-upload/logo.vue?raw'
+import receiptSource from '../snippets/file-upload/receipt.vue?raw'
+</script>
+
+# FileUpload
+
+FileUpload turns one native file picker into calm application state. It chooses or drops one file, keeps the last accepted value when a candidate is rejected, supplies a temporary preview URL, and cleans that preview up when it is replaced or removed.
+
+The application writes every visible element: the real choose button, drop surface, filename, preview, remove action, error, and Tailwind classes. It also owns the eventual upload request. There is no visual variant, upload runtime, anatomy package, or hidden storage decision.
+
+<KleanPreview id="file-upload-basic" :source="vueUsage" filename="ReceiptField.vue">
+  <template #preview>
+    <FileUploadRecipes />
+  </template>
+  <template #caption>
+    Browse and drop feed the same one-file contract. The visible button remains the keyboard and screen-reader path.
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and writes the matching one-file source into the conventional component directory:
+
+<KleanInstallation
+  id="file-upload-installation"
+  component="file-upload"
+  :source="fileUploadSource"
+  filename="FileUpload.vue"
+  destination="assets/js/components/ui/file-upload/FileUpload.vue"
+/>
+
+There is no provider, initializer, `klean-ui.json`, upload SDK, class helper, barrel file, or Klean runtime dependency.
+
+## Usage
+
+The framework-native binding contains a `File` or `null`. The content slot or render function receives the same small API in each framework.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="ReceiptField.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="ReceiptField.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="ReceiptField.svelte" />
+
+## API
+
+### Inputs and events
+
+| Input or event           | Default | Purpose                                                                                                       |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------- |
+| bound file               | `null`  | Vue `v-model`, React `value`/`onChange`, or Svelte `bind:file`; the selected `File` is the application truth. |
+| `accept`                 | —       | Native accept expression, also checked for dropped files: MIME types, wildcards such as `image/*`, or `.ext`. |
+| `capture`                | —       | Native mobile capture hint such as `environment`.                                                             |
+| `disabled`               | `false` | Prevents browse, drop, replace, and clear.                                                                    |
+| `validate(file)`         | accept  | Returns `true`/`undefined` to accept, a message to reject, or `{ reason, message }` for a named policy.       |
+| `change` / `onChange`    | —       | Receives the accepted `File` or `null` after clear.                                                           |
+| `reject` / `onReject`    | —       | Receives `{ file, reason, message }`; a multiple drop also includes `files`.                                  |
+| `class` / `className`    | —       | Ordinary classes on the neutral FileUpload root.                                                              |
+| native/global attributes | —       | IDs, titles, data hooks, and accessible relationships for the root.                                           |
+
+### Content API
+
+| Value        | Purpose                                                                                                               |
+| ------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `file`       | The current accepted `File` or `null`.                                                                                |
+| `previewUrl` | A temporary local URL for the current file. Render it only in an element appropriate for the file type.               |
+| `dragging`   | Whether a file drag is currently over the bound drop surface.                                                         |
+| `choose()`   | Opens the platform file picker. Call it from a real visible button.                                                   |
+| `clear()`    | Returns the bound file to `null` and releases its preview.                                                            |
+| `dropzone`   | Additive drag/drop event and data bindings for an ordinary caller-owned element. It does not invent button semantics. |
+
+There is deliberately no `variant`, `multiple`, `maxSize`, `upload`, `progress`, `retry`, `endpoint`, `existingUrl`, or preview-kind prop. Validation and visible presentation are clearer where the product rule is written.
+
+## Browse and drop are one path
+
+`accept` affects the platform picker and is also checked when a file is dropped. A drop of several files is rejected instead of silently choosing one. A rejected candidate never destroys the current accepted file.
+
+Drop remains additive. The drop surface is not given a button role or tab stop because a real visible button already invokes `choose()`. Users who cannot or do not drag receive the same capability with native keyboard activation and an honest accessible name.
+
+Client checks are convenience, not trust. MIME metadata and filenames can be wrong. Repeat file type, size, authorization, and content checks on the server before storing or serving an upload.
+
+## Native form boundary
+
+FileUpload resets its internal picker after selection so choosing the same file again is observable. The bound `File` is therefore the source of truth and the application builds the multipart request explicitly.
+
+That is why FileUpload does not accept `name`, `form`, or `required`: those props would falsely imply that the browser submits the hidden picker for you. Keep required validation next to the rest of the form state. Use [Input](/klean-ui/components/input) with `type="file"` when ordinary native form serialization—not a custom preview or drop experience—is the actual requirement.
+
+Upload progress, cancellation, retry, scanning, storage, and server errors also belong to the request layer. Compose [Spinner](/klean-ui/components/spinner), [Alert](/klean-ui/components/alert), and a real status region around FileUpload when those states exist.
+
+## Hagfish business logo
+
+The persisted logo remains server-owned. FileUpload owns only the new local candidate; the wrapper decides whether “Remove” clears that candidate or requests deletion of the current server asset.
+
+<KleanPreview id="file-upload-logo" :source="logoSource" filename="BusinessLogoField.vue">
+  <template #preview>
+    <FileUploadRecipes recipe="logo" />
+  </template>
+  <template #caption>
+    Existing remote state and a new local File are different truths. The recipe keeps that distinction visible.
+  </template>
+</KleanPreview>
+
+The square tile, initials, remote fallback, border, and actions are ordinary markup. Avatar is not used here because an invoice logo is editable content, not compact person-or-team identity.
+
+## Hagfish receipt
+
+The receipt flow accepts camera-friendly images and PDF documents, validates the product size limit, previews only images, and leaves multipart submission to the expense form.
+
+<KleanPreview id="file-upload-receipt" :source="receiptSource" filename="ReceiptField.vue">
+  <template #preview>
+    <FileUploadRecipes recipe="receipt" />
+  </template>
+  <template #caption>
+    Image preview, PDF metadata, replace, remove, drop, and rejection all come from one bound File without product props in FileUpload.
+  </template>
+</KleanPreview>
+
+`capture="environment"` is a hint to capable mobile browsers, not a requirement to open the camera. The ordinary picker remains available when the browser or device ignores it.
+
+## Durable behavior
+
+An unsubmitted local `File` cannot be reconstructed after refresh, Back/Forward restoration, SSR, or on another device. FileUpload does not pretend otherwise. On refresh, show the server-owned current asset or ask the user to select the file again.
+
+Form drafts may safely remember application metadata such as “a receipt still needs to be reselected,” but must not persist a temporary preview URL or fake a file handle. When a candidate is replaced, cleared, externally changed, or its owner unmounts, its temporary preview is released.
+
+Persisted assets become durable only after the server accepts them and returns authoritative record data or a URL. Navigation and rollback should then use that server truth.
+
+## Accessibility
+
+- Always provide a real visible `button type="button"` for `choose()`; drag and drop is never the only path.
+- Name the button for the action and context: “Choose receipt,” “Replace business logo,” or equivalent visible text.
+- Keep rejection text visible and use `role="alert"` when it appears as the immediate result of the user's choice.
+- Give image previews useful alt text such as “Selected receipt preview.” Do not use an image element for PDFs or unknown file types.
+- Include filename and size as text. Do not rely on a thumbnail, color, or icon alone.
+- Keep disabled styling and behavior aligned on the visible controls and FileUpload.
+- Preserve visible focus and at least a 44-pixel target on choose, replace, and remove buttons.
+- Motion for drag feedback is optional and must respect reduced-motion preferences.
+
+## Styling with Tailwind
+
+FileUpload renders no opinionated visible surface. Style the application markup directly: a quiet rounded dropzone, a compact logo tile, a Hagfish border and shadow, or a dense receipt row are all Tailwind recipes.
+
+When one product repeats the same treatment, keep a small product wrapper such as `ReceiptField.vue`. That wrapper may own copy and policy without turning them into global Klean variants.
+
+## When not to use
+
+- Use [Input](/klean-ui/components/input) with `type="file"` for an ordinary native file field submitted by its form.
+- Use [Avatar](/klean-ui/components/avatar) to render resilient identity, not to select or upload its source.
+- Use a dedicated evidenced component for multiple-file queues, reorderable galleries, image cropping, or resumable uploads.
+- Keep upload transport, storage SDKs, antivirus scanning, and server validation outside FileUpload.
+- Do not persist `File`, blob URLs, or client MIME metadata as durable truth.
+
+## Complete framework source
+
+Copy, inspect, and change the complete one-file source for your framework.
+
+### Vue source
+
+<CopyCode :code="fileUploadSource" label="FileUpload.vue" />
+
+### React source
+
+<CopyCode :code="reactSource" label="FileUpload.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteSource" label="FileUpload.svelte" />
+
+## Related components
+
+- [Button](/klean-ui/components/button) — provides the real visible browse, replace, and remove actions.
+- [Input](/klean-ui/components/input) — handles an ordinary native `type="file"` field when custom orchestration is unnecessary.
+- [Avatar](/klean-ui/components/avatar) — renders identity after the application has a persisted image source.
+- [Alert](/klean-ui/components/alert) — presents recoverable upload or server-validation failures.
+- [Spinner](/klean-ui/components/spinner) — supplements visible pending upload status.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -81,6 +81,10 @@ A native table with a neutral baseline, caller-written captions, sections, heade
 
 A durable server-driven table block with one native table, page-scoped selection, clean Inertia URL queries, truthful pending state, and caller-owned application markup.
 
+### [FileUpload](/klean-ui/components/file-upload)
+
+One native file-selection bridge with honest validation, previews, drop behavior, and caller-owned upload markup.
+
 ### [Sparkline](/klean-ui/components/sparkline)
 
 A compact trend beside an exact value, with truthful decorative defaults, honest missing-data gaps, and caller-owned Tailwind styling.

--- a/docs/klean-ui/snippets/file-upload/logo.vue
+++ b/docs/klean-ui/snippets/file-upload/logo.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { ref, shallowRef } from 'vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
+
+const props = defineProps({ currentLogoUrl: String })
+const logo = shallowRef(null)
+const removeCurrent = ref(false)
+</script>
+
+<template>
+  <FileUpload v-model="logo" accept="image/*" v-slot="upload">
+    <div class="flex items-center gap-4">
+      <div class="size-20 overflow-hidden rounded-xl border-2 border-black">
+        <img
+          v-if="upload.previewUrl || (!removeCurrent && currentLogoUrl)"
+          :src="upload.previewUrl || currentLogoUrl"
+          alt="Current business logo"
+          class="size-full object-cover"
+        />
+        <span v-else class="grid size-full place-items-center">HF</span>
+      </div>
+      <div>
+        <button type="button" @click="upload.choose">
+          {{ upload.file || currentLogoUrl ? 'Replace' : 'Choose logo' }}
+        </button>
+        <button
+          v-if="upload.file || (!removeCurrent && currentLogoUrl)"
+          type="button"
+          @click="upload.file ? upload.clear() : (removeCurrent = true)"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  </FileUpload>
+</template>

--- a/docs/klean-ui/snippets/file-upload/receipt.vue
+++ b/docs/klean-ui/snippets/file-upload/receipt.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { ref, shallowRef } from 'vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
+
+const receipt = shallowRef(null)
+const error = ref('')
+
+function validateReceipt(candidate) {
+  return candidate.size <= 5 * 1024 * 1024
+    ? true
+    : 'Receipts must be 5 MB or smaller.'
+}
+</script>
+
+<template>
+  <FileUpload
+    v-model="receipt"
+    accept="image/jpeg,image/png,.pdf"
+    capture="environment"
+    :validate="validateReceipt"
+    @change="error = ''"
+    @reject="error = $event.message"
+    v-slot="upload"
+  >
+    <div v-bind="upload.dropzone" class="border-2 border-dashed p-5">
+      <img
+        v-if="upload.file?.type.startsWith('image/')"
+        :src="upload.previewUrl"
+        alt="Selected receipt preview"
+      />
+      <p v-else>{{ upload.file?.name || 'Drop a receipt here' }}</p>
+      <button type="button" @click="upload.choose">
+        {{ upload.file ? 'Replace receipt' : 'Choose receipt' }}
+      </button>
+      <button v-if="upload.file" type="button" @click="upload.clear">
+        Remove
+      </button>
+    </div>
+    <p v-if="error" role="alert">{{ error }}</p>
+  </FileUpload>
+</template>

--- a/docs/klean-ui/snippets/file-upload/usage.jsx
+++ b/docs/klean-ui/snippets/file-upload/usage.jsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import FileUpload from '@/components/ui/file-upload/FileUpload.jsx'
+
+export default function ReceiptField() {
+  const [file, setFile] = useState(null)
+  const [error, setError] = useState('')
+
+  return (
+    <FileUpload
+      value={file}
+      onChange={(candidate) => {
+        setFile(candidate)
+        setError('')
+      }}
+      onReject={(detail) => setError(detail.message)}
+      accept="image/png,image/jpeg,.pdf"
+      validate={(candidate) =>
+        candidate.size <= 2 * 1024 * 1024 || 'Choose a file under 2 MB.'
+      }
+    >
+      {(upload) => (
+        <>
+          <div
+            {...upload.dropzone}
+            className={`rounded-xl border border-dashed p-6 ${
+              upload.dragging ? 'border-gray-950 bg-gray-50' : 'border-gray-300'
+            }`}
+          >
+            <p>{upload.file?.name || 'Drop one file here'}</p>
+            <button type="button" onClick={upload.choose}>
+              {upload.file ? 'Replace file' : 'Choose file'}
+            </button>
+            {upload.file ? (
+              <button type="button" onClick={upload.clear}>
+                Remove
+              </button>
+            ) : null}
+          </div>
+          {error ? <p role="alert">{error}</p> : null}
+        </>
+      )}
+    </FileUpload>
+  )
+}

--- a/docs/klean-ui/snippets/file-upload/usage.svelte
+++ b/docs/klean-ui/snippets/file-upload/usage.svelte
@@ -1,0 +1,33 @@
+<script>
+  import FileUpload from '$lib/components/ui/file-upload/FileUpload.svelte'
+
+  let file = $state(null)
+  let error = $state('')
+</script>
+
+<FileUpload
+  bind:file
+  accept="image/png,image/jpeg,.pdf"
+  validate={(candidate) =>
+    candidate.size <= 2 * 1024 * 1024 || 'Choose a file under 2 MB.'}
+  onchange={() => (error = '')}
+  onreject={(detail) => (error = detail.message)}
+>
+  {#snippet children(upload)}
+    <div
+      {...upload.dropzone}
+      class={`rounded-xl border border-dashed p-6 ${
+        upload.dragging ? 'border-gray-950 bg-gray-50' : 'border-gray-300'
+      }`}
+    >
+      <p>{upload.file?.name || 'Drop one file here'}</p>
+      <button type="button" onclick={upload.choose}>
+        {upload.file ? 'Replace file' : 'Choose file'}
+      </button>
+      {#if upload.file}
+        <button type="button" onclick={upload.clear}>Remove</button>
+      {/if}
+    </div>
+    {#if error}<p role="alert">{error}</p>{/if}
+  {/snippet}
+</FileUpload>

--- a/docs/klean-ui/snippets/file-upload/usage.vue
+++ b/docs/klean-ui/snippets/file-upload/usage.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { ref, shallowRef } from 'vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
+
+const file = shallowRef(null)
+const error = ref('')
+
+function validate(candidate) {
+  return candidate.size <= 2 * 1024 * 1024 ? true : 'Choose a file under 2 MB.'
+}
+</script>
+
+<template>
+  <FileUpload
+    v-model="file"
+    accept="image/png,image/jpeg,.pdf"
+    :validate="validate"
+    @change="error = ''"
+    @reject="error = $event.message"
+    v-slot="upload"
+  >
+    <div
+      v-bind="upload.dropzone"
+      :class="[
+        'rounded-xl border border-dashed p-6',
+        upload.dragging ? 'border-gray-950 bg-gray-50' : 'border-gray-300'
+      ]"
+    >
+      <p>{{ upload.file?.name || 'Drop one file here' }}</p>
+      <button type="button" @click="upload.choose">
+        {{ upload.file ? 'Replace file' : 'Choose file' }}
+      </button>
+      <button v-if="upload.file" type="button" @click="upload.clear">
+        Remove
+      </button>
+    </div>
+    <p v-if="error" role="alert">{{ error }}</p>
+  </FileUpload>
+</template>

--- a/docs/klean-ui/sources/file-upload/FileUpload.jsx
+++ b/docs/klean-ui/sources/file-upload/FileUpload.jsx
@@ -1,0 +1,253 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react'
+
+function acceptedByAttribute(file, accept) {
+  const rules = accept
+    ?.split(',')
+    .map((rule) => rule.trim().toLowerCase())
+    .filter(Boolean)
+  if (!rules?.length) return true
+
+  const type = file.type?.toLowerCase() ?? ''
+  const name = file.name?.toLowerCase() ?? ''
+  return rules.some((rule) => {
+    if (rule.startsWith('.')) return name.endsWith(rule)
+    if (rule.endsWith('/*')) return type.startsWith(rule.slice(0, -1))
+    return type === rule
+  })
+}
+
+const FileUpload = forwardRef(function FileUpload(
+  {
+    value,
+    defaultValue = null,
+    onChange,
+    onReject,
+    accept,
+    capture,
+    disabled = false,
+    validate = () => true,
+    className,
+    children,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-dragging': _dataDragging,
+    'data-disabled': _dataDisabled,
+    ...props
+  },
+  forwardedRef
+) {
+  const rootRef = useRef(null)
+  const inputRef = useRef(null)
+  const dragDepth = useRef(0)
+  const controlled = value !== undefined
+  const [localFile, setLocalFile] = useState(defaultValue)
+  const [previewUrl, setPreviewUrl] = useState('')
+  const [dragging, setDragging] = useState(false)
+  const file = controlled ? value : localFile
+
+  const resetInput = useCallback(() => {
+    if (inputRef.current) inputRef.current.value = ''
+  }, [])
+
+  const setFile = useCallback(
+    (candidate) => {
+      if (!controlled) setLocalFile(candidate)
+      onChange?.(candidate)
+      resetInput()
+      return true
+    },
+    [controlled, onChange, resetInput]
+  )
+
+  const reject = useCallback(
+    (candidate, reason, message, files) => {
+      const detail = { file: candidate ?? null, reason, message }
+      if (files) detail.files = files
+      onReject?.(detail)
+      resetInput()
+      return false
+    },
+    [onReject, resetInput]
+  )
+
+  const select = useCallback(
+    (files) => {
+      if (disabled) return false
+      const candidates = Array.from(files ?? [])
+      if (!candidates.length) return false
+      if (candidates.length > 1) {
+        return reject(
+          candidates[0],
+          'multiple',
+          'Choose one file at a time.',
+          candidates
+        )
+      }
+
+      const candidate = candidates[0]
+      if (!acceptedByAttribute(candidate, accept)) {
+        return reject(candidate, 'accept', 'That file type is not accepted.')
+      }
+
+      let result
+      try {
+        result = validate(candidate)
+      } catch {
+        return reject(
+          candidate,
+          'validate',
+          'That file could not be validated.'
+        )
+      }
+
+      if (result !== true && result !== undefined) {
+        return reject(
+          candidate,
+          typeof result === 'object' && result?.reason
+            ? result.reason
+            : 'validate',
+          typeof result === 'string' && result
+            ? result
+            : typeof result === 'object' && result?.message
+              ? result.message
+              : 'That file is not valid.'
+        )
+      }
+
+      return setFile(candidate)
+    },
+    [accept, disabled, reject, setFile, validate]
+  )
+
+  const choose = useCallback(() => {
+    const input = inputRef.current
+    if (disabled || !input) return
+    resetInput()
+    if (typeof input.showPicker === 'function') {
+      try {
+        input.showPicker()
+        return
+      } catch {
+        // The native click path covers browsers that restrict showPicker().
+      }
+    }
+    input.click()
+  }, [disabled, resetInput])
+
+  const clear = useCallback(() => {
+    if (!disabled) setFile(null)
+  }, [disabled, setFile])
+
+  function hasFiles(event) {
+    return Array.from(event.dataTransfer?.types ?? []).includes('Files')
+  }
+
+  function handleDragEnter(event) {
+    if (disabled || !hasFiles(event)) return
+    event.preventDefault()
+    dragDepth.current += 1
+    setDragging(true)
+  }
+
+  function handleDragOver(event) {
+    if (disabled || !hasFiles(event)) return
+    event.preventDefault()
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+    setDragging(true)
+  }
+
+  function handleDragLeave(event) {
+    if (disabled || !hasFiles(event)) return
+    event.preventDefault()
+    dragDepth.current = Math.max(0, dragDepth.current - 1)
+    if (dragDepth.current === 0) setDragging(false)
+  }
+
+  function handleDrop(event) {
+    if (!hasFiles(event)) return
+    event.preventDefault()
+    dragDepth.current = 0
+    setDragging(false)
+    if (!disabled) select(event.dataTransfer?.files)
+  }
+
+  useEffect(() => {
+    if (
+      !file ||
+      typeof Blob === 'undefined' ||
+      !(file instanceof Blob) ||
+      typeof URL.createObjectURL !== 'function'
+    ) {
+      setPreviewUrl('')
+      return undefined
+    }
+
+    const url = URL.createObjectURL(file)
+    setPreviewUrl(url)
+    return () => URL.revokeObjectURL?.(url)
+  }, [file])
+
+  const dropzone = {
+    'data-dragging': dragging ? '' : undefined,
+    'data-disabled': disabled ? '' : undefined,
+    onDragEnter: handleDragEnter,
+    onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop
+  }
+  const api = {
+    get file() {
+      return file
+    },
+    get previewUrl() {
+      return previewUrl
+    },
+    get dragging() {
+      return dragging
+    },
+    choose,
+    clear,
+    get dropzone() {
+      return dropzone
+    }
+  }
+
+  useImperativeHandle(forwardedRef, () => ({
+    root: rootRef.current,
+    choose,
+    clear
+  }))
+
+  return (
+    <div
+      {...props}
+      ref={rootRef}
+      data-slot="file-upload"
+      data-state={file ? 'ready' : 'empty'}
+      data-dragging={dragging ? '' : undefined}
+      data-disabled={disabled ? '' : undefined}
+      className={className}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        hidden
+        data-part="input"
+        accept={accept}
+        capture={capture}
+        disabled={disabled}
+        onChange={(event) => select(event.currentTarget.files)}
+      />
+      {typeof children === 'function' ? children(api) : children}
+    </div>
+  )
+})
+
+export default FileUpload

--- a/docs/klean-ui/sources/file-upload/FileUpload.svelte
+++ b/docs/klean-ui/sources/file-upload/FileUpload.svelte
@@ -1,0 +1,221 @@
+<script>
+  let {
+    file = $bindable(null),
+    onchange,
+    onreject,
+    accept,
+    capture,
+    disabled = false,
+    validate = () => true,
+    class: className,
+    children,
+    "data-slot": _dataSlot,
+    "data-state": _dataState,
+    "data-dragging": _dataDragging,
+    "data-disabled": _dataDisabled,
+    ...props
+  } = $props();
+
+  let root = $state();
+  let input = $state();
+  let previewUrl = $state("");
+  let dragging = $state(false);
+  let dragDepth = 0;
+
+  function resetInput() {
+    if (input) input.value = "";
+  }
+
+  function acceptedByAttribute(candidate) {
+    const rules = accept
+      ?.split(",")
+      .map((rule) => rule.trim().toLowerCase())
+      .filter(Boolean);
+    if (!rules?.length) return true;
+
+    const type = candidate.type?.toLowerCase() ?? "";
+    const filename = candidate.name?.toLowerCase() ?? "";
+    return rules.some((rule) => {
+      if (rule.startsWith(".")) return filename.endsWith(rule);
+      if (rule.endsWith("/*")) return type.startsWith(rule.slice(0, -1));
+      return type === rule;
+    });
+  }
+
+  function reject(candidate, reason, message, files = undefined) {
+    const detail = { file: candidate ?? null, reason, message };
+    if (files) detail.files = files;
+    onreject?.(detail);
+    resetInput();
+    return false;
+  }
+
+  function setFile(candidate) {
+    file = candidate;
+    onchange?.(candidate);
+    resetInput();
+    return true;
+  }
+
+  function select(files) {
+    if (disabled) return false;
+    const candidates = Array.from(files ?? []);
+    if (!candidates.length) return false;
+    if (candidates.length > 1) {
+      return reject(
+        candidates[0],
+        "multiple",
+        "Choose one file at a time.",
+        candidates,
+      );
+    }
+
+    const candidate = candidates[0];
+    if (!acceptedByAttribute(candidate)) {
+      return reject(candidate, "accept", "That file type is not accepted.");
+    }
+
+    let result;
+    try {
+      result = validate(candidate);
+    } catch {
+      return reject(candidate, "validate", "That file could not be validated.");
+    }
+
+    if (result !== true && result !== undefined) {
+      return reject(
+        candidate,
+        typeof result === "object" && result?.reason
+          ? result.reason
+          : "validate",
+        typeof result === "string" && result
+          ? result
+          : typeof result === "object" && result?.message
+            ? result.message
+            : "That file is not valid.",
+      );
+    }
+
+    return setFile(candidate);
+  }
+
+  export function choose() {
+    if (disabled || !input) return;
+    resetInput();
+    if (typeof input.showPicker === "function") {
+      try {
+        input.showPicker();
+        return;
+      } catch {
+        // The native click path covers browsers that restrict showPicker().
+      }
+    }
+    input.click();
+  }
+
+  export function clear() {
+    if (!disabled) setFile(null);
+  }
+
+  export function getRoot() {
+    return root;
+  }
+
+  function hasFiles(event) {
+    return Array.from(event.dataTransfer?.types ?? []).includes("Files");
+  }
+
+  function handleDragEnter(event) {
+    if (disabled || !hasFiles(event)) return;
+    event.preventDefault();
+    dragDepth += 1;
+    dragging = true;
+  }
+
+  function handleDragOver(event) {
+    if (disabled || !hasFiles(event)) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+    dragging = true;
+  }
+
+  function handleDragLeave(event) {
+    if (disabled || !hasFiles(event)) return;
+    event.preventDefault();
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (dragDepth === 0) dragging = false;
+  }
+
+  function handleDrop(event) {
+    if (!hasFiles(event)) return;
+    event.preventDefault();
+    dragDepth = 0;
+    dragging = false;
+    if (!disabled) select(event.dataTransfer?.files);
+  }
+
+  let dropzone = $derived({
+    "data-dragging": dragging ? "" : undefined,
+    "data-disabled": disabled ? "" : undefined,
+    ondragenter: handleDragEnter,
+    ondragover: handleDragOver,
+    ondragleave: handleDragLeave,
+    ondrop: handleDrop,
+  });
+
+  let api = {
+    get file() {
+      return file;
+    },
+    get previewUrl() {
+      return previewUrl;
+    },
+    get dragging() {
+      return dragging;
+    },
+    get dropzone() {
+      return dropzone;
+    },
+    choose,
+    clear,
+  };
+
+  $effect(() => {
+    const candidate = file;
+    if (
+      !candidate ||
+      typeof Blob === "undefined" ||
+      !(candidate instanceof Blob) ||
+      typeof URL.createObjectURL !== "function"
+    ) {
+      previewUrl = "";
+      return;
+    }
+
+    const url = URL.createObjectURL(candidate);
+    previewUrl = url;
+    return () => URL.revokeObjectURL?.(url);
+  });
+</script>
+
+<div
+  {...props}
+  bind:this={root}
+  data-slot="file-upload"
+  data-state={file ? "ready" : "empty"}
+  data-dragging={dragging ? "" : undefined}
+  data-disabled={disabled ? "" : undefined}
+  class={className}
+>
+  <input
+    bind:this={input}
+    type="file"
+    hidden
+    data-part="input"
+    {accept}
+    {capture}
+    {disabled}
+    onchange={(event) => select(event.currentTarget.files)}
+  />
+  {@render children?.(api)}
+</div>


### PR DESCRIPTION
## What changed

- add FileUpload to the Klean UI Components navigation and overview
- render a working one-file browse/drop preview with copy/source affordances
- document installation and equivalent Vue, React, and current Svelte usage
- document the intentionally small public API and structured rejection contract
- explain the honest boundary around native form serialization, required validation, multipart transport, server trust, and persisted assets
- add copyable Hagfish business-logo and receipt recipes
- cover durable refresh behavior, accessibility, caller Tailwind, and related components
- include complete framework-native source for all three frameworks

## Verification

- changed files pass Prettier
- `npm run build`
- local desktop and 390px mobile visual review
- live examples render without console errors or horizontal overflow

The repository-wide Prettier command still reports six pre-existing files outside this PR; every changed FileUpload file passes its focused Prettier check.

Closes #220
