### PR TITLE
docs(klean-ui): explain Slide pending focus

### DIFF
--- a/docs/.vitepress/theme/components/klean/slide/Slide.vue
+++ b/docs/.vitepress/theme/components/klean/slide/Slide.vue
@@ -40,6 +40,7 @@ const baseClasses = [
   'group/slide relative inline-grid min-h-11 w-56 max-w-full touch-none cursor-grab select-none overflow-hidden rounded-full border border-gray-300 bg-gray-100 p-1 text-sm font-medium text-gray-700 shadow-sm outline-none',
   'focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2',
   'disabled:cursor-not-allowed disabled:opacity-50',
+  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
   'dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-white'
 ]
 
@@ -79,6 +80,7 @@ const buttonAttrs = computed(() => {
     type: _type,
     disabled: _disabled,
     'aria-busy': _ariaBusy,
+    'aria-disabled': _ariaDisabled,
     'data-slot': _dataSlot,
     'data-state': _dataState,
     'data-progress': _dataProgress,
@@ -236,6 +238,11 @@ function handleClick(event) {
     return
   }
 
+  if (props.disabled || props.pending) {
+    event.preventDefault()
+    return
+  }
+
   if (event.detail !== 0) {
     event.preventDefault()
     return
@@ -294,8 +301,9 @@ onBeforeUnmount(() => {
     ref="button"
     v-bind="buttonAttrs"
     type="button"
-    :disabled="disabled || pending"
+    :disabled="disabled"
     :aria-busy="pending ? 'true' : attrs['aria-busy']"
+    :aria-disabled="pending ? 'true' : attrs['aria-disabled']"
     data-slot="slide"
     :data-state="state"
     :data-progress="progressState"

--- a/docs/klean-ui/components/slide.md
+++ b/docs/klean-ui/components/slide.md
@@ -127,7 +127,7 @@ A future range-value control would be named Slider and would use native slider s
 | Input        | Vue          | React       | Svelte          | Purpose                                                                   |
 | ------------ | ------------ | ----------- | --------------- | ------------------------------------------------------------------------- |
 | Disabled     | `:disabled`  | `disabled`  | `disabled`      | Native disabled state; no confirmation can fire.                          |
-| Pending      | `:pending`   | `pending`   | `pending`       | Caller-owned in-progress truth; disables duplicates and sets `aria-busy`. |
+| Pending      | `:pending`   | `pending`   | `pending`       | Caller-owned in-progress truth; blocks duplicates without dropping focus. |
 | Confirmation | `@confirm`   | `onConfirm` | `onconfirm`     | Called once after a valid slide or native button activation.              |
 | Styling      | `class`      | `className` | `class`         | Ordinary Tailwind merged after neutral defaults.                          |
 | Content      | default slot | `children`  | default snippet | Visible, product-owned action language.                                   |
@@ -136,6 +136,8 @@ A future range-value control would be named Slider and would use native slider s
 Native `aria-describedby`, `name`, `value`, `form`, data attributes, and other ordinary button attributes pass through. The confirmation threshold is the one conventional 85% behavior, not an application setting.
 
 Keep `pending` truthful. Set it before starting asynchronous work, then return it to `false` on success or failure. That reset is declarative; there is no imperative `reset()` method.
+
+Pending is temporary application state, so Slide reports `aria-busy="true"` and `aria-disabled="true"` while retaining focus. The explicit `disabled` input remains a real native disabled state for controls that cannot currently be used.
 
 The custom thumb receives `pending` and `progress`, where progress is `start`, `middle`, `ready`, or `complete`. Use those truthful states for content, not a second source of interaction state.
 

--- a/docs/klean-ui/sources/slide/Slide.jsx
+++ b/docs/klean-ui/sources/slide/Slide.jsx
@@ -7,6 +7,7 @@ const BASE_CLASSES = [
   'group/slide relative inline-grid min-h-11 w-56 max-w-full touch-none cursor-grab select-none overflow-hidden rounded-full border border-gray-300 bg-gray-100 p-1 text-sm font-medium text-gray-700 shadow-sm outline-none',
   'focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2',
   'disabled:cursor-not-allowed disabled:opacity-50',
+  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
   'dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-white'
 ]
 
@@ -38,6 +39,7 @@ const Slide = forwardRef(function Slide(
     onPointerCancel,
     onLostPointerCapture,
     'aria-busy': ariaBusy,
+    'aria-disabled': ariaDisabled,
     ...buttonProps
   },
   forwardedRef
@@ -261,6 +263,11 @@ const Slide = forwardRef(function Slide(
       return
     }
 
+    if (disabled || pending) {
+      event.preventDefault()
+      return
+    }
+
     if (event.detail !== 0) {
       event.preventDefault()
       return
@@ -304,8 +311,9 @@ const Slide = forwardRef(function Slide(
       {...buttonProps}
       ref={setRef}
       type="button"
-      disabled={disabled || pending}
+      disabled={disabled}
       aria-busy={pending ? true : ariaBusy}
+      aria-disabled={pending ? true : ariaDisabled}
       data-slot="slide"
       data-state={state}
       data-progress={progressState}

--- a/docs/klean-ui/sources/slide/Slide.svelte
+++ b/docs/klean-ui/sources/slide/Slide.svelte
@@ -8,6 +8,7 @@
     "group/slide relative inline-grid min-h-11 w-56 max-w-full touch-none cursor-grab select-none overflow-hidden rounded-full border border-gray-300 bg-gray-100 p-1 text-sm font-medium text-gray-700 shadow-sm outline-none",
     "focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2",
     "disabled:cursor-not-allowed disabled:opacity-50",
+    "aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
     "dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-white",
   ];
 
@@ -36,6 +37,7 @@
     onpointercancel,
     onlostpointercapture,
     "aria-busy": ariaBusy,
+    "aria-disabled": ariaDisabled,
     children,
     thumb,
     ...buttonProps
@@ -209,6 +211,11 @@
       return;
     }
 
+    if (disabled || pending) {
+      event.preventDefault();
+      return;
+    }
+
     if (event.detail !== 0) {
       event.preventDefault();
       return;
@@ -263,8 +270,9 @@
   {...buttonProps}
   bind:this={buttonElement}
   type="button"
-  disabled={disabled || pending}
+  {disabled}
   aria-busy={pending ? "true" : ariaBusy}
+  aria-disabled={pending ? "true" : ariaDisabled}
   data-slot="slide"
   data-state={state}
   data-progress={progressState}


### PR DESCRIPTION
## What changed

- synchronize complete Vue, React, and Svelte Slide sources
- document pending as focus-preserving `aria-busy` and `aria-disabled` state
- distinguish temporary pending from native caller-disabled state

## Verification

- `npm run build`
- focused Prettier formatting
- `git diff --check`

Closes #240

Depends on sailscastshq/klean-ui#127.