### PR TITLE
docs: sync Vue Filter Bar source

### DIFF
--- a/docs/.vitepress/theme/components/klean/filter-bar/FilterBar.vue
+++ b/docs/.vitepress/theme/components/klean/filter-bar/FilterBar.vue
@@ -38,8 +38,14 @@ const rootAttrs = computed(() => {
   return rest
 })
 
+function setDraft(next) {
+  draft.value = clone(
+    typeof next === 'function' ? next(clone(draft.value)) : next
+  )
+}
+
 function update(key, nextValue) {
-  draft.value = { ...draft.value, [key]: nextValue }
+  setDraft((current) => ({ ...current, [key]: nextValue }))
 }
 
 function commit(next, eventName) {
@@ -148,7 +154,7 @@ watch(
   { deep: true }
 )
 
-defineExpose({ root, apply, cancel, clear, remove })
+defineExpose({ root, setDraft, apply, cancel, clear, remove })
 </script>
 
 <template>
@@ -171,6 +177,7 @@ defineExpose({ root, apply, cancel, clear, remove })
       :count="count"
       :dirty="dirty"
       :busy="busy"
+      :set-draft="setDraft"
       :update="update"
       :apply="apply"
       :cancel="cancel"


### PR DESCRIPTION
Closes #226

Syncs the live and copyable Vue Filter Bar source with Klean UI pull request 113.

- exposes whole-draft setDraft through the scoped slot and component instance
- keeps the already documented API table truthful
- preserves the existing live recipe and docs-site formatting

Verification:
- npm run build
- git diff --check
