### PR TITLE
docs: add Klean UI Empty State

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -134,6 +134,7 @@ function kleanUiGuide() {
         { text: 'DataTable', link: '/klean-ui/components/data-table' },
         { text: 'Row Actions', link: '/klean-ui/components/row-actions' },
         { text: 'Bulk Actions', link: '/klean-ui/components/bulk-actions' },
+        { text: 'Empty State', link: '/klean-ui/components/empty-state' },
         { text: 'Filter Bar', link: '/klean-ui/components/filter-bar' },
         { text: 'FileUpload', link: '/klean-ui/components/file-upload' },
         { text: 'Sparkline', link: '/klean-ui/components/sparkline' },

--- a/docs/.vitepress/theme/components/klean/empty-state/EmptyState.vue
+++ b/docs/.vitepress/theme/components/klean/empty-state/EmptyState.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+defineProps({
+  /** Native element or framework component that truthfully fits the document. */
+  as: { type: [String, Object, Function], default: 'div' }
+})
+
+const attrs = useAttrs()
+const element = ref()
+const rootAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <component
+    :is="as"
+    ref="element"
+    v-bind="rootAttrs"
+    data-slot="empty-state"
+    :class="
+      twMerge(
+        'flex min-h-48 w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </component>
+</template>

--- a/docs/.vitepress/theme/components/klean/empty-state/EmptyStateRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/empty-state/EmptyStateRecipes.vue
@@ -1,0 +1,106 @@
+<script setup>
+import { ref } from 'vue'
+import EmptyState from './EmptyState.vue'
+
+const query = ref('worker')
+const notice = ref('')
+
+function clearFilters() {
+  query.value = ''
+  notice.value = 'Filters cleared'
+}
+</script>
+
+<template>
+  <div class="grid w-full max-w-4xl gap-5 sm:grid-cols-2">
+    <section
+      aria-labelledby="empty-state-projects-title"
+      class="dark bg-gray-950 p-5 text-white sm:p-6"
+    >
+      <EmptyState
+        class="min-h-80 rounded-lg border border-gray-800 bg-gray-900 px-5 text-white"
+      >
+        <span
+          aria-hidden="true"
+          class="grid size-11 place-items-center rounded-lg bg-gray-800 text-lg"
+        >
+          ＋
+        </span>
+        <div class="max-w-xs">
+          <h3
+            id="empty-state-projects-title"
+            class="m-0 text-lg font-semibold text-white"
+          >
+            No projects yet
+          </h3>
+          <p class="mt-2 text-sm leading-6 text-gray-400">
+            Create your first project to deploy an application with Slipway.
+          </p>
+        </div>
+        <a
+          href="#create-project"
+          class="inline-flex min-h-10 items-center rounded-md bg-white px-4 text-sm font-medium text-gray-950 no-underline hover:bg-gray-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          Create project
+        </a>
+      </EmptyState>
+    </section>
+
+    <section
+      aria-labelledby="empty-state-clients-title"
+      class="bg-[#f7f3eb] p-5 text-black sm:p-6"
+    >
+      <EmptyState
+        class="min-h-80 rounded-none border-2 border-black bg-white px-5 text-black shadow-[5px_5px_0_0_#000]"
+      >
+        <span aria-hidden="true" class="text-4xl leading-none">◎</span>
+        <div class="max-w-xs">
+          <h3
+            id="empty-state-clients-title"
+            class="m-0 text-xl font-bold tracking-tight"
+          >
+            No clients yet
+          </h3>
+          <p class="mt-2 text-sm leading-6 text-black/60">
+            Add a client before sending your first beautifully boring invoice.
+          </p>
+        </div>
+        <a
+          href="#add-client"
+          class="inline-flex min-h-10 items-center border-2 border-black bg-black px-4 text-sm font-semibold text-white no-underline hover:bg-white hover:text-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
+        >
+          Add client
+        </a>
+      </EmptyState>
+    </section>
+
+    <section
+      aria-labelledby="empty-state-records-title"
+      class="overflow-hidden rounded-lg border border-gray-200 bg-white text-gray-950 dark:border-gray-800 dark:bg-gray-950 dark:text-white sm:col-span-2"
+    >
+      <header class="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+        <h3 id="empty-state-records-title" class="m-0 text-sm font-semibold">
+          Bridge records
+        </h3>
+      </header>
+      <EmptyState
+        v-if="query"
+        class="min-h-0 gap-2 px-4 py-9 text-sm text-gray-500 dark:text-gray-400"
+      >
+        <p>No records match “{{ query }}”.</p>
+        <button
+          type="button"
+          class="min-h-9 cursor-pointer rounded-md px-3 font-medium text-gray-950 underline underline-offset-4 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 dark:text-white dark:hover:bg-gray-900 dark:focus-visible:outline-white"
+          @click="clearFilters"
+        >
+          Clear filters
+        </button>
+      </EmptyState>
+      <p v-else class="m-0 px-4 py-9 text-center text-sm text-gray-500">
+        Filters cleared. Records can render here.
+      </p>
+    </section>
+
+    <p class="sr-only" aria-live="polite">{{ notice }}</p>
+  </div>
+</template>

--- a/docs/klean-ui/components/empty-state.md
+++ b/docs/klean-ui/components/empty-state.md
@@ -1,0 +1,154 @@
+---
+title: Empty State
+titleTemplate: Klean UI
+description: One shallow empty-result layout with caller-owned semantic headings, truthful reasons, real next actions, and ordinary Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import EmptyStateRecipes from '../../.vitepress/theme/components/klean/empty-state/EmptyStateRecipes.vue'
+import emptyStateSource from '../../.vitepress/theme/components/klean/empty-state/EmptyState.vue?raw'
+import reactSource from '../sources/empty-state/EmptyState.jsx?raw'
+import svelteSource from '../sources/empty-state/EmptyState.svelte?raw'
+import vueUsage from '../snippets/empty-state/usage.vue?raw'
+import reactUsage from '../snippets/empty-state/usage.jsx?raw'
+import svelteUsage from '../snippets/empty-state/usage.svelte?raw'
+</script>
+
+# Empty State
+
+Empty State gives a valid surface a calm layout when it currently has nothing to show. The application writes the semantic heading, the specific reason, and the real next action. Klean does not hide those decisions behind component anatomy.
+
+It is one component, not a family of `EmptyHeader`, `EmptyMedia`, `EmptyTitle`, `EmptyDescription`, or `EmptyContent` wrappers. There is no media variant, action schema, loading prop, error prop, illustration package, or product copy.
+
+<KleanPreview id="empty-state-products" :source="vueUsage" filename="ProjectsEmptyState.vue">
+  <template #preview>
+    <EmptyStateRecipes />
+  </template>
+  <template #caption>
+    First use, filtered zero results, and different product voices share a layout boundary without becoming the same message.
+  </template>
+</KleanPreview>
+
+## Installation
+
+The command detects Vue, React, or Svelte and copies the matching one-file source into the conventional UI directory.
+
+<KleanInstallation
+  id="empty-state-installation"
+  component="empty-state"
+  :source="emptyStateSource"
+  filename="EmptyState.vue"
+  destination="assets/js/components/ui/empty-state/EmptyState.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+There is no initializer, provider, `klean-ui.json`, class helper, barrel file, or runtime Klean dependency.
+
+## Usage
+
+Write the same ordinary document markup you would use without a component. Empty State supplies the surrounding layout and class-merging seam.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="ProjectsEmptyState.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="ProjectsEmptyState.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="ProjectsEmptyState.svelte" />
+
+## API
+
+| Purpose          | Vue          | React       | Svelte             |
+| ---------------- | ------------ | ----------- | ------------------ |
+| Truthful element | `as`         | `as`        | `as`               |
+| Content          | default slot | `children`  | `children` snippet |
+| Root styling     | `class`      | `className` | `class`            |
+
+`as` defaults to `div`, which adds no landmark or heading assumption. Pass `section`, `article`, or a framework component only when that element truthfully fits the surrounding document. Native attributes and events pass through unchanged.
+
+There are no `title`, `description`, `icon`, or `actions` props. Those are content, and content should remain visible in the caller's markup.
+
+## Name the reason
+
+“Nothing here” is rarely enough. Tell the user which condition they are in and what can happen next.
+
+- **First use:** “No projects yet” may offer a Create project Link.
+- **Filtered zero:** “No records match ‘worker’” should offer Clear filters when possible.
+- **Completed work:** “You are all caught up” may need no action.
+- **Unavailable capability:** explain the prerequisite or authorized next destination rather than pretending the collection is merely empty.
+
+Keep the title scannable and the description short. Do not reuse cheerful onboarding copy for a filtered search that found nothing.
+
+## Loading, empty, and error are different
+
+Render Empty State only after the request has succeeded and the valid surface is genuinely empty.
+
+- While content is pending, preserve the region and use Spinner or the forthcoming Loading State composition.
+- When the request failed, show a recoverable error with a truthful retry or navigation action.
+- When stale content remains visible during a partial reload, do not replace it with Empty State.
+
+This boundary prevents empty content from flashing during navigation and prevents failures from being mistaken for “zero records.”
+
+## Links, buttons, and authorization
+
+Use a native anchor or framework-native Inertia Link for destinations. Use a button for commands such as clearing filters or retrying a local derivation. Empty State never converts an action description into a callback.
+
+Render only actions authorized by the current server response. If an action is unavailable, update the explanation too; hiding “Create project” while leaving “Get started by creating a project” is misleading.
+
+## Keyboard and accessibility
+
+- The root has no role or live region by default, so server-rendered empty content is not announced twice.
+- The caller owns heading hierarchy. Use the heading level that fits the surrounding page or region.
+- Name a `section` with `aria-labelledby` when it should be a discoverable region.
+- Decorative icons use `aria-hidden="true"`; meaningful images receive useful alternative text.
+- Links and buttons retain native focus, keyboard activation, and modified-click behavior.
+- Dynamically appearing emptiness normally does not need interruption. Add a targeted status message only when the interaction genuinely requires an announcement.
+
+## Styling with Tailwind
+
+The baseline centers a wrapping column with comfortable space. `class` or `className` merges onto that root. Every icon, heading, description, Link, and button is caller markup styled with ordinary Tailwind.
+
+Use classes such as `min-h-0 py-8` for a compact table state, a border and background for a card, or a larger minimum height for a page. There is no `variant`, `compact`, `fullPage`, `media`, `tone`, or product theme prop.
+
+## When to use
+
+Use Empty State when a successfully loaded collection, page, panel, table, or workflow has nothing meaningful to render and a short explanation helps the user understand why.
+
+## When not to use
+
+- Use [Spinner](/klean-ui/components/spinner) or preserve stale content while data is loading.
+- Use [Alert](/klean-ui/components/alert) for important contextual guidance around content that still exists.
+- Use [Toast](/klean-ui/components/toast) for transient feedback after an action.
+- Use [Command](/klean-ui/components/command) or [Combobox](/klean-ui/components/combobox) built-in no-result content inside those interactions.
+- Do not use an illustration-heavy first-use panel for a frequently repeated filtered-zero result.
+
+## Complete framework source
+
+### Vue
+
+<CopyCode :code="emptyStateSource" label="EmptyState.vue" />
+
+### React
+
+<CopyCode :code="reactSource" label="EmptyState.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteSource" label="EmptyState.svelte" />
+
+## Related components
+
+- [DataTable](/klean-ui/components/data-table) — owns the successfully loaded collection and selection around a table empty state.
+- [Filter Bar](/klean-ui/components/filter-bar) — owns the committed filters that a filtered-zero action may clear.
+- [Button](/klean-ui/components/button) — represents a caller-owned command such as clearing filters.
+- [Card](/klean-ui/components/card) — can provide a visual surface around an Empty State without changing its meaning.
+- [Spinner](/klean-ui/components/spinner) — communicates pending work instead of absent content.
+- [Alert](/klean-ui/components/alert) — provides contextual warning or guidance when content still exists.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -89,6 +89,10 @@ A compact group of real row links and buttons with optional accessible overflow,
 
 A selected-record action region with a polite count, real caller-authored links and buttons, truthful busy state, and deliberate focus recovery.
 
+### [Empty State](/klean-ui/components/empty-state)
+
+One shallow empty-result layout with caller-owned semantic headings, explicit reasons, real next actions, and ordinary Tailwind.
+
 ### [Filter Bar](/klean-ui/components/filter-bar)
 
 A native filter form with separate draft and committed state, immediate active-filter removal, pending safety, deterministic URLs, and caller-owned controls and Tailwind.

--- a/docs/klean-ui/snippets/empty-state/usage.jsx
+++ b/docs/klean-ui/snippets/empty-state/usage.jsx
@@ -1,0 +1,15 @@
+import { Link } from '@inertiajs/react'
+import EmptyState from '@/components/ui/empty-state/EmptyState.jsx'
+
+export function ProjectsEmptyState() {
+  return (
+    <EmptyState as="section" aria-labelledby="projects-empty-title">
+      <svg aria-hidden="true">{/* Application icon */}</svg>
+      <div>
+        <h2 id="projects-empty-title">No projects yet</h2>
+        <p>Create your first project to deploy an application.</p>
+      </div>
+      <Link href="/projects/new">Create project</Link>
+    </EmptyState>
+  )
+}

--- a/docs/klean-ui/snippets/empty-state/usage.svelte
+++ b/docs/klean-ui/snippets/empty-state/usage.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { Link } from '@inertiajs/svelte'
+  import EmptyState from '@/components/ui/empty-state/EmptyState.svelte'
+</script>
+
+<EmptyState as="section" aria-labelledby="projects-empty-title">
+  <svg aria-hidden="true"><!-- Application icon --></svg>
+  <div>
+    <h2 id="projects-empty-title">No projects yet</h2>
+    <p>Create your first project to deploy an application.</p>
+  </div>
+  <Link href="/projects/new">Create project</Link>
+</EmptyState>

--- a/docs/klean-ui/snippets/empty-state/usage.vue
+++ b/docs/klean-ui/snippets/empty-state/usage.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { Link } from '@inertiajs/vue3'
+import EmptyState from '@/components/ui/empty-state/EmptyState.vue'
+</script>
+
+<template>
+  <EmptyState as="section" aria-labelledby="projects-empty-title">
+    <svg aria-hidden="true"><!-- Application icon --></svg>
+    <div>
+      <h2 id="projects-empty-title">No projects yet</h2>
+      <p>Create your first project to deploy an application.</p>
+    </div>
+    <Link href="/projects/new">Create project</Link>
+  </EmptyState>
+</template>

--- a/docs/klean-ui/sources/empty-state/EmptyState.jsx
+++ b/docs/klean-ui/sources/empty-state/EmptyState.jsx
@@ -1,0 +1,21 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES =
+  'flex min-h-48 w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white'
+
+const EmptyState = forwardRef(function EmptyState(
+  { as: Component = 'div', className, 'data-slot': _dataSlot, ...props },
+  ref
+) {
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      data-slot="empty-state"
+      className={twMerge(BASE_CLASSES, className)}
+    />
+  )
+})
+
+export default EmptyState

--- a/docs/klean-ui/sources/empty-state/EmptyState.svelte
+++ b/docs/klean-ui/sources/empty-state/EmptyState.svelte
@@ -1,0 +1,42 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES =
+    "flex min-h-48 w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white";
+
+  let {
+    as = "div",
+    children,
+    class: className,
+    "data-slot": _dataSlot,
+    ...rootProps
+  } = $props();
+
+  let element = $state();
+
+  export function getElement() {
+    return element;
+  }
+</script>
+
+{#if typeof as === "string"}
+  <svelte:element
+    this={as}
+    {...rootProps}
+    bind:this={element}
+    data-slot="empty-state"
+    class={twMerge(BASE_CLASSES, className)}
+  >
+    {@render children?.()}
+  </svelte:element>
+{:else}
+  {@const Component = as}
+  <Component
+    {...rootProps}
+    bind:this={element}
+    data-slot="empty-state"
+    class={twMerge(BASE_CLASSES, className)}
+  >
+    {@render children?.()}
+  </Component>
+{/if}


### PR DESCRIPTION
Closes #232

Adds the canonical live and copyable Empty State documentation for Vue, React, and Svelte: zero-config installation, one-piece API, semantic content guidance, first-use versus filtered-zero boundaries, real Link/button actions, accessibility, Tailwind recipes, loading/error distinctions, and related components.

Upstream source: sailscastshq/klean-ui#119