### PR TITLE
docs: add the Klean UI Row Actions page

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -132,6 +132,7 @@ function kleanUiGuide() {
         { text: 'Tabs', link: '/klean-ui/components/tabs' },
         { text: 'Table', link: '/klean-ui/components/table' },
         { text: 'DataTable', link: '/klean-ui/components/data-table' },
+        { text: 'Row Actions', link: '/klean-ui/components/row-actions' },
         { text: 'Filter Bar', link: '/klean-ui/components/filter-bar' },
         { text: 'FileUpload', link: '/klean-ui/components/file-upload' },
         { text: 'Sparkline', link: '/klean-ui/components/sparkline' },

--- a/docs/.vitepress/theme/components/klean/row-actions/RowActions.vue
+++ b/docs/.vitepress/theme/components/klean/row-actions/RowActions.vue
@@ -1,0 +1,103 @@
+<script setup>
+import { computed, ref, useAttrs, useId, useSlots, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+import Menu from '../menu/Menu.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Accessible name for this row's actions and overflow menu. */
+  label: { type: String, default: 'Actions' },
+  /** Prevents duplicate overflow interaction while application work is pending. */
+  busy: { type: Boolean, default: false },
+  /** Optional stable id for the overflow menu. */
+  id: { type: String, default: undefined },
+  /** Preferred logical menu placement. Collision handling may flip it. */
+  placement: { type: String, default: 'bottom-end' },
+  /** Space in pixels between the trigger and menu. */
+  offset: { type: Number, default: 4 }
+})
+
+const attrs = useAttrs()
+const slots = useSlots()
+const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+const menuId = computed(() => props.id ?? `klean-row-actions-${generatedId}`)
+const open = ref(false)
+const hasMenu = computed(() => Boolean(slots.menu))
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-label': _ariaLabel,
+    'aria-busy': _ariaBusy,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function stopPropagation(event) {
+  event.stopPropagation()
+}
+
+watch(
+  () => props.busy,
+  (busy) => {
+    if (busy) open.value = false
+  }
+)
+</script>
+
+<template>
+  <div
+    v-bind="rootAttrs"
+    role="group"
+    :aria-label="label"
+    :aria-busy="busy ? 'true' : undefined"
+    data-slot="row-actions"
+    :class="twMerge('inline-flex items-center gap-1', attrs.class)"
+    @pointerdown="stopPropagation"
+    @click="stopPropagation"
+  >
+    <slot />
+
+    <button
+      v-if="hasMenu"
+      type="button"
+      :disabled="busy"
+      :aria-label="label"
+      :aria-controls="menuId"
+      :aria-expanded="open ? 'true' : 'false'"
+      :popovertarget="menuId"
+      data-slot="row-actions-trigger"
+      class="inline-grid size-9 cursor-pointer place-items-center rounded-md text-current hover:bg-black/5 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/10"
+    >
+      <slot name="trigger">
+        <svg
+          class="size-4"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"
+          />
+        </svg>
+      </slot>
+    </button>
+
+    <Menu
+      v-if="hasMenu"
+      :id="menuId"
+      v-model:open="open"
+      :aria-label="label"
+      :placement="placement"
+      :offset="offset"
+      data-row-actions-menu=""
+      class="min-w-40"
+      v-slot="{ close }"
+    >
+      <slot name="menu" :close="close" />
+    </Menu>
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/klean/row-actions/RowActionsRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/row-actions/RowActionsRecipes.vue
@@ -1,0 +1,125 @@
+<script setup>
+import { ref } from 'vue'
+import RowActions from './RowActions.vue'
+
+const notice = ref('Choose an action')
+</script>
+
+<template>
+  <div class="grid w-full max-w-4xl gap-5 sm:grid-cols-2">
+    <section
+      aria-labelledby="row-actions-invoices"
+      class="bg-[#f7f3eb] p-5 text-black sm:p-6"
+    >
+      <h3 id="row-actions-invoices" class="m-0 text-lg font-semibold">
+        Invoices
+      </h3>
+      <div
+        class="mt-4 flex items-center justify-between gap-3 border-2 border-black bg-white p-4 shadow-[4px_4px_0_0_#000]"
+      >
+        <div class="min-w-0">
+          <a
+            href="#invoice-inv-1042"
+            class="whitespace-nowrap font-semibold text-black no-underline hover:underline"
+          >
+            INV-1042
+          </a>
+          <p class="mt-1 truncate text-sm text-black/60">Acme Studio · Draft</p>
+        </div>
+        <RowActions label="Actions for invoice INV-1042">
+          <a
+            href="#preview-inv-1042"
+            class="inline-flex min-h-10 items-center border-2 border-black px-3 text-sm font-medium text-black no-underline hover:bg-black hover:text-white"
+          >
+            Preview
+          </a>
+          <template #menu>
+            <a
+              href="#edit-inv-1042"
+              class="block px-3 py-2 text-sm text-black no-underline hover:bg-black hover:text-white"
+            >
+              Edit invoice
+            </a>
+            <button
+              type="button"
+              class="block w-full cursor-pointer px-3 py-2 text-left text-sm hover:bg-black hover:text-white"
+              @click="notice = 'Invoice duplicated'"
+            >
+              Duplicate
+            </button>
+            <button
+              type="button"
+              class="block w-full cursor-pointer px-3 py-2 text-left text-sm text-red-700 hover:bg-red-700 hover:text-white"
+              @click="notice = 'Delete confirmation opened'"
+            >
+              Delete draft
+            </button>
+          </template>
+        </RowActions>
+      </div>
+    </section>
+
+    <section
+      aria-labelledby="row-actions-services"
+      class="dark bg-gray-950 p-5 text-white sm:p-6"
+    >
+      <h3
+        id="row-actions-services"
+        class="m-0 text-lg font-semibold text-white"
+      >
+        Bridge services
+      </h3>
+      <div
+        class="mt-4 divide-y divide-gray-800 overflow-visible rounded-lg border border-gray-800 bg-gray-900"
+      >
+        <div
+          v-for="service in ['api', 'worker']"
+          :key="service"
+          class="flex items-center justify-between gap-3 p-3"
+        >
+          <div>
+            <a
+              :href="`#service-${service}`"
+              class="font-mono text-sm font-medium text-white no-underline hover:underline"
+            >
+              {{ service }}
+            </a>
+            <p class="mt-1 text-xs text-gray-400">Healthy · fra1</p>
+          </div>
+          <RowActions :label="`Actions for ${service}`">
+            <a
+              :href="`#logs-${service}`"
+              class="inline-flex min-h-9 items-center rounded-md px-3 text-sm font-medium text-gray-200 no-underline hover:bg-white/10"
+            >
+              Logs
+            </a>
+            <template #menu>
+              <a
+                :href="`#settings-${service}`"
+                class="block rounded-sm px-3 py-2 text-sm text-gray-200 no-underline hover:bg-white/10"
+              >
+                Settings
+              </a>
+              <button
+                type="button"
+                class="block w-full cursor-pointer rounded-sm px-3 py-2 text-left text-sm text-gray-200 hover:bg-white/10"
+                @click="notice = `${service} redeploy requested`"
+              >
+                Redeploy
+              </button>
+              <button
+                type="button"
+                class="block w-full cursor-pointer rounded-sm px-3 py-2 text-left text-sm text-red-400 hover:bg-red-950/60"
+                @click="notice = `Delete ${service} confirmation opened`"
+              >
+                Delete service
+              </button>
+            </template>
+          </RowActions>
+        </div>
+      </div>
+    </section>
+
+    <p class="sr-only" aria-live="polite">{{ notice }}</p>
+  </div>
+</template>

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -81,6 +81,10 @@ A native table with a neutral baseline, caller-written captions, sections, heade
 
 A durable server-driven table block with one native table, page-scoped selection, clean Inertia URL queries, truthful pending state, and caller-owned application markup.
 
+### [Row Actions](/klean-ui/components/row-actions)
+
+A compact group of real row links and buttons with optional accessible overflow, truthful busy state, row-click isolation, and caller-owned Tailwind styling.
+
 ### [Filter Bar](/klean-ui/components/filter-bar)
 
 A native filter form with separate draft and committed state, immediate active-filter removal, pending safety, deterministic URLs, and caller-owned controls and Tailwind.

--- a/docs/klean-ui/components/row-actions.md
+++ b/docs/klean-ui/components/row-actions.md
@@ -1,0 +1,171 @@
+---
+title: Row Actions
+titleTemplate: Klean UI
+description: A durable action group for application rows with real links and buttons, optional Menu overflow, truthful busy state, and caller-owned Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import RowActionsRecipes from '../../.vitepress/theme/components/klean/row-actions/RowActionsRecipes.vue'
+import rowActionsSource from '../../.vitepress/theme/components/klean/row-actions/RowActions.vue?raw'
+import menuSource from '../../.vitepress/theme/components/klean/menu/Menu.vue?raw'
+import popoverSource from '../../.vitepress/theme/components/klean/popover/Popover.vue?raw'
+import reactSource from '../sources/row-actions/RowActions.jsx?raw'
+import svelteSource from '../sources/row-actions/RowActions.svelte?raw'
+import vueUsage from '../snippets/row-actions/usage.vue?raw'
+import reactUsage from '../snippets/row-actions/usage.jsx?raw'
+import svelteUsage from '../snippets/row-actions/usage.svelte?raw'
+
+const vueFiles = [
+  {
+    filename: 'Popover.vue',
+    destination: 'assets/js/components/ui/popover/Popover.vue',
+    source: popoverSource
+  },
+  {
+    filename: 'Menu.vue',
+    destination: 'assets/js/components/ui/menu/Menu.vue',
+    source: menuSource
+  },
+  {
+    filename: 'RowActions.vue',
+    destination: 'assets/js/components/ui/row-actions/RowActions.vue',
+    source: rowActionsSource
+  }
+]
+</script>
+
+# Row Actions
+
+Row Actions keeps the commands and destinations for one application record together. Frequent destinations can remain visible. Secondary actions can sit behind one compact overflow trigger. Every item is still the real anchor, Boring Stack Link, or button that the application intended.
+
+It is one component, not a family of `RowAction`, `RowActionItem`, or `RowActionTrigger` wrappers. There is no action schema, permission callback, visual variant, mutation client, or confirmation prop. The caller writes ordinary semantic markup and styles it with Tailwind.
+
+<KleanPreview id="row-actions-products" :source="vueUsage" filename="ServiceActions.vue">
+  <template #preview>
+    <RowActionsRecipes />
+  </template>
+  <template #caption>
+    Hagfish keeps invoice actions graphic and direct. Slipway keeps service actions quiet and operational. The component contract stays the same.
+  </template>
+</KleanPreview>
+
+## Installation
+
+The command detects Vue, React, or Svelte, copies the matching source, and adds its Menu and Popover dependencies into the same conventional UI directory.
+
+<KleanInstallation
+  id="row-actions-installation"
+  component="row-actions"
+  :source="rowActionsSource"
+  filename="RowActions.vue"
+  destination="assets/js/components/ui/row-actions/RowActions.vue"
+  :files="vueFiles"
+  :dependencies="['tailwind-merge']"
+/>
+
+There is no initializer, provider, `klean-ui.json`, class helper, barrel file, or runtime Klean dependency.
+
+## Usage
+
+Keep the most frequent action visible when that genuinely saves work. Put secondary commands and destinations in the overflow content.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="ServiceActions.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="ServiceActions.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="ServiceActions.svelte" />
+
+## API
+
+| Purpose            | Vue             | React       | Svelte             |
+| ------------------ | --------------- | ----------- | ------------------ |
+| Visible actions    | default slot    | `children`  | `children` snippet |
+| Overflow actions   | `#menu` slot    | `menu`      | `menu` snippet     |
+| Trigger contents   | `#trigger` slot | `trigger`   | `trigger` snippet  |
+| Accessible name    | `label`         | `label`     | `label`            |
+| Pending operation  | `busy`          | `busy`      | `busy`             |
+| Stable overflow ID | `id`            | `id`        | `id`               |
+| Preferred position | `placement`     | `placement` | `placement`        |
+| Trigger gap        | `offset`        | `offset`    | `offset`           |
+| Root styling       | `class`         | `className` | `class`            |
+
+`label` defaults to “Actions.” Use a record-specific label such as “Actions for invoice INV-1042” whenever several action groups appear on the page. `placement` defaults to `bottom-end`, `offset` defaults to `4`, and collision handling may move the menu when the preferred side has no room.
+
+If no overflow content is supplied, Row Actions renders no trigger or menu. If overflow exists, the default trigger is a compact ellipsis button. Replace only its visual contents when the application already has an established icon treatment; Row Actions keeps the button semantics and relationship.
+
+## Durable application behavior
+
+Navigation stays navigation. Use a native anchor or framework-native Inertia Link so URLs remain openable in a new tab, copyable, server-renderable, and recoverable after reload. Row Actions does not convert destinations into click callbacks.
+
+Commands stay buttons. The application owns the router request, processing state, result message, authorization, and server validation. Pass `busy` while an operation makes another overflow choice unsafe; the menu closes and its trigger becomes unavailable, while caller-owned visible actions remain truthful rather than being silently disabled.
+
+Row Actions stops pointer and click propagation at its root so an action inside a clickable table row does not also activate the row. It does not prevent the link or button's own default behavior.
+
+## Permissions and destructive actions
+
+Render only actions the current response authorizes. Ordinary framework conditionals are clearer than a component permission language, and the server still enforces the operation.
+
+A destructive menu item should open a [Dialog](/klean-ui/components/dialog) that names the record and consequence. The Dialog owns confirmation and focus containment; the application owns the request and pending state. Do not make the first click delete the record, and do not ask Row Actions to guess which commands are destructive.
+
+## Keyboard and accessibility
+
+- The root is a named `group`, so repeated action sets remain distinguishable.
+- Visible links and buttons keep their native Tab behavior.
+- The overflow trigger exposes its menu relationship and expanded state.
+- Arrow Down or Arrow Up on the trigger opens the menu at the first or last enabled item.
+- Inside the menu, Arrow keys, Home, End, typeahead, Tab, and Escape follow the established [Menu](/klean-ui/components/menu) contract.
+- Selecting an item closes the menu and restores trigger focus when appropriate.
+- Disabled or `aria-disabled` menu items are skipped and cannot accidentally activate.
+- `busy` is exposed on the group and disables only the overflow trigger.
+- The caller supplies complete visible labels, focus-visible Tailwind classes, and any live result message.
+
+## Styling with Tailwind
+
+Row Actions supplies only a compact inline layout and a neutral trigger. `class` or `className` merges onto the group. The visible actions, overflow items, and optional trigger contents are caller markup, so Tailwind is their entire visual API.
+
+There is no `variant`, `tone`, `size`, `destructive`, `itemClass`, or product theme prop. When several rows share one treatment, create a small application component around the copied source and the product's ordinary classes.
+
+## When to use
+
+Use Row Actions for one record in a Table, DataTable, card list, invoice list, member list, deployment history, or similar repeated application surface. It is especially useful when one common destination should stay visible and less frequent choices need compact overflow.
+
+## When not to use
+
+- Use a plain [Button](/klean-ui/components/button) or Link when the record has only one action.
+- Use [Menu](/klean-ui/components/menu) directly when the trigger is not part of a repeated row action group.
+- Use [Command](/klean-ui/components/command) for application-wide search and command discovery.
+- Use a visible page toolbar for actions that apply to the whole result rather than one record.
+- Do not hide the row's only important task behind an ellipsis merely to make the layout sparse.
+
+## Complete framework source
+
+### Vue
+
+<CopyCode :code="rowActionsSource" label="RowActions.vue" />
+
+### React
+
+<CopyCode :code="reactSource" label="RowActions.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteSource" label="RowActions.svelte" />
+
+## Related components
+
+- [DataTable](/klean-ui/components/data-table) — coordinates server-owned rows, sorting, selection, and pagination around per-row actions.
+- [Table](/klean-ui/components/table) — provides the semantic table markup that may contain action cells.
+- [Menu](/klean-ui/components/menu) — supplies overflow keyboard behavior and truthful link/button items.
+- [Button](/klean-ui/components/button) — represents a visible row command.
+- [Dialog](/klean-ui/components/dialog) — confirms destructive row operations.
+- [Tooltip](/klean-ui/components/tooltip) — supplements a terse icon trigger when visible text cannot fit.

--- a/docs/klean-ui/snippets/row-actions/usage.jsx
+++ b/docs/klean-ui/snippets/row-actions/usage.jsx
@@ -1,0 +1,37 @@
+import { Link, router } from '@inertiajs/react'
+import RowActions from '@/components/ui/row-actions/RowActions.jsx'
+
+export function ServiceActions({ service, busy }) {
+  return (
+    <RowActions
+      label={`Actions for ${service.name}`}
+      busy={busy}
+      menu={
+        <>
+          <Link href={`/services/${service.id}/settings`}>Settings</Link>
+          <button
+            type="button"
+            onClick={() =>
+              router.post(
+                `/services/${service.id}/deployments`,
+                {},
+                { preserveScroll: true }
+              )
+            }
+          >
+            Redeploy
+          </button>
+          <button
+            type="button"
+            command="show-modal"
+            commandFor={`delete-${service.id}`}
+          >
+            Delete service
+          </button>
+        </>
+      }
+    >
+      <Link href={`/services/${service.id}/logs`}>Logs</Link>
+    </RowActions>
+  )
+}

--- a/docs/klean-ui/snippets/row-actions/usage.svelte
+++ b/docs/klean-ui/snippets/row-actions/usage.svelte
@@ -1,0 +1,37 @@
+<script>
+  import { Link, router } from '@inertiajs/svelte'
+  import RowActions from '@/components/ui/row-actions/RowActions.svelte'
+
+  let { service, busy = false } = $props()
+
+  function redeploy() {
+    router.post(
+      `/services/${service.id}/deployments`,
+      {},
+      { preserveScroll: true }
+    )
+  }
+</script>
+
+{#snippet visibleActions()}
+  <Link href={`/services/${service.id}/logs`}>Logs</Link>
+{/snippet}
+
+{#snippet overflowActions()}
+  <Link href={`/services/${service.id}/settings`}>Settings</Link>
+  <button type="button" onclick={redeploy}>Redeploy</button>
+  <button
+    type="button"
+    command="show-modal"
+    commandfor={`delete-${service.id}`}
+  >
+    Delete service
+  </button>
+{/snippet}
+
+<RowActions
+  label={`Actions for ${service.name}`}
+  {busy}
+  children={visibleActions}
+  menu={overflowActions}
+/>

--- a/docs/klean-ui/snippets/row-actions/usage.vue
+++ b/docs/klean-ui/snippets/row-actions/usage.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { Link, router } from '@inertiajs/vue3'
+import RowActions from '@/components/ui/row-actions/RowActions.vue'
+
+defineProps({ service: Object, busy: Boolean })
+
+function redeploy(service) {
+  router.post(
+    `/services/${service.id}/deployments`,
+    {},
+    { preserveScroll: true }
+  )
+}
+</script>
+
+<template>
+  <RowActions :label="`Actions for ${service.name}`" :busy="busy">
+    <Link :href="`/services/${service.id}/logs`">Logs</Link>
+
+    <template #menu>
+      <Link :href="`/services/${service.id}/settings`">Settings</Link>
+      <button type="button" @click="redeploy(service)">Redeploy</button>
+      <button
+        type="button"
+        command="show-modal"
+        :commandfor="`delete-${service.id}`"
+      >
+        Delete service
+      </button>
+    </template>
+  </RowActions>
+</template>

--- a/docs/klean-ui/sources/row-actions/RowActions.jsx
+++ b/docs/klean-ui/sources/row-actions/RowActions.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useId, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+import Menu from '../menu/Menu.jsx'
+
+export default function RowActions({
+  label = 'Actions',
+  busy = false,
+  id,
+  placement = 'bottom-end',
+  offset = 4,
+  className,
+  children,
+  menu,
+  trigger,
+  onClick,
+  onPointerDown,
+  ...rootProps
+}) {
+  const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+  const menuId = id ?? `klean-row-actions-${generatedId}`
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (busy) setOpen(false)
+  }, [busy])
+
+  function handleClick(event) {
+    event.stopPropagation()
+    onClick?.(event)
+  }
+
+  function handlePointerDown(event) {
+    event.stopPropagation()
+    onPointerDown?.(event)
+  }
+
+  return (
+    <div
+      {...rootProps}
+      role="group"
+      aria-label={label}
+      aria-busy={busy || undefined}
+      data-slot="row-actions"
+      className={twMerge('inline-flex items-center gap-1', className)}
+      onPointerDown={handlePointerDown}
+      onClick={handleClick}
+    >
+      {children}
+
+      {menu ? (
+        <>
+          <button
+            type="button"
+            disabled={busy}
+            aria-label={label}
+            aria-controls={menuId}
+            aria-expanded={open}
+            popoverTarget={menuId}
+            data-slot="row-actions-trigger"
+            className="inline-grid size-9 cursor-pointer place-items-center rounded-md text-current hover:bg-black/5 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/10"
+          >
+            {trigger ?? (
+              <svg
+                className="size-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z" />
+              </svg>
+            )}
+          </button>
+          <Menu
+            id={menuId}
+            open={open}
+            onOpenChange={setOpen}
+            aria-label={label}
+            placement={placement}
+            offset={offset}
+            data-row-actions-menu=""
+            className="min-w-40"
+          >
+            {menu}
+          </Menu>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/docs/klean-ui/sources/row-actions/RowActions.svelte
+++ b/docs/klean-ui/sources/row-actions/RowActions.svelte
@@ -1,0 +1,94 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+  import Menu from "../menu/Menu.svelte";
+
+  const componentIdentity = $props.id();
+  const generatedId = componentIdentity.replace(/[^a-zA-Z0-9_-]/g, "");
+  let {
+    label = "Actions",
+    busy = false,
+    id,
+    placement = "bottom-end",
+    offset = 4,
+    class: className = "",
+    children,
+    menu,
+    trigger,
+    onclick,
+    onpointerdown,
+    "data-slot": _dataSlot,
+    ...rootProps
+  } = $props();
+
+  let open = $state(false);
+  let menuId = $derived(id ?? `klean-row-actions-${generatedId}`);
+
+  $effect(() => {
+    if (busy) open = false;
+  });
+
+  function handleClick(event) {
+    event.stopPropagation();
+    onclick?.(event);
+  }
+
+  function handlePointerDown(event) {
+    event.stopPropagation();
+    onpointerdown?.(event);
+  }
+</script>
+
+{#snippet menuContent(context)}
+  {@render menu?.(context)}
+{/snippet}
+
+<div
+  {...rootProps}
+  role="group"
+  aria-label={label}
+  aria-busy={busy || undefined}
+  data-slot="row-actions"
+  class={twMerge("inline-flex items-center gap-1", className)}
+  onclick={handleClick}
+  onpointerdown={handlePointerDown}
+>
+  {@render children?.()}
+
+  {#if menu}
+    <button
+      type="button"
+      disabled={busy}
+      aria-label={label}
+      aria-controls={menuId}
+      aria-expanded={open}
+      popovertarget={menuId}
+      data-slot="row-actions-trigger"
+      class="inline-grid size-9 cursor-pointer place-items-center rounded-md text-current hover:bg-black/5 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/10"
+    >
+      {#if trigger}
+        {@render trigger()}
+      {:else}
+        <svg
+          class="size-4"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"
+          />
+        </svg>
+      {/if}
+    </button>
+    <Menu
+      id={menuId}
+      bind:open
+      aria-label={label}
+      {placement}
+      {offset}
+      data-row-actions-menu=""
+      class="min-w-40"
+      children={menuContent}
+    />
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- add a live and copyable Row Actions page to the Klean UI component catalog
- document the one-piece Vue, React, and Svelte API plus zero-config installation
- cover durable links, caller-owned commands and permissions, destructive confirmation, accessibility, and Tailwind styling
- add grounded Hagfish invoice and Slipway Bridge recipes

## Verification
- VitePress production build passes
- every changed file passes Prettier
- live page and overflow interaction verified in the browser

Closes #228