### PR TITLE
docs(klean-ui): add Sidebar component

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -143,6 +143,7 @@ function kleanUiGuide() {
         { text: 'Command', link: '/klean-ui/components/command' },
         { text: 'Dialog', link: '/klean-ui/components/dialog' },
         { text: 'Sheet', link: '/klean-ui/components/sheet' },
+        { text: 'Sidebar', link: '/klean-ui/components/sidebar' },
         { text: 'Calendar', link: '/klean-ui/components/calendar' },
         { text: 'Date Picker', link: '/klean-ui/components/date-picker' },
         {

--- a/docs/.vitepress/theme/components/klean/sidebar/Sidebar.vue
+++ b/docs/.vitepress/theme/components/klean/sidebar/Sidebar.vue
@@ -1,0 +1,160 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, useAttrs, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Stable landmark id and zero-configuration persistence namespace. */
+  id: { type: String, default: 'app-sidebar' },
+  /** Framework-native controlled visibility. Omit for remembered state. */
+  open: { type: Boolean, default: undefined },
+  /** Initial visibility before a remembered choice exists. */
+  defaultOpen: { type: Boolean, default: true },
+  /** Remember this desktop choice across visits and application tabs. */
+  remember: { type: Boolean, default: true }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const root = ref()
+const internalOpen = ref(props.defaultOpen)
+const restored = ref(false)
+const controlled = computed(() => props.open !== undefined)
+const visible = computed(() =>
+  controlled.value ? props.open : internalOpen.value
+)
+const storageKey = computed(() => `klean:sidebar:${props.id}:open`)
+
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-restored': _dataRestored,
+    'aria-hidden': _ariaHidden,
+    inert: _inert,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const rootClasses = computed(() =>
+  twMerge(
+    'min-w-0 shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-out motion-reduce:transition-none',
+    attrs.class
+  )
+)
+
+function readRemembered() {
+  if (!props.remember || typeof window === 'undefined') return undefined
+  try {
+    const value = window.localStorage.getItem(storageKey.value)
+    if (value === 'true') return true
+    if (value === 'false') return false
+  } catch {
+    // Storage may be unavailable in private or constrained browser contexts.
+  }
+  return undefined
+}
+
+function rememberVisibility(next) {
+  if (!props.remember || typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(storageKey.value, String(next))
+  } catch {
+    // Visibility still works when persistence is unavailable.
+  }
+}
+
+function setOpen(next) {
+  const normalized = Boolean(next)
+  if (!controlled.value) internalOpen.value = normalized
+  emit('update:open', normalized)
+  rememberVisibility(normalized)
+}
+
+function show() {
+  setOpen(true)
+}
+
+function hide() {
+  setOpen(false)
+}
+
+function toggle() {
+  setOpen(!visible.value)
+}
+
+function restore() {
+  if (controlled.value) {
+    rememberVisibility(visible.value)
+    return
+  }
+  const remembered = readRemembered()
+  const next = remembered ?? props.defaultOpen
+  internalOpen.value = next
+  emit('update:open', next)
+}
+
+function handleStorage(event) {
+  if (
+    !props.remember ||
+    event.storageArea !== window.localStorage ||
+    event.key !== storageKey.value
+  ) {
+    return
+  }
+
+  if (event.newValue === 'true') {
+    if (!controlled.value) internalOpen.value = true
+    emit('update:open', true)
+  }
+  if (event.newValue === 'false') {
+    if (!controlled.value) internalOpen.value = false
+    emit('update:open', false)
+  }
+}
+
+onMounted(() => {
+  restore()
+  restored.value = true
+  window.addEventListener('storage', handleStorage)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('storage', handleStorage)
+})
+
+watch(
+  () => props.open,
+  (next) => {
+    if (restored.value && next !== undefined) rememberVisibility(next)
+  }
+)
+
+watch(
+  () => [props.id, props.remember],
+  () => {
+    if (restored.value) restore()
+  }
+)
+
+defineExpose({ root, show, hide, toggle })
+</script>
+
+<template>
+  <aside
+    ref="root"
+    v-bind="rootAttrs"
+    :id="props.id"
+    data-slot="sidebar"
+    :data-state="visible ? 'open' : 'closed'"
+    :data-restored="restored ? 'true' : 'false'"
+    :aria-hidden="visible ? undefined : 'true'"
+    :inert="visible ? undefined : ''"
+    :class="rootClasses"
+  >
+    <slot :open="visible" :show="show" :hide="hide" :toggle="toggle" />
+  </aside>
+</template>

--- a/docs/.vitepress/theme/components/klean/sidebar/SidebarRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/sidebar/SidebarRecipes.vue
@@ -1,0 +1,193 @@
+<script setup>
+import { ref } from 'vue'
+import KleanButton from '../Button.vue'
+import KleanSheet from '../sheet/Sheet.vue'
+import KleanSidebar from './Sidebar.vue'
+
+const active = ref('projects')
+const desktopOpen = ref(true)
+const desktopSidebar = ref()
+const mobileSheet = ref()
+const items = [
+  { value: 'projects', label: 'Projects', icon: '▣' },
+  { value: 'deployments', label: 'Deployments', icon: '↗' },
+  { value: 'lookout', label: 'Lookout', icon: '◉' },
+  { value: 'settings', label: 'Settings', icon: '⌘' }
+]
+
+function navigate(value) {
+  active.value = value
+  mobileSheet.value?.close()
+}
+</script>
+
+<template>
+  <div
+    class="flex h-[34rem] w-full overflow-hidden rounded-xl border border-gray-200 bg-white text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-white"
+  >
+    <a
+      href="#docs-sidebar-main"
+      class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:bg-white focus:px-4 focus:py-3 focus:text-gray-950"
+      >Skip to content</a
+    >
+
+    <KleanSidebar
+      id="docs-primary-sidebar"
+      ref="desktopSidebar"
+      :remember="false"
+      aria-label="Slipway navigation"
+      class="hidden w-52 border-r border-gray-200 bg-gray-50 data-[state=closed]:w-0 data-[state=closed]:opacity-0 dark:border-gray-800 dark:bg-gray-950 md:block"
+      @update:open="desktopOpen = $event"
+    >
+      <div class="flex h-full w-52 flex-col">
+        <header class="flex min-h-16 items-center gap-3 px-4">
+          <span
+            class="grid size-8 place-items-center rounded-lg bg-gray-950 text-xs font-bold text-white dark:bg-white dark:text-gray-950"
+            >S</span
+          >
+          <div class="min-w-0">
+            <strong class="block truncate text-sm">Slipway Labs</strong>
+            <span class="block text-xs text-gray-500">Production</span>
+          </div>
+        </header>
+        <nav
+          aria-label="Workspace"
+          class="min-h-0 flex-1 overflow-y-auto px-3 py-3"
+        >
+          <ul class="grid gap-1 text-sm">
+            <li v-for="item in items" :key="item.value">
+              <a
+                :href="`#docs-${item.value}`"
+                :aria-current="active === item.value ? 'page' : undefined"
+                :class="[
+                  'flex min-h-11 items-center gap-3 rounded-lg px-3 py-2 no-underline transition-colors',
+                  active === item.value
+                    ? 'bg-gray-200 font-medium text-gray-950 dark:bg-gray-800 dark:text-white'
+                    : 'text-gray-600 hover:bg-gray-100 hover:text-gray-950 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-white'
+                ]"
+                @click="navigate(item.value)"
+              >
+                <span
+                  aria-hidden="true"
+                  class="grid size-5 place-items-center text-xs"
+                  >{{ item.icon }}</span
+                >
+                <span>{{ item.label }}</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </KleanSidebar>
+
+    <main
+      id="docs-sidebar-main"
+      tabindex="-1"
+      class="min-w-0 flex-1 overflow-y-auto"
+    >
+      <header
+        class="flex min-h-16 items-center gap-3 border-b border-gray-200 px-4 dark:border-gray-800"
+      >
+        <KleanButton
+          commandfor="docs-mobile-navigation"
+          command="show-modal"
+          aria-label="Open navigation"
+          class="min-h-10 min-w-10 bg-transparent p-0 text-gray-700 hover:bg-gray-100 dark:bg-transparent dark:text-gray-200 dark:hover:bg-gray-900 md:hidden"
+        >
+          <span aria-hidden="true">☰</span>
+        </KleanButton>
+        <KleanButton
+          type="button"
+          aria-controls="docs-primary-sidebar"
+          :aria-expanded="String(desktopOpen)"
+          :aria-label="desktopOpen ? 'Hide navigation' : 'Show navigation'"
+          class="hidden min-h-10 min-w-10 bg-transparent p-0 text-gray-700 hover:bg-gray-100 dark:bg-transparent dark:text-gray-200 dark:hover:bg-gray-900 md:inline-flex"
+          @click="desktopSidebar.toggle()"
+        >
+          <span aria-hidden="true">◫</span>
+        </KleanButton>
+        <div class="min-w-0">
+          <p class="truncate text-xs text-gray-500">Projects</p>
+          <h2 class="truncate text-sm font-semibold">Sailscasts API</h2>
+        </div>
+      </header>
+      <div class="p-5 sm:p-7">
+        <h3 class="text-2xl font-semibold tracking-tight">Services</h3>
+        <p
+          class="mt-2 max-w-lg text-sm leading-6 text-gray-600 dark:text-gray-400"
+        >
+          The page stays ordinary and the current destination remains a real
+          link.
+        </p>
+        <div class="mt-6 grid gap-3 xl:grid-cols-2">
+          <article
+            v-for="service in ['web', 'worker']"
+            :key="service"
+            class="rounded-xl border border-gray-200 p-4 dark:border-gray-800"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <strong class="text-sm">{{ service }}</strong>
+              <span class="size-2 rounded-full bg-emerald-500"
+                ><span class="sr-only">Running</span></span
+              >
+            </div>
+            <p class="mt-4 font-mono text-xs text-gray-500">
+              fra · node 24 · main
+            </p>
+          </article>
+        </div>
+      </div>
+    </main>
+
+    <KleanSheet
+      id="docs-mobile-navigation"
+      ref="mobileSheet"
+      aria-labelledby="docs-mobile-navigation-title"
+      class="right-auto left-0 mr-auto ml-0 w-72 -translate-x-full border-r border-l-0 bg-gray-50 open:translate-x-0 starting:open:-translate-x-full dark:bg-gray-950 md:hidden"
+    >
+      <div class="flex h-full flex-col">
+        <header class="flex min-h-16 items-center justify-between px-4">
+          <h2 id="docs-mobile-navigation-title" class="text-sm font-semibold">
+            Slipway Labs
+          </h2>
+          <KleanButton
+            commandfor="docs-mobile-navigation"
+            command="request-close"
+            autofocus
+            aria-label="Close navigation"
+            class="min-h-10 min-w-10 bg-transparent p-0 text-gray-600 hover:bg-gray-200 dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            <span aria-hidden="true">×</span>
+          </KleanButton>
+        </header>
+        <nav
+          aria-label="Workspace"
+          class="min-h-0 flex-1 overflow-y-auto px-3 py-3"
+        >
+          <ul class="grid gap-1 text-sm">
+            <li v-for="item in items" :key="item.value">
+              <a
+                :href="`#docs-mobile-${item.value}`"
+                :aria-current="active === item.value ? 'page' : undefined"
+                :class="[
+                  'flex min-h-11 items-center gap-3 rounded-lg px-3 py-2 no-underline',
+                  active === item.value
+                    ? 'bg-gray-200 font-medium dark:bg-gray-800'
+                    : 'text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-900'
+                ]"
+                @click="navigate(item.value)"
+              >
+                <span
+                  aria-hidden="true"
+                  class="grid size-5 place-items-center text-xs"
+                  >{{ item.icon }}</span
+                >
+                <span>{{ item.label }}</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </KleanSheet>
+  </div>
+</template>

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -125,6 +125,10 @@ A native modal surface with platform focus containment, inert background behavio
 
 A native off-canvas dialog for mobile navigation, comments, inspectors, and focused edge workflows, with caller-owned placement, semantic content, and Tailwind styling.
 
+### [Sidebar](/klean-ui/components/sidebar)
+
+A durable native desktop aside with remembered visibility, honest closed-state semantics, and application-owned links, navigation, and Tailwind styling.
+
 ### [Calendar](/klean-ui/components/calendar)
 
 An always-visible, locale-aware date-only surface with complete keyboard navigation, caller-owned availability, and stable `YYYY-MM-DD` values.

--- a/docs/klean-ui/components/sidebar.md
+++ b/docs/klean-ui/components/sidebar.md
@@ -1,0 +1,174 @@
+---
+title: Sidebar
+titleTemplate: Klean UI
+description: A durable native desktop aside with remembered visibility and application-owned navigation, links, and Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import SidebarRecipes from '../../.vitepress/theme/components/klean/sidebar/SidebarRecipes.vue'
+import sidebarSource from '../../.vitepress/theme/components/klean/sidebar/Sidebar.vue?raw'
+import reactSource from '../sources/sidebar/Sidebar.jsx?raw'
+import svelteSource from '../sources/sidebar/Sidebar.svelte?raw'
+import vueUsage from '../snippets/sidebar/usage.vue?raw'
+import reactUsage from '../snippets/sidebar/usage.jsx?raw'
+import svelteUsage from '../snippets/sidebar/usage.svelte?raw'
+import appShellSource from '../snippets/sidebar/app-shell.vue?raw'
+</script>
+
+# Sidebar
+
+Sidebar is one persistent native `<aside>` for application navigation. It remembers whether the user left it open, keeps closed links out of the focus order, and exposes a small imperative handle for an application-owned trigger.
+
+The application still writes every `<nav>`, list, real `<a>` or Boring Stack `<Link>`, current-page marker, logo, menu, permission check, and Tailwind class. There is no item schema, router adapter, provider, collapse icon, breakpoint, visual variant, or application-shell package.
+
+<KleanPreview id="sidebar-app-shell" :source="appShellSource" filename="AppShell.vue">
+  <template #preview>
+    <SidebarRecipes />
+  </template>
+  <template #caption>
+    Resize the page: Sidebar is persistent desktop navigation; the same app-owned navigation becomes a native modal Sheet on narrow screens.
+  </template>
+</KleanPreview>
+
+## Installation
+
+One command detects Vue, React, or Svelte and copies the matching one-file source into the conventional component directory:
+
+<KleanInstallation
+  id="sidebar-installation"
+  component="sidebar"
+  :source="sidebarSource"
+  filename="Sidebar.vue"
+  destination="assets/js/components/ui/sidebar/Sidebar.vue"
+/>
+
+There is no initializer, `klean-ui.json`, provider, navigation configuration, class helper, barrel file, or Klean runtime.
+
+## Sidebar or Sheet?
+
+The two components solve different semantic problems. Do not make one pretend to be both.
+
+| Surface                                 | Use                                                      | Browser relationship         |
+| --------------------------------------- | -------------------------------------------------------- | ---------------------------- |
+| [Sidebar](/klean-ui/components/sidebar) | Persistent navigation that occupies desktop layout space | Ordinary non-modal `<aside>` |
+| [Sheet](/klean-ui/components/sheet)     | Temporary mobile navigation over the current page        | Native modal `<dialog>`      |
+
+The desktop Sidebar may be open or closed by preference. The mobile Sheet is temporary and closes after navigation. Keeping them separate lets the browser own modal focus containment, Escape, background inertness, and focus return without burdening the desktop landmark with dialog behavior.
+
+## Usage
+
+The component does not manufacture navigation items. Write honest links directly and connect the external trigger with `aria-controls` and `aria-expanded`.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="AppShell.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="AppShell.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="AppShell.svelte" />
+
+## API
+
+| Purpose                              | Vue            | React                  | Svelte            | Default                        |
+| ------------------------------------ | -------------- | ---------------------- | ----------------- | ------------------------------ |
+| Stable landmark and memory namespace | `id`           | `id`                   | `id`              | `app-sidebar`                  |
+| Open state                           | `v-model:open` | `open`, `onOpenChange` | `bind:open`       | uncontrolled                   |
+| Initial state                        | `default-open` | `defaultOpen`          | `defaultOpen`     | `true`                         |
+| Remember the choice                  | `remember`     | `remember`             | `remember`        | `true`                         |
+| Styling                              | `class`        | `className`            | `class`           | structural motion only         |
+| Actions                              | component ref  | forwarded ref          | component binding | `show()`, `hide()`, `toggle()` |
+
+The content slot, render function, or snippet also receives `{ open, show, hide, toggle }`. That is useful for an internal collapse control, but the closed Sidebar becomes inert; the application should keep at least one show/toggle button outside it.
+
+Use a stable, unique `id` whenever an application has more than one shell, such as `primary-navigation` and `bridge-navigation`. That gives each Sidebar an independent remembered choice without another configuration prop.
+
+Set `remember={false}` only when persistence would be dishonest: an embedded preview, test fixture, kiosk, or other intentionally transient shell.
+
+## Durable behavior
+
+Sidebar remembers the last desktop choice across visits and keeps open application tabs in agreement. A controlled caller remains authoritative, malformed or unavailable browser memory does not break navigation, and server rendering never assumes a browser exists.
+
+The restored value is reported through the framework-native binding callback. Initializing a bound value as `undefined` lets Sidebar restore its remembered state and gives the parent the correct value for the trigger's `aria-expanded`. Passing an explicit boolean makes the caller authoritative from the first render.
+
+Closing sets `data-state="closed"`, `aria-hidden="true"`, and `inert` on the aside. Caller Tailwind then collapses its width and opacity. This matters: visually hiding a rail while leaving its links keyboard-focusable would be a regression.
+
+Back/Forward navigation and route changes do not rewrite the desktop preference. The destination remains durable because every item is still a real link; Sidebar never turns navigation into button state.
+
+## Responsive application shell
+
+Extract the app-owned navigation links into a local `AppNavigation` component, then compose it into Sidebar and Sheet. That shares routes, active state, authorization, labels, and product styling without making Klean accept a navigation-data schema.
+
+<CopyCode :code="appShellSource" label="AppShell.vue" />
+
+Desktop and mobile may need different surrounding headers or close controls. Keep those surface-specific elements outside `AppNavigation`; the navigation component should contain the truthful destinations shared by both.
+
+## Link and current-page semantics
+
+Use a real `<a href>` for document navigation or the framework-native Boring Stack `Link` for an Inertia visit. Mark only the current destination with `aria-current="page"`. Sidebar does not infer the route because applications differ on nested resources, query-backed workspaces, permissions, and what counts as a current section.
+
+Buttons inside the Sidebar are for real actions such as switching a team or signing out. Do not use a button for a destination and do not give ordinary navigation links tab roles.
+
+## Accessibility
+
+- Give the aside an accessible label such as `aria-label="Project navigation"` when the page contains more than one complementary landmark.
+- Put a labeled `<nav>` and a list of destinations inside it. Sidebar is the shell landmark, not a replacement for navigation semantics.
+- Keep the trigger outside the collapsible aside and connect it with `aria-controls` and `aria-expanded`.
+- Include a skip link before a dense application shell and give the main landmark a stable target.
+- Use visible focus, ordinary link activation, and `aria-current="page"`; do not add a custom arrow-key navigation model to a standard list of links.
+- The neutral width/opacity transition respects reduced motion. Caller-added motion must do the same.
+- Use Sheet for narrow-screen modal navigation so the browser owns focus containment, Escape, background inertness, scroll locking, and invoker focus return.
+
+## Styling with Tailwind
+
+Sidebar supplies only structural overflow and a short width/opacity transition. The caller supplies the actual open width and closed treatment:
+
+```html
+class="w-56 border-r bg-gray-50 data-[state=closed]:w-0
+data-[state=closed]:opacity-0"
+```
+
+`tailwind-merge` lets later caller classes replace timing, easing, width, opacity, or overflow. Use ordinary responsive utilities such as `hidden md:block`; there is no `side`, `size`, `density`, `tone`, `collapsedWidth`, or visual variant prop.
+
+An icon-only rail is not the same closed state because its links remain available. Keep an icon rail as an explicit application recipe with accessible names and tooltips rather than forcing it through Sidebar's inert closed contract.
+
+## When not to use
+
+- Use ordinary `<aside>` markup when the region never opens, closes, or remembers a choice.
+- Use [Sheet](/klean-ui/components/sheet) for modal mobile navigation or another temporary edge surface.
+- Use [Tabs](/klean-ui/components/tabs) for peer sections within the current page or route, not global application hierarchy.
+- Use [Menu](/klean-ui/components/menu) for a compact set of actions or destinations opened from one trigger.
+- Do not use Sidebar as a router, authorization layer, nested-tree state machine, resizable panel, or universal page layout.
+
+## Complete framework source
+
+Copy, inspect, and change the complete one-file source for your framework.
+
+### Vue source
+
+<CopyCode :code="sidebarSource" label="Sidebar.vue" />
+
+### React source
+
+<CopyCode :code="reactSource" label="Sidebar.jsx" />
+
+### Svelte source
+
+<CopyCode :code="svelteSource" label="Sidebar.svelte" />
+
+## Related components
+
+- [Sheet](/klean-ui/components/sheet) — presents the same app-owned navigation as a native modal on narrow screens.
+- [Button](/klean-ui/components/button) — supplies the external open/close trigger and honest action controls.
+- [Menu](/klean-ui/components/menu) — handles team, account, and contextual actions inside the shell.
+- [Avatar](/klean-ui/components/avatar) — renders resilient team or account identity without becoming navigation.
+- [Tooltip](/klean-ui/components/tooltip) — names evidenced icon-only rail controls when an application keeps them visible.
+- [Breadcrumb](/klean-ui/components/breadcrumb) — represents the current location inside the hierarchy.
+- [Tabs](/klean-ui/components/tabs) — handles peer page sections or route destinations below the application shell.

--- a/docs/klean-ui/snippets/sidebar/app-shell.vue
+++ b/docs/klean-ui/snippets/sidebar/app-shell.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { ref } from 'vue'
+import AppNavigation from '@/components/AppNavigation.vue'
+import Button from '@/components/ui/button/Button.vue'
+import Sheet from '@/components/ui/sheet/Sheet.vue'
+import Sidebar from '@/components/ui/sidebar/Sidebar.vue'
+
+const sidebar = ref()
+const sheet = ref()
+const desktopOpen = ref()
+</script>
+
+<div class="flex h-screen overflow-hidden">
+  <Sidebar
+    id="primary-navigation"
+    ref="sidebar"
+    aria-label="Project navigation"
+    class="hidden w-56 border-r data-[state=closed]:w-0 md:block"
+    @update:open="desktopOpen = $event"
+  >
+    <AppNavigation />
+  </Sidebar>
+
+  <main id="main-content" class="min-w-0 flex-1">
+    <Button
+      commandfor="mobile-navigation"
+      command="show-modal"
+      class="md:hidden"
+    >
+      Open navigation
+    </Button>
+    <Button
+      type="button"
+      class="hidden md:inline-flex"
+      aria-controls="primary-navigation"
+      :aria-expanded="String(desktopOpen)"
+      @click="sidebar.toggle()"
+    >
+      {{ desktopOpen ? 'Hide navigation' : 'Show navigation' }}
+    </Button>
+    <slot />
+  </main>
+
+  <Sheet
+    id="mobile-navigation"
+    ref="sheet"
+    aria-label="Project navigation"
+    class="right-auto left-0 mr-auto ml-0 w-72 -translate-x-full border-r border-l-0 open:translate-x-0 starting:open:-translate-x-full md:hidden"
+  >
+    <AppNavigation @navigate="sheet.close()" />
+  </Sheet>
+</div>

--- a/docs/klean-ui/snippets/sidebar/usage.jsx
+++ b/docs/klean-ui/snippets/sidebar/usage.jsx
@@ -1,0 +1,44 @@
+import { Link } from '@inertiajs/react'
+import { useRef, useState } from 'react'
+import Sidebar from '@/components/ui/sidebar/Sidebar.jsx'
+
+export default function AppShell() {
+  const sidebar = useRef(null)
+  const [open, setOpen] = useState()
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar
+        ref={sidebar}
+        id="primary-navigation"
+        aria-label="Project navigation"
+        onOpenChange={setOpen}
+        className="w-56 border-r data-[state=closed]:w-0 data-[state=closed]:opacity-0"
+      >
+        <nav aria-label="Workspace" className="w-56 p-3">
+          <Link
+            href="/"
+            aria-current="page"
+            className="block min-h-11 px-3 py-3"
+          >
+            Projects
+          </Link>
+          <Link href="/lookout" className="block min-h-11 px-3 py-3">
+            Lookout
+          </Link>
+        </nav>
+      </Sidebar>
+
+      <main className="min-w-0 flex-1">
+        <button
+          type="button"
+          aria-controls="primary-navigation"
+          aria-expanded={Boolean(open)}
+          onClick={() => sidebar.current?.toggle()}
+        >
+          {open ? 'Hide navigation' : 'Show navigation'}
+        </button>
+      </main>
+    </div>
+  )
+}

--- a/docs/klean-ui/snippets/sidebar/usage.svelte
+++ b/docs/klean-ui/snippets/sidebar/usage.svelte
@@ -1,0 +1,35 @@
+<script>
+  import { Link } from '@inertiajs/svelte'
+  import Sidebar from '@/components/ui/sidebar/Sidebar.svelte'
+
+  let sidebar
+  let open
+</script>
+
+<div class="flex h-screen overflow-hidden">
+  <Sidebar
+    bind:this={sidebar}
+    bind:open
+    id="primary-navigation"
+    aria-label="Project navigation"
+    class="w-56 border-r data-[state=closed]:w-0 data-[state=closed]:opacity-0"
+  >
+    <nav aria-label="Workspace" class="w-56 p-3">
+      <Link href="/" aria-current="page" class="block min-h-11 px-3 py-3">
+        Projects
+      </Link>
+      <Link href="/lookout" class="block min-h-11 px-3 py-3">Lookout</Link>
+    </nav>
+  </Sidebar>
+
+  <main class="min-w-0 flex-1">
+    <button
+      type="button"
+      aria-controls="primary-navigation"
+      aria-expanded={Boolean(open)}
+      onclick={() => sidebar?.toggle()}
+    >
+      {open ? 'Hide navigation' : 'Show navigation'}
+    </button>
+  </main>
+</div>

--- a/docs/klean-ui/snippets/sidebar/usage.vue
+++ b/docs/klean-ui/snippets/sidebar/usage.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { Link } from '@inertiajs/vue3'
+import { ref } from 'vue'
+import Button from '@/components/ui/button/Button.vue'
+import Sidebar from '@/components/ui/sidebar/Sidebar.vue'
+
+const sidebar = ref()
+const open = ref()
+</script>
+
+<div class="flex h-screen overflow-hidden">
+  <Sidebar
+    id="primary-navigation"
+    ref="sidebar"
+    aria-label="Project navigation"
+    class="w-56 border-r data-[state=closed]:w-0 data-[state=closed]:opacity-0"
+    @update:open="open = $event"
+  >
+    <nav aria-label="Workspace" class="w-56 p-3">
+      <Link href="/" aria-current="page" class="block min-h-11 px-3 py-3">
+        Projects
+      </Link>
+      <Link href="/lookout" class="block min-h-11 px-3 py-3">
+        Lookout
+      </Link>
+    </nav>
+  </Sidebar>
+
+  <main class="min-w-0 flex-1">
+    <Button
+      type="button"
+      aria-controls="primary-navigation"
+      :aria-expanded="String(open)"
+      @click="sidebar.toggle()"
+    >
+      {{ open ? 'Hide navigation' : 'Show navigation' }}
+    </Button>
+  </main>
+</div>

--- a/docs/klean-ui/sources/sidebar/Sidebar.jsx
+++ b/docs/klean-ui/sources/sidebar/Sidebar.jsx
@@ -1,0 +1,138 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const Sidebar = forwardRef(function Sidebar(
+  {
+    id = 'app-sidebar',
+    open,
+    defaultOpen = true,
+    remember = true,
+    onOpenChange,
+    className,
+    children,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-restored': _dataRestored,
+    'aria-hidden': _ariaHidden,
+    inert: _inert,
+    ...props
+  },
+  forwardedRef
+) {
+  const rootRef = useRef(null)
+  const onOpenChangeRef = useRef(onOpenChange)
+  const [internalOpen, setInternalOpen] = useState(defaultOpen)
+  const [restored, setRestored] = useState(false)
+  const controlled = open !== undefined
+  const visible = controlled ? open : internalOpen
+  const storageKey = `klean:sidebar:${id}:open`
+
+  useEffect(() => {
+    onOpenChangeRef.current = onOpenChange
+  }, [onOpenChange])
+
+  const rememberVisibility = useCallback(
+    (next) => {
+      if (!remember || typeof window === 'undefined') return
+      try {
+        window.localStorage.setItem(storageKey, String(next))
+      } catch {
+        // Visibility still works when persistence is unavailable.
+      }
+    },
+    [remember, storageKey]
+  )
+
+  const setOpen = useCallback(
+    (next) => {
+      const normalized = Boolean(next)
+      if (!controlled) setInternalOpen(normalized)
+      onOpenChangeRef.current?.(normalized)
+      rememberVisibility(normalized)
+    },
+    [controlled, rememberVisibility]
+  )
+
+  const show = useCallback(() => setOpen(true), [setOpen])
+  const hide = useCallback(() => setOpen(false), [setOpen])
+  const toggle = useCallback(() => setOpen(!visible), [setOpen, visible])
+
+  useImperativeHandle(forwardedRef, () => ({
+    root: rootRef.current,
+    show,
+    hide,
+    toggle
+  }))
+
+  useEffect(() => {
+    if (!controlled && remember) {
+      try {
+        const value = window.localStorage.getItem(storageKey)
+        const next =
+          value === 'true' ? true : value === 'false' ? false : defaultOpen
+        setInternalOpen(next)
+        onOpenChangeRef.current?.(next)
+      } catch {
+        // The supplied default remains authoritative without storage.
+        onOpenChangeRef.current?.(defaultOpen)
+      }
+    }
+
+    setRestored(true)
+
+    function handleStorage(event) {
+      if (
+        !remember ||
+        event.storageArea !== window.localStorage ||
+        event.key !== storageKey
+      ) {
+        return
+      }
+      if (event.newValue === 'true') {
+        if (!controlled) setInternalOpen(true)
+        onOpenChangeRef.current?.(true)
+      }
+      if (event.newValue === 'false') {
+        if (!controlled) setInternalOpen(false)
+        onOpenChangeRef.current?.(false)
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [controlled, defaultOpen, remember, storageKey])
+
+  useEffect(() => {
+    if (restored && controlled) rememberVisibility(visible)
+  }, [controlled, rememberVisibility, restored, visible])
+
+  const api = { open: visible, show, hide, toggle }
+
+  return (
+    <aside
+      {...props}
+      ref={rootRef}
+      id={id}
+      data-slot="sidebar"
+      data-state={visible ? 'open' : 'closed'}
+      data-restored={restored ? 'true' : 'false'}
+      aria-hidden={visible ? undefined : 'true'}
+      inert={visible ? undefined : true}
+      className={twMerge(
+        'min-w-0 shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-out motion-reduce:transition-none',
+        className
+      )}
+    >
+      {typeof children === 'function' ? children(api) : children}
+    </aside>
+  )
+})
+
+export default Sidebar

--- a/docs/klean-ui/sources/sidebar/Sidebar.svelte
+++ b/docs/klean-ui/sources/sidebar/Sidebar.svelte
@@ -1,0 +1,137 @@
+<script>
+  import { onMount } from "svelte";
+  import { twMerge } from "tailwind-merge";
+
+  let {
+    id = "app-sidebar",
+    open = $bindable(),
+    defaultOpen = true,
+    remember = true,
+    onopenchange,
+    class: className,
+    children,
+    "data-slot": _dataSlot,
+    "data-state": _dataState,
+    "data-restored": _dataRestored,
+    "aria-hidden": _ariaHidden,
+    inert: _inert,
+    ...props
+  } = $props();
+
+  function initialVisibility() {
+    return defaultOpen;
+  }
+
+  let root = $state();
+  const controlled = open !== undefined;
+  let internalOpen = $state(initialVisibility());
+  let restored = $state(false);
+  let visible = $derived(open === undefined ? internalOpen : open);
+  let storageKey = $derived(`klean:sidebar:${id}:open`);
+
+  function rememberVisibility(next) {
+    if (!remember || typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(storageKey, String(next));
+    } catch {
+      // Visibility still works when persistence is unavailable.
+    }
+  }
+
+  function setOpen(next, notify = true) {
+    const normalized = Boolean(next);
+    internalOpen = normalized;
+    open = normalized;
+    if (notify) onopenchange?.(normalized);
+    rememberVisibility(normalized);
+  }
+
+  export function show() {
+    setOpen(true);
+  }
+
+  export function hide() {
+    setOpen(false);
+  }
+
+  export function toggle() {
+    setOpen(!visible);
+  }
+
+  export function getRoot() {
+    return root;
+  }
+
+  onMount(() => {
+    if (open === undefined && remember) {
+      try {
+        const value = window.localStorage.getItem(storageKey);
+        const next =
+          value === "true" ? true : value === "false" ? false : defaultOpen;
+        internalOpen = next;
+        open = next;
+        onopenchange?.(next);
+      } catch {
+        // The supplied default remains authoritative without storage.
+        onopenchange?.(defaultOpen);
+      }
+    } else if (open !== undefined) {
+      rememberVisibility(open);
+    }
+
+    restored = true;
+
+    function handleStorage(event) {
+      if (
+        !remember ||
+        event.storageArea !== window.localStorage ||
+        event.key !== storageKey
+      ) {
+        return;
+      }
+      if (event.newValue === "true") {
+        if (!controlled) internalOpen = true;
+        open = true;
+        onopenchange?.(true);
+      }
+      if (event.newValue === "false") {
+        if (!controlled) internalOpen = false;
+        open = false;
+        onopenchange?.(false);
+      }
+    }
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  });
+
+  $effect(() => {
+    if (restored) rememberVisibility(visible);
+  });
+
+  let api = {
+    get open() {
+      return visible;
+    },
+    show,
+    hide,
+    toggle,
+  };
+</script>
+
+<aside
+  {...props}
+  bind:this={root}
+  {id}
+  data-slot="sidebar"
+  data-state={visible ? "open" : "closed"}
+  data-restored={restored ? "true" : "false"}
+  aria-hidden={visible ? undefined : "true"}
+  inert={visible ? undefined : ""}
+  class={twMerge(
+    "min-w-0 shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-out motion-reduce:transition-none",
+    className,
+  )}
+>
+  {@render children?.(api)}
+</aside>


### PR DESCRIPTION
## Outcome

- add Sidebar under the existing Klean UI Components section
- provide a live responsive Slipway-style application shell
- document the persistent desktop Sidebar versus native modal mobile Sheet boundary
- add installation, framework-native Vue/React/Svelte usage, complete sources, Durable behavior, link semantics, accessibility, Tailwind ownership, and related components
- keep routes, permissions, navigation markup, and product styling application-owned

## Verification

- production VitePress build passes
- all changed files pass focused Prettier checks
- live page is available locally at `/klean-ui/components/sidebar`

Closes #222
