### PR TITLE
docs: document loading state

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -135,6 +135,7 @@ function kleanUiGuide() {
         { text: 'Row Actions', link: '/klean-ui/components/row-actions' },
         { text: 'Bulk Actions', link: '/klean-ui/components/bulk-actions' },
         { text: 'Empty State', link: '/klean-ui/components/empty-state' },
+        { text: 'Loading State', link: '/klean-ui/components/loading-state' },
         { text: 'Filter Bar', link: '/klean-ui/components/filter-bar' },
         { text: 'FileUpload', link: '/klean-ui/components/file-upload' },
         { text: 'Sparkline', link: '/klean-ui/components/sparkline' },

--- a/docs/.vitepress/theme/components/klean/loading-state/LoadingState.vue
+++ b/docs/.vitepress/theme/components/klean/loading-state/LoadingState.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
+const element = ref()
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-live': _ariaLive,
+    'aria-atomic': _ariaAtomic,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <div
+    ref="element"
+    v-bind="rootAttrs"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    data-slot="loading-state"
+    :class="
+      twMerge(
+        'flex min-h-32 w-full flex-col items-center justify-center gap-3 p-6 text-center text-gray-600 dark:text-gray-300',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/klean/loading-state/LoadingStateRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/loading-state/LoadingStateRecipes.vue
@@ -1,0 +1,85 @@
+<script setup>
+import LoadingState from './LoadingState.vue'
+import ProductLoader from '../spinner/ProductLoader.vue'
+import Spinner from '../spinner/Spinner.vue'
+</script>
+
+<template>
+  <div class="grid w-full max-w-4xl gap-5 sm:grid-cols-2">
+    <section
+      aria-busy="true"
+      aria-labelledby="loading-state-deployments-title"
+      class="dark bg-gray-950 text-white"
+    >
+      <h3 id="loading-state-deployments-title" class="sr-only">Deployments</h3>
+      <LoadingState class="min-h-72 text-gray-300 dark:text-gray-300">
+        <Spinner class="size-10 text-white">
+          <ProductLoader />
+        </Spinner>
+        <span class="text-sm">Loading deployments…</span>
+      </LoadingState>
+    </section>
+
+    <section
+      aria-busy="true"
+      aria-labelledby="loading-state-invoices-title"
+      class="border-2 border-black bg-[#f4f0e8] p-6 text-black shadow-[4px_4px_0_0_#000]"
+    >
+      <h3 id="loading-state-invoices-title" class="m-0 text-xl font-semibold">
+        Invoices
+      </h3>
+      <LoadingState
+        class="min-h-56 items-stretch gap-4 p-0 pt-6 text-left text-black dark:text-black"
+      >
+        <span class="sr-only">Loading invoices…</span>
+        <div aria-hidden="true" class="space-y-3">
+          <div
+            v-for="row in 3"
+            :key="row"
+            class="h-12 animate-pulse bg-black/10 motion-reduce:animate-none"
+          ></div>
+        </div>
+      </LoadingState>
+    </section>
+
+    <section
+      aria-busy="true"
+      aria-labelledby="loading-state-services-title"
+      aria-describedby="loading-state-services-status"
+      class="rounded-lg border border-gray-200 bg-white p-6 text-gray-950 dark:border-gray-800 dark:bg-gray-950 dark:text-white sm:col-span-2"
+    >
+      <div
+        class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 pb-4 dark:border-gray-800"
+      >
+        <h3 id="loading-state-services-title" class="m-0 text-lg font-semibold">
+          Services
+        </h3>
+        <LoadingState
+          id="loading-state-services-status"
+          class="min-h-0 w-auto flex-row justify-start gap-2 p-0 text-left text-sm text-gray-500 dark:text-gray-400"
+        >
+          <Spinner class="size-4" />
+          Refreshing…
+        </LoadingState>
+      </div>
+      <ul class="m-0 divide-y divide-gray-200 p-0 dark:divide-gray-800">
+        <li class="flex items-center justify-between gap-4 py-4 first:mt-0">
+          <span>api.sailscasts.com</span>
+          <span class="text-sm text-emerald-700 dark:text-emerald-400">
+            Healthy
+          </span>
+        </li>
+        <li class="flex items-center justify-between gap-4 py-4">
+          <span>docs.sailscasts.com</span>
+          <span class="text-sm text-emerald-700 dark:text-emerald-400">
+            Healthy
+          </span>
+        </li>
+        <li class="flex items-center justify-between gap-4 py-4">
+          <span>workers</span>
+          <span class="text-sm text-gray-500">Updating</span>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -93,6 +93,10 @@ A selected-record action region with a polite count, real caller-authored links 
 
 One shallow empty-result layout with caller-owned semantic headings, explicit reasons, real next actions, and ordinary Tailwind.
 
+### [Loading State](/klean-ui/components/loading-state)
+
+One truthful pending-content status layout with caller-owned busy regions, useful copy, product marks, skeleton markup, and ordinary Tailwind.
+
 ### [Filter Bar](/klean-ui/components/filter-bar)
 
 A native filter form with separate draft and committed state, immediate active-filter removal, pending safety, deterministic URLs, and caller-owned controls and Tailwind.

--- a/docs/klean-ui/components/loading-state.md
+++ b/docs/klean-ui/components/loading-state.md
@@ -1,0 +1,144 @@
+---
+title: Loading State
+titleTemplate: Klean UI
+description: One truthful pending-content status layout with caller-owned busy regions, request state, useful copy, skeleton markup, and Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import LoadingStateRecipes from '../../.vitepress/theme/components/klean/loading-state/LoadingStateRecipes.vue'
+import loadingStateSource from '../../.vitepress/theme/components/klean/loading-state/LoadingState.vue?raw'
+import reactSource from '../sources/loading-state/LoadingState.jsx?raw'
+import svelteSource from '../sources/loading-state/LoadingState.svelte?raw'
+import vueUsage from '../snippets/loading-state/usage.vue?raw'
+import reactUsage from '../snippets/loading-state/usage.jsx?raw'
+import svelteUsage from '../snippets/loading-state/usage.svelte?raw'
+</script>
+
+# Loading State
+
+Loading State gives pending content one calm, useful status surface. The application marks the region that is busy, names the work in plain language, and decides whether to show a product mark, caller-written skeletons, or content that is already useful.
+
+It is one component. There is no request prop, timer, data-fetching hook, skeleton component, visual variant, full-page mode, or product copy hidden behind its API.
+
+<KleanPreview id="loading-state-apps" :source="vueUsage" filename="ServicesLoading.vue">
+  <template #preview>
+    <LoadingStateRecipes />
+  </template>
+  <template #caption>
+    An initial load, a caller-shaped skeleton, and a refresh that preserves useful rows share the same truthful status contract.
+  </template>
+</KleanPreview>
+
+## Installation
+
+The command detects Vue, React, or Svelte and copies the matching one-file source into the conventional UI directory.
+
+<KleanInstallation
+  id="loading-state-installation"
+  component="loading-state"
+  :source="loadingStateSource"
+  filename="LoadingState.vue"
+  destination="assets/js/components/ui/loading-state/LoadingState.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+The examples also use [Spinner](/klean-ui/components/spinner). Add it separately with `npx klean-ui add spinner`, or place an application-owned mark or skeleton inside Loading State.
+
+## Usage
+
+Put `aria-busy` on the region whose content is changing. Loading State provides the persistent polite status; the caller supplies useful words and optional visuals.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="ServicesLoading.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="ServicesLoading.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="ServicesLoading.svelte" />
+
+## API
+
+| Purpose        | Vue          | React           | Svelte             |
+| -------------- | ------------ | --------------- | ------------------ |
+| Content        | default slot | `children`      | `children` snippet |
+| Root styling   | `class`      | `className`     | `class`            |
+| Element access | template ref | forwarded `ref` | component binding  |
+
+Native `div` attributes and events pass through. The root remains a polite, atomic status so the same content is not accidentally made assertive by styling code.
+
+There are no `loading`, `delay`, `promise`, `skeleton`, `title`, `description`, `variant`, `tone`, `compact`, `fullPage`, `retry`, or `cancel` props. Request state, timing, content, and recovery stay visible in application code.
+
+## Loading State, Spinner, and skeletons
+
+- **Loading State** is the semantic and layout boundary for pending content.
+- **Spinner** is an optional decorative mark inside a button or Loading State.
+- **Skeletons** describe the shape of one application's content, so write them as ordinary caller markup inside Loading State.
+
+Spinner alone does not name the work. A skeleton alone should be hidden from assistive technology and paired with useful status text. Loading State can contain either, both, or neither.
+
+## Initial loads and refreshes
+
+For the first load, it is reasonable for Loading State to occupy the content region. Keep the region's heading available and mark that region busy.
+
+For a refresh, preserve content that is still useful. Place a compact Loading State beside the region heading and keep the existing rows, chart, or summary readable until the new response arrives. This avoids destructive flicker and retains context during Inertia partial reloads.
+
+The application decides when pending work starts and ends. Loading State does not delay its appearance or invent a minimum duration; those decisions depend on the real request and whether stale content is safe.
+
+## Accessibility
+
+- The root is a persistent `role="status"` with polite, atomic announcements.
+- Put `aria-busy="true"` on the affected button, form, table region, or section—not on an unrelated page wrapper.
+- Write specific text such as “Loading invoices…” or “Refreshing deployments…”.
+- Hide decorative spinners and skeleton shapes from assistive technology.
+- Respect reduced motion on caller-authored skeleton animation with `motion-reduce:animate-none`.
+- Do not move focus when loading begins or ends. Preserve the control or content context the user already has.
+- When a submission failure needs immediate attention, use a contextual error surface rather than changing Loading State into an alert.
+
+## Styling with Tailwind
+
+The baseline is a centered, wrapping column with a useful minimum height. `class` or `className` merges onto the root, so applications can create compact refresh text, a full content-region loader, or a left-aligned skeleton with ordinary Tailwind.
+
+The visual content remains caller markup. Slipway can keep its animated Slippy mark, Hagfish can keep its sharp invoice skeletons, and neither product treatment becomes a Klean prop.
+
+## When to use
+
+Use Loading State when a named region is waiting for content or refreshing existing content and a visible, accessible status will help the user understand what is happening.
+
+## When not to use
+
+- Use [Spinner](/klean-ui/components/spinner) directly inside a pending button when the button text already names the work.
+- Use [Empty State](/klean-ui/components/empty-state) only after a request succeeds and there is genuinely nothing to show.
+- Use [Alert](/klean-ui/components/alert) for contextual warnings or recoverable failures.
+- Use [Toast](/klean-ui/components/toast) for transient feedback after an action completes.
+- Use native `<progress>` when meaningful progress can be measured.
+
+## Complete framework source
+
+### Vue
+
+<CopyCode :code="loadingStateSource" label="LoadingState.vue" />
+
+### React
+
+<CopyCode :code="reactSource" label="LoadingState.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteSource" label="LoadingState.svelte" />
+
+## Related components
+
+- [Spinner](/klean-ui/components/spinner) — supplies an optional decorative loading mark.
+- [Empty State](/klean-ui/components/empty-state) — represents a successfully loaded surface with no content.
+- [DataTable](/klean-ui/components/data-table) — can preserve rows and expose a compact refresh status.
+- [Button](/klean-ui/components/button) — owns truthful pending and disabled state for commands.
+- [Alert](/klean-ui/components/alert) — communicates a warning or recoverable failure instead of pending work.
+- [Toast](/klean-ui/components/toast) — announces transient completion feedback.

--- a/docs/klean-ui/snippets/loading-state/usage.jsx
+++ b/docs/klean-ui/snippets/loading-state/usage.jsx
@@ -1,0 +1,14 @@
+import LoadingState from '@/components/ui/loading-state/LoadingState.jsx'
+import Spinner from '@/components/ui/spinner/Spinner.jsx'
+
+export default function ServicesLoading() {
+  return (
+    <section aria-busy="true" aria-labelledby="services-title">
+      <h2 id="services-title">Services</h2>
+      <LoadingState>
+        <Spinner className="size-6" />
+        <span>Loading services…</span>
+      </LoadingState>
+    </section>
+  )
+}

--- a/docs/klean-ui/snippets/loading-state/usage.svelte
+++ b/docs/klean-ui/snippets/loading-state/usage.svelte
@@ -1,0 +1,12 @@
+<script>
+  import LoadingState from '@/components/ui/loading-state/LoadingState.svelte'
+  import Spinner from '@/components/ui/spinner/Spinner.svelte'
+</script>
+
+<section aria-busy="true" aria-labelledby="services-title">
+  <h2 id="services-title">Services</h2>
+  <LoadingState>
+    <Spinner class="size-6" />
+    <span>Loading services…</span>
+  </LoadingState>
+</section>

--- a/docs/klean-ui/snippets/loading-state/usage.vue
+++ b/docs/klean-ui/snippets/loading-state/usage.vue
@@ -1,0 +1,14 @@
+<script setup>
+import LoadingState from '@/components/ui/loading-state/LoadingState.vue'
+import Spinner from '@/components/ui/spinner/Spinner.vue'
+</script>
+
+<template>
+  <section aria-busy="true" aria-labelledby="services-title">
+    <h2 id="services-title">Services</h2>
+    <LoadingState>
+      <Spinner class="size-6" />
+      <span>Loading services…</span>
+    </LoadingState>
+  </section>
+</template>

--- a/docs/klean-ui/sources/loading-state/LoadingState.jsx
+++ b/docs/klean-ui/sources/loading-state/LoadingState.jsx
@@ -1,0 +1,31 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES =
+  'flex min-h-32 w-full flex-col items-center justify-center gap-3 p-6 text-center text-gray-600 dark:text-gray-300'
+
+const LoadingState = forwardRef(function LoadingState(
+  {
+    className,
+    role: _role,
+    'aria-live': _ariaLive,
+    'aria-atomic': _ariaAtomic,
+    'data-slot': _dataSlot,
+    ...props
+  },
+  ref
+) {
+  return (
+    <div
+      {...props}
+      ref={ref}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-slot="loading-state"
+      className={twMerge(BASE_CLASSES, className)}
+    />
+  )
+})
+
+export default LoadingState

--- a/docs/klean-ui/sources/loading-state/LoadingState.svelte
+++ b/docs/klean-ui/sources/loading-state/LoadingState.svelte
@@ -1,0 +1,34 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES =
+    "flex min-h-32 w-full flex-col items-center justify-center gap-3 p-6 text-center text-gray-600 dark:text-gray-300";
+
+  let {
+    children,
+    class: className,
+    role: _role,
+    "aria-live": _ariaLive,
+    "aria-atomic": _ariaAtomic,
+    "data-slot": _dataSlot,
+    ...rootProps
+  } = $props();
+
+  let element = $state();
+
+  export function getElement() {
+    return element;
+  }
+</script>
+
+<div
+  {...rootProps}
+  bind:this={element}
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"
+  data-slot="loading-state"
+  class={twMerge(BASE_CLASSES, className)}
+>
+  {@render children?.()}
+</div>


### PR DESCRIPTION
Closes #234

Adds the canonical Loading State docs with interactive real-application recipes, zero-configuration installation, copyable Vue/React/Svelte usage and source, accessibility guidance, stale-content refresh guidance, Tailwind ownership, and related components.

Verification:
- targeted formatting passes
- VitePress production build passes
- live docs route and sidebar pass
- preview/source tabs render correctly
- temporary staging directory deleted