### PR TITLE
docs(klean-ui): document controlled Dialog focus

### DIFF
--- a/docs/.vitepress/theme/components/klean/dialog/Dialog.vue
+++ b/docs/.vitepress/theme/components/klean/dialog/Dialog.vue
@@ -66,6 +66,22 @@ let previousDocumentOverflow = ''
 let scrollLocked = false
 let fallbackInvoker
 
+function resolveInvoker(source, element) {
+  const activeElement =
+    typeof document === 'undefined' ? undefined : document.activeElement
+
+  return [source, activeElement].find(
+    (candidate) =>
+      candidate &&
+      candidate !== document.body &&
+      candidate !== document.documentElement &&
+      candidate !== element &&
+      !element.contains(candidate) &&
+      candidate.isConnected &&
+      typeof candidate.focus === 'function'
+  )
+}
+
 function callListener(listener, event) {
   for (const callback of Array.isArray(listener) ? listener : [listener]) {
     callback?.(event)
@@ -99,7 +115,7 @@ function showModal(source) {
   const element = dialog.value
   if (!element || element.open) return
 
-  fallbackInvoker = source
+  fallbackInvoker = resolveInvoker(source, element)
   element.showModal()
   observeNativeOpen(true)
 }

--- a/docs/klean-ui/components/dialog.md
+++ b/docs/klean-ui/components/dialog.md
@@ -117,8 +117,8 @@ must not interrupt the current task.
 Opening with `showModal()` puts the element in the top layer. The browser owns
 the inert background, modal focus containment, initial focus, Escape behavior,
 and the native `<form method="dialog">` completion path. Klean adds controlled
-state observation, a `closedby` fallback, safe scroll restoration, and caller-winning
-Tailwind defaults.
+state observation, exact invoker focus return, a `closedby` fallback, safe scroll
+restoration, and caller-winning Tailwind defaults.
 
 Every Dialog needs an accessible name. Point `aria-labelledby` at a visible
 heading or provide `aria-label`. Use `aria-describedby` for a short description;
@@ -144,7 +144,9 @@ completion; observe state only when application behavior genuinely needs it.
 ## Durable behavior
 
 - Escape, platform close, and backdrop dismissal follow `dismissible`.
-- The native dialog owns focus entry, containment, and return.
+- The native dialog owns focus entry and containment. Klean remembers the exact
+  external invoker for native-command, imperative, and controlled opening, then
+  restores it after close when it is still connected.
 - Background scroll returns to its previous value after close and unmount.
 - Explicit completion remains available when ambient dismissal is disabled.
 - Open state stays ephemeral unless the Dialog represents a shareable resource.

--- a/docs/klean-ui/sources/dialog/Dialog.jsx
+++ b/docs/klean-ui/sources/dialog/Dialog.jsx
@@ -41,6 +41,22 @@ const Dialog = forwardRef(function Dialog(
   desiredOpenRef.current = desiredOpen
   onOpenChangeRef.current = onOpenChange
 
+  const resolveInvoker = useCallback((source, element) => {
+    const activeElement =
+      typeof document === 'undefined' ? undefined : document.activeElement
+
+    return [source, activeElement].find(
+      (candidate) =>
+        candidate &&
+        candidate !== document.body &&
+        candidate !== document.documentElement &&
+        candidate !== element &&
+        !element.contains(candidate) &&
+        candidate.isConnected &&
+        typeof candidate.focus === 'function'
+    )
+  }, [])
+
   const setRef = useCallback(
     (element) => {
       dialogRef.current = element
@@ -82,11 +98,11 @@ const Dialog = forwardRef(function Dialog(
       const element = dialogRef.current
       if (!element || element.open) return
 
-      fallbackInvoker.current = source
+      fallbackInvoker.current = resolveInvoker(source, element)
       element.showModal()
       observeNativeOpen(true)
     },
-    [observeNativeOpen]
+    [observeNativeOpen, resolveInvoker]
   )
 
   const close = useCallback(

--- a/docs/klean-ui/sources/dialog/Dialog.svelte
+++ b/docs/klean-ui/sources/dialog/Dialog.svelte
@@ -35,6 +35,22 @@
   let scrollLocked = false;
   let desiredOpen = $derived(open ?? internalOpen);
 
+  function resolveInvoker(source, element) {
+    const activeElement =
+      typeof document === "undefined" ? undefined : document.activeElement;
+
+    return [source, activeElement].find(
+      (candidate) =>
+        candidate &&
+        candidate !== document.body &&
+        candidate !== document.documentElement &&
+        candidate !== element &&
+        !element.contains(candidate) &&
+        candidate.isConnected &&
+        typeof candidate.focus === "function",
+    );
+  }
+
   function lockScroll() {
     if (scrollLocked || typeof document === "undefined") return;
     previousDocumentOverflow = document.documentElement.style.overflow;
@@ -62,7 +78,7 @@
   export function showModal(source) {
     if (!dialogElement || dialogElement.open) return;
 
-    fallbackInvoker = source;
+    fallbackInvoker = resolveInvoker(source, dialogElement);
     dialogElement.showModal();
     observeNativeOpen(true);
   }


### PR DESCRIPTION
## What changed

- sync the copyable Vue, React, and Svelte Dialog sources
- document exact invoker restoration for controlled and native opening
- keep the public API unchanged and implementation details out of the guide

## Verification

- targeted Prettier check
- `npm run build`

Closes #242
Tracks sailscastshq/klean-ui#128