### PR TITLE
docs: document error state

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -136,6 +136,7 @@ function kleanUiGuide() {
         { text: 'Bulk Actions', link: '/klean-ui/components/bulk-actions' },
         { text: 'Empty State', link: '/klean-ui/components/empty-state' },
         { text: 'Loading State', link: '/klean-ui/components/loading-state' },
+        { text: 'Error State', link: '/klean-ui/components/error-state' },
         { text: 'Filter Bar', link: '/klean-ui/components/filter-bar' },
         { text: 'FileUpload', link: '/klean-ui/components/file-upload' },
         { text: 'Sparkline', link: '/klean-ui/components/sparkline' },

--- a/docs/.vitepress/theme/components/klean/error-state/ErrorState.vue
+++ b/docs/.vitepress/theme/components/klean/error-state/ErrorState.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+defineProps({
+  /** Native element or framework component that truthfully fits the document. */
+  as: { type: [String, Object, Function], default: 'div' }
+})
+
+const attrs = useAttrs()
+const element = ref()
+const rootAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <component
+    :is="as"
+    ref="element"
+    v-bind="rootAttrs"
+    data-slot="error-state"
+    :class="
+      twMerge(
+        'flex min-h-48 w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </component>
+</template>

--- a/docs/.vitepress/theme/components/klean/error-state/ErrorStateRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/error-state/ErrorStateRecipes.vue
@@ -1,0 +1,139 @@
+<script setup>
+import { ref } from 'vue'
+import Button from '../Button.vue'
+import ErrorState from './ErrorState.vue'
+
+const bridgeFailed = ref(true)
+const invoicesFailed = ref(true)
+const dynamicFailure = ref(false)
+const notice = ref('')
+
+function retryBridge() {
+  bridgeFailed.value = false
+  notice.value = 'Bridge records loaded'
+}
+
+function retryInvoices() {
+  invoicesFailed.value = false
+  notice.value = 'Invoices loaded'
+}
+</script>
+
+<template>
+  <div class="grid w-full max-w-4xl gap-5 sm:grid-cols-2">
+    <section
+      aria-labelledby="error-state-bridge-title"
+      class="dark bg-gray-950 p-5 text-white sm:p-6"
+    >
+      <ErrorState
+        v-if="bridgeFailed"
+        class="min-h-80 rounded-xl border border-gray-800 bg-gray-900 px-6 text-white"
+      >
+        <span
+          aria-hidden="true"
+          class="grid size-12 place-items-center rounded-lg bg-red-950 text-xl text-red-300"
+        >
+          !
+        </span>
+        <div class="max-w-sm">
+          <h3 id="error-state-bridge-title" class="m-0 text-lg font-semibold">
+            Bridge records could not load
+          </h3>
+          <p class="mt-2 text-sm leading-6 text-gray-400">
+            Slipway could not reach this datastore. Your filters have been
+            preserved.
+          </p>
+        </div>
+        <Button
+          type="button"
+          class="min-h-10 min-w-0 bg-white px-4 py-2 text-gray-950 hover:bg-gray-200 dark:bg-white dark:text-gray-950"
+          @click="retryBridge"
+        >
+          Try again
+        </Button>
+      </ErrorState>
+      <p
+        v-else
+        class="m-0 grid min-h-80 place-items-center text-sm text-gray-300"
+      >
+        Bridge records loaded.
+      </p>
+    </section>
+
+    <section
+      aria-labelledby="error-state-invoices-title"
+      class="border-2 border-black bg-[#f4f0e8] p-5 text-black shadow-[5px_5px_0_0_#000] sm:p-6"
+    >
+      <ErrorState
+        v-if="invoicesFailed"
+        class="min-h-80 rounded-none border-2 border-black bg-white px-6 text-black"
+      >
+        <span aria-hidden="true" class="text-5xl leading-none">×</span>
+        <div class="max-w-sm">
+          <h3 id="error-state-invoices-title" class="m-0 text-xl font-bold">
+            Invoices could not load
+          </h3>
+          <p class="mt-2 text-sm leading-6 text-black/60">
+            Hagfish kept your current work. Check the connection and try again.
+          </p>
+        </div>
+        <Button
+          type="button"
+          class="min-h-11 min-w-0 rounded-none border-2 border-black bg-black px-5 font-semibold text-white hover:bg-white hover:text-black dark:bg-black dark:text-white"
+          @click="retryInvoices"
+        >
+          Try again
+        </Button>
+      </ErrorState>
+      <p v-else class="m-0 grid min-h-80 place-items-center text-sm">
+        Invoices loaded.
+      </p>
+    </section>
+
+    <section
+      aria-labelledby="error-state-dynamic-title"
+      class="rounded-lg border border-gray-200 bg-white p-5 text-gray-950 dark:border-gray-800 dark:bg-gray-950 dark:text-white sm:col-span-2 sm:p-6"
+    >
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 id="error-state-dynamic-title" class="m-0 font-semibold">
+            Deployment activity
+          </h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            A dynamic failure opts into alert semantics in caller markup.
+          </p>
+        </div>
+        <Button
+          type="button"
+          class="min-h-10 min-w-0 px-4 py-2"
+          @click="dynamicFailure = true"
+        >
+          Simulate failure
+        </Button>
+      </div>
+      <ErrorState
+        v-if="dynamicFailure"
+        role="alert"
+        aria-labelledby="error-state-dynamic-message"
+        class="mt-5 min-h-0 items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-left dark:border-red-900/50 dark:bg-red-950/20"
+      >
+        <h4 id="error-state-dynamic-message" class="m-0 text-sm font-semibold">
+          Activity could not refresh
+        </h4>
+        <p class="m-0 text-sm text-gray-600 dark:text-gray-300">
+          Existing activity remains available. Try again when the connection is
+          restored.
+        </p>
+        <Button
+          type="button"
+          class="mt-1 min-h-9 min-w-0 px-3 py-1.5 text-sm"
+          @click="dynamicFailure = false"
+        >
+          Dismiss
+        </Button>
+      </ErrorState>
+    </section>
+
+    <p class="sr-only" aria-live="polite">{{ notice }}</p>
+  </div>
+</template>

--- a/docs/klean-ui/components/error-state.md
+++ b/docs/klean-ui/components/error-state.md
@@ -1,0 +1,163 @@
+---
+title: Error State
+titleTemplate: Klean UI
+description: One shallow failed-content layout with caller-owned semantics, truthful recovery, safe diagnostics, and ordinary Tailwind across Vue, React, and Svelte.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
+import ErrorStateRecipes from '../../.vitepress/theme/components/klean/error-state/ErrorStateRecipes.vue'
+import errorStateSource from '../../.vitepress/theme/components/klean/error-state/ErrorState.vue?raw'
+import reactSource from '../sources/error-state/ErrorState.jsx?raw'
+import svelteSource from '../sources/error-state/ErrorState.svelte?raw'
+import vueUsage from '../snippets/error-state/usage.vue?raw'
+import reactUsage from '../snippets/error-state/usage.jsx?raw'
+import svelteUsage from '../snippets/error-state/usage.svelte?raw'
+</script>
+
+# Error State
+
+Error State gives a failed page or content region a calm layout for a truthful explanation and a safe way forward. The application writes the heading, copy, recovery controls, announcement semantics, focus behavior, and ordinary Tailwind.
+
+It is one component, not a family of title, description, icon, action, or details wrappers. It does not catch exceptions, normalize errors, retry requests, move focus, navigate, log, or expose diagnostic data.
+
+<KleanPreview id="error-state-apps" :source="vueUsage" filename="ServicesError.vue">
+  <template #preview>
+    <ErrorStateRecipes />
+  </template>
+  <template #caption>
+    Slipway and Hagfish keep distinct product treatments, while a dynamically appearing failure opts into a native alert only when the caller needs it.
+  </template>
+</KleanPreview>
+
+## Installation
+
+The command detects Vue, React, or Svelte and copies the matching one-file source into the conventional UI directory.
+
+<KleanInstallation
+  id="error-state-installation"
+  component="error-state"
+  :source="errorStateSource"
+  filename="ErrorState.vue"
+  destination="assets/js/components/ui/error-state/ErrorState.vue"
+  :dependencies="['tailwind-merge']"
+/>
+
+The examples also use [Button](/klean-ui/components/button). Add it separately with `npx klean-ui add button`, or use an existing native button or framework-native Link.
+
+## Usage
+
+Use native alert semantics only when a failure appears dynamically and warrants interruption. Static error pages should use ordinary page or section semantics so their heading is not announced twice.
+
+### Vue
+
+<CopyCode :code="vueUsage" label="ServicesError.vue" />
+
+### React
+
+<CopyCode :code="reactUsage" label="ServicesError.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteUsage" label="ServicesError.svelte" />
+
+## API
+
+| Purpose          | Vue          | React       | Svelte             |
+| ---------------- | ------------ | ----------- | ------------------ |
+| Truthful element | `as`         | `as`        | `as`               |
+| Content          | default slot | `children`  | `children` snippet |
+| Root styling     | `class`      | `className` | `class`            |
+
+`as` defaults to `div`. Native attributes and events pass through unchanged, including a caller-authored `role="alert"`, `aria-labelledby`, click handler, or data attribute.
+
+There are no `title`, `description`, `icon`, `actions`, `details`, `message`, `error`, `retry`, `variant`, `tone`, `compact`, or `fullPage` props. Those decisions remain visible in application markup.
+
+## Static pages and dynamic alerts
+
+A server-rendered 403, 404, 419, 429, 500, or 503 page already has normal document reading order. Use `as="section"` with a real heading, but do not add an alert merely because the page describes an error.
+
+When a previously usable region changes into a failure after a request, add `role="alert"` in caller markup if immediate announcement is warranted. Keep the explanation specific and provide recovery only when recovery is real.
+
+Do not automatically focus Error State. If the control that started the request remains useful, keep it mounted. If a focused retry control disappears after success, deliberately restore focus to a stable control or the newly loaded region.
+
+## Recovery stays durable
+
+- Retry commands are native buttons and keep their application-owned request logic.
+- Destinations are native anchors or framework-native Inertia Links, preserving modified clicks, history, and server-rendered fallbacks.
+- Preserve safe stale content, filters, and form values when recovery does not require clearing them.
+- Render only actions the current server response authorizes.
+- Do not label a permanent denial or missing page as retryable.
+
+Klean does not accept an action array or convert descriptions into callbacks. Recovery is ordinary markup that remains understandable without client-side adaptation.
+
+## Safe diagnostics
+
+The caller may add a native `<details>` element for diagnostics that are safe and genuinely useful to the current user. Never pass raw stack traces, provider responses, secrets, tokens, SQL, internal identifiers, or unsanitized HTML into a user-facing Error State.
+
+Log private diagnostics through the application's normal observability path. User copy should explain what failed, what was preserved, and what can happen next.
+
+## Error State is not every error
+
+- Field validation stays beside its control and may be summarized with links to the invalid fields.
+- [Alert](/klean-ui/components/alert) gives contextual guidance while the surrounding content still exists.
+- [Toast](/klean-ui/components/toast) gives transient feedback after a mutation.
+- An application error boundary catches rendering exceptions; Error State may be the boundary's caller-authored fallback, but does not implement the boundary.
+- A deployment with a failed status is domain content, not necessarily a failed page or region.
+
+This separation keeps the user's input intact and avoids turning every red message into the same interaction.
+
+## Accessibility
+
+- Use a heading level that fits the surrounding document.
+- Name a region with `aria-labelledby` when it should be discoverable.
+- Use `role="alert"` only for a newly appearing failure that needs interruption.
+- Do not combine `role="alert"` with another live region that repeats the same message.
+- Keep retry and navigation controls native and keyboard reachable.
+- Preserve focus by default; move it only when the interaction has a clear destination.
+- Decorative error icons use `aria-hidden="true"`.
+- Write specific recovery copy. “Something went wrong” alone is not actionable.
+
+## Styling with Tailwind
+
+The neutral baseline centers a wrapping column with comfortable space. `class` or `className` merges onto the root. Every icon, heading, paragraph, Link, button, and details disclosure is caller markup styled with ordinary Tailwind.
+
+Slipway can use a calm dark region, Hagfish can keep its sharp monochrome borders, and a status page can become a left-aligned editorial layout. There is no visual-variant API.
+
+## When to use
+
+Use Error State when a page or meaningful content region failed and the user needs an explanation, a safe recovery action, or an honest destination.
+
+## When not to use
+
+- Use [Loading State](/klean-ui/components/loading-state) while content is pending.
+- Use [Empty State](/klean-ui/components/empty-state) after a successful request returns no content.
+- Use [Alert](/klean-ui/components/alert) when important content still exists around the message.
+- Use Field validation for input-specific errors.
+- Use [Toast](/klean-ui/components/toast) for transient action feedback.
+
+## Complete framework source
+
+### Vue
+
+<CopyCode :code="errorStateSource" label="ErrorState.vue" />
+
+### React
+
+<CopyCode :code="reactSource" label="ErrorState.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteSource" label="ErrorState.svelte" />
+
+## Related components
+
+- [Loading State](/klean-ui/components/loading-state) — represents pending content before success or failure is known.
+- [Empty State](/klean-ui/components/empty-state) — represents a successfully loaded surface with no content.
+- [Alert](/klean-ui/components/alert) — gives contextual guidance without replacing the surrounding region.
+- [Button](/klean-ui/components/button) — supplies a native caller-owned retry command.
+- [Toast](/klean-ui/components/toast) — announces transient mutation feedback.
+- [DataTable](/klean-ui/components/data-table) — may preserve safe rows while a refresh failure is explained.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -97,6 +97,10 @@ One shallow empty-result layout with caller-owned semantic headings, explicit re
 
 One truthful pending-content status layout with caller-owned busy regions, useful copy, product marks, skeleton markup, and ordinary Tailwind.
 
+### [Error State](/klean-ui/components/error-state)
+
+One shallow failed-content layout with caller-owned announcement semantics, recovery controls, safe diagnostics, and ordinary Tailwind.
+
 ### [Filter Bar](/klean-ui/components/filter-bar)
 
 A native filter form with separate draft and committed state, immediate active-filter removal, pending safety, deterministic URLs, and caller-owned controls and Tailwind.

--- a/docs/klean-ui/snippets/error-state/usage.jsx
+++ b/docs/klean-ui/snippets/error-state/usage.jsx
@@ -1,0 +1,16 @@
+import ErrorState from '@/components/ui/error-state/ErrorState.jsx'
+import Button from '@/components/ui/button/Button.jsx'
+
+export default function ServicesError({ failed, retry }) {
+  if (!failed) return null
+
+  return (
+    <ErrorState role="alert" aria-labelledby="services-error-title">
+      <h2 id="services-error-title">Services could not load</h2>
+      <p>Slipway could not reach the deployment service.</p>
+      <Button type="button" onClick={retry}>
+        Try again
+      </Button>
+    </ErrorState>
+  )
+}

--- a/docs/klean-ui/snippets/error-state/usage.svelte
+++ b/docs/klean-ui/snippets/error-state/usage.svelte
@@ -1,0 +1,14 @@
+<script>
+  import ErrorState from '@/components/ui/error-state/ErrorState.svelte'
+  import Button from '@/components/ui/button/Button.svelte'
+
+  let { failed, retry } = $props()
+</script>
+
+{#if failed}
+  <ErrorState role="alert" aria-labelledby="services-error-title">
+    <h2 id="services-error-title">Services could not load</h2>
+    <p>Slipway could not reach the deployment service.</p>
+    <Button type="button" onclick={retry}>Try again</Button>
+  </ErrorState>
+{/if}

--- a/docs/klean-ui/snippets/error-state/usage.vue
+++ b/docs/klean-ui/snippets/error-state/usage.vue
@@ -1,0 +1,15 @@
+<script setup>
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
+import Button from '@/components/ui/button/Button.vue'
+
+defineProps({ failed: Boolean })
+defineEmits(['retry'])
+</script>
+
+<template>
+  <ErrorState v-if="failed" role="alert" aria-labelledby="services-error-title">
+    <h2 id="services-error-title">Services could not load</h2>
+    <p>Slipway could not reach the deployment service.</p>
+    <Button type="button" @click="$emit('retry')">Try again</Button>
+  </ErrorState>
+</template>

--- a/docs/klean-ui/sources/error-state/ErrorState.jsx
+++ b/docs/klean-ui/sources/error-state/ErrorState.jsx
@@ -1,0 +1,21 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES =
+  'flex min-h-48 w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white'
+
+const ErrorState = forwardRef(function ErrorState(
+  { as: Component = 'div', className, 'data-slot': _dataSlot, ...props },
+  ref
+) {
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      data-slot="error-state"
+      className={twMerge(BASE_CLASSES, className)}
+    />
+  )
+})
+
+export default ErrorState

--- a/docs/klean-ui/sources/error-state/ErrorState.svelte
+++ b/docs/klean-ui/sources/error-state/ErrorState.svelte
@@ -1,0 +1,42 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES =
+    "flex min-h-48 w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white";
+
+  let {
+    as = "div",
+    children,
+    class: className,
+    "data-slot": _dataSlot,
+    ...rootProps
+  } = $props();
+
+  let element = $state();
+
+  export function getElement() {
+    return element;
+  }
+</script>
+
+{#if typeof as === "string"}
+  <svelte:element
+    this={as}
+    {...rootProps}
+    bind:this={element}
+    data-slot="error-state"
+    class={twMerge(BASE_CLASSES, className)}
+  >
+    {@render children?.()}
+  </svelte:element>
+{:else}
+  {@const Component = as}
+  <Component
+    {...rootProps}
+    bind:this={element}
+    data-slot="error-state"
+    class={twMerge(BASE_CLASSES, className)}
+  >
+    {@render children?.()}
+  </Component>
+{/if}


### PR DESCRIPTION
Closes #236

Adds the canonical Error State docs with interactive Slipway and Hagfish recipes, zero-configuration installation, copyable Vue/React/Svelte usage and source, static-versus-dynamic semantics, durable recovery, safe diagnostics, Tailwind ownership, and related component boundaries.

Verification:
- targeted formatting passes
- VitePress production build passes
- live route and sidebar pass
- dynamic alert, dismiss, retry, and source-tab interactions pass
- temporary staging directory deleted