### PR TITLE
docs(klean-ui): document Slide thumb content

### DIFF
--- a/docs/.vitepress/theme/components/klean/slide/Slide.vue
+++ b/docs/.vitepress/theme/components/klean/slide/Slide.vue
@@ -328,15 +328,21 @@ onBeforeUnmount(() => {
       :class="thumbClasses"
       :style="thumbStyle"
     >
-      <svg
-        class="size-4 rtl:rotate-180"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-      >
-        <path d="m9 5 7 7-7 7" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
+      <slot name="thumb" :pending="pending" :progress="progressState">
+        <svg
+          class="size-4 rtl:rotate-180"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            d="m9 5 7 7-7 7"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </slot>
     </span>
     <span data-slot="slide-status" class="sr-only" aria-live="polite">
       {{ status }}

--- a/docs/klean-ui/components/slide.md
+++ b/docs/klean-ui/components/slide.md
@@ -18,6 +18,9 @@ import vueUsage from '../snippets/slide/usage.vue?raw'
 import reactUsage from '../snippets/slide/usage.jsx?raw'
 import svelteUsage from '../snippets/slide/usage.svelte?raw'
 import stylingUsage from '../snippets/slide/styling.vue?raw'
+import vueThumb from '../snippets/slide/thumb.vue?raw'
+import reactThumb from '../snippets/slide/thumb.jsx?raw'
+import svelteThumb from '../snippets/slide/thumb.svelte?raw'
 
 const pending = ref(false)
 const message = ref('Ready to deploy.')
@@ -128,10 +131,31 @@ A future range-value control would be named Slider and would use native slider s
 | Confirmation | `@confirm`   | `onConfirm` | `onconfirm`     | Called once after a valid slide or native button activation.              |
 | Styling      | `class`      | `className` | `class`         | Ordinary Tailwind merged after neutral defaults.                          |
 | Content      | default slot | `children`  | default snippet | Visible, product-owned action language.                                   |
+| Thumb        | `#thumb`     | `thumb`     | `thumb` snippet | Optional product-owned decorative content; the arrow remains the default. |
 
 Native `aria-describedby`, `name`, `value`, `form`, data attributes, and other ordinary button attributes pass through. The confirmation threshold is the one conventional 85% behavior, not an application setting.
 
 Keep `pending` truthful. Set it before starting asynchronous work, then return it to `false` on success or failure. That reset is declarative; there is no imperative `reset()` method.
+
+The custom thumb receives `pending` and `progress`, where progress is `start`, `middle`, `ready`, or `complete`. Use those truthful states for content, not a second source of interaction state.
+
+## Custom thumb content
+
+The default arrow needs no configuration. When a product has a meaningful mark—such as an application mascot—place it in the thumb with the framework-native content hook.
+
+### Vue
+
+<CopyCode :code="vueThumb" label="DeployAction.vue" />
+
+### React
+
+<CopyCode :code="reactThumb" label="DeployAction.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteThumb" label="DeployAction.svelte" />
+
+The entire thumb is decorative. Keep the image `alt` empty and communicate pending work through the visible action label and the surrounding application status, not through the moving artwork alone.
 
 ## Styling progress
 

--- a/docs/klean-ui/snippets/slide/thumb.jsx
+++ b/docs/klean-ui/snippets/slide/thumb.jsx
@@ -1,0 +1,13 @@
+;<Slide
+  pending={deploying}
+  onConfirm={deploy}
+  thumb={({ pending }) => (
+    <img
+      src="/mascot.svg"
+      alt=""
+      className={`size-6 ${pending ? 'animate-spin motion-reduce:animate-none' : ''}`}
+    />
+  )}
+>
+  {deploying ? 'Deploying…' : 'Slide to deploy'}
+</Slide>

--- a/docs/klean-ui/snippets/slide/thumb.svelte
+++ b/docs/klean-ui/snippets/slide/thumb.svelte
@@ -1,0 +1,11 @@
+{#snippet thumb({ pending })}
+  <img
+    src="/mascot.svg"
+    alt=""
+    class={`size-6 ${pending ? 'animate-spin motion-reduce:animate-none' : ''}`}
+  />
+{/snippet}
+
+<Slide pending={deploying} onconfirm={deploy} {thumb}>
+  {deploying ? 'Deploying…' : 'Slide to deploy'}
+</Slide>

--- a/docs/klean-ui/snippets/slide/thumb.vue
+++ b/docs/klean-ui/snippets/slide/thumb.vue
@@ -1,0 +1,12 @@
+<Slide :pending="deploying" @confirm="deploy">
+  {{ deploying ? 'Deploying…' : 'Slide to deploy' }}
+
+  <template #thumb="{ pending }">
+    <img
+      src="/mascot.svg"
+      alt=""
+      class="size-6"
+      :class="pending ? 'animate-spin motion-reduce:animate-none' : ''"
+    />
+  </template>
+</Slide>

--- a/docs/klean-ui/sources/slide/Slide.jsx
+++ b/docs/klean-ui/sources/slide/Slide.jsx
@@ -28,6 +28,7 @@ const Slide = forwardRef(function Slide(
     pending = false,
     className,
     children,
+    thumb,
     onConfirm,
     onClick,
     onKeyDown,
@@ -293,6 +294,10 @@ const Slide = forwardRef(function Slide(
         : progress >= 0.33
           ? 'middle'
           : 'start'
+  const thumbContent =
+    typeof thumb === 'function'
+      ? thumb({ pending, progress: progressState })
+      : thumb
 
   return (
     <button
@@ -332,15 +337,23 @@ const Slide = forwardRef(function Slide(
         className={THUMB_CLASSES.join(' ')}
         style={{ transform: `translateX(${direction * progress * travel}px)` }}
       >
-        <svg
-          className="size-4 rtl:rotate-180"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <path d="m9 5 7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
+        {thumb === undefined ? (
+          <svg
+            className="size-4 rtl:rotate-180"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path
+              d="m9 5 7 7-7 7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          thumbContent
+        )}
       </span>
       <span data-slot="slide-status" className="sr-only" aria-live="polite">
         {status}

--- a/docs/klean-ui/sources/slide/Slide.svelte
+++ b/docs/klean-ui/sources/slide/Slide.svelte
@@ -37,6 +37,7 @@
     onlostpointercapture,
     "aria-busy": ariaBusy,
     children,
+    thumb,
     ...buttonProps
   } = $props();
 
@@ -299,16 +300,20 @@
     class={THUMB_CLASSES.join(" ")}
     style:transform={`translateX(${direction * progress * travel}px)`}
   >
-    <svg
-      class="size-4 rtl:rotate-180"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-    >
-      <path d="m9 5 7 7-7 7" stroke-linecap="round" stroke-linejoin="round"
-      ></path>
-    </svg>
+    {#if thumb}
+      {@render thumb({ pending, progress: progressState })}
+    {:else}
+      <svg
+        class="size-4 rtl:rotate-180"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path d="m9 5 7 7-7 7" stroke-linecap="round" stroke-linejoin="round"
+        ></path>
+      </svg>
+    {/if}
   </span>
   <span data-slot="slide-status" class="sr-only" aria-live="polite">
     {status}


### PR DESCRIPTION
## What changed

- sync complete copyable Slide source for Vue, React, and Svelte
- document each framework-native thumb-content API
- add copyable mascot and pending-indicator recipes
- clarify decorative semantics and truthful pending/progress state

## Verification

- `npm run build`
- focused Prettier check
- `git diff --check`

Closes #238

Depends on sailscastshq/klean-ui#125.