### PR TITLE
docs(klean-ui): keep Toast source above floating surfaces

### DIFF
--- a/docs/.vitepress/theme/components/klean/toast/Toast.vue
+++ b/docs/.vitepress/theme/components/klean/toast/Toast.vue
@@ -1,5 +1,13 @@
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, useAttrs, watch } from 'vue'
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  useTemplateRef,
+  watch
+} from 'vue'
 import { twMerge } from 'tailwind-merge'
 import { toast } from './toast.js'
 
@@ -97,6 +105,7 @@ const props = defineProps({
 
 const attrs = useAttrs()
 const items = ref([])
+const viewport = useTemplateRef('viewport')
 const activeController = computed(() => props.controller ?? toast)
 const defaultDirection = computed(() =>
   props.position.endsWith('-left') ? 'left' : 'right'
@@ -107,7 +116,7 @@ let unsubscribe = () => {}
 
 const viewportClasses = computed(() =>
   twMerge(
-    'pointer-events-none fixed z-100 m-0 flex w-[min(24rem,calc(100vw-2rem))] flex-col',
+    'pointer-events-none fixed inset-auto z-100 m-0 flex w-[min(24rem,calc(100vw-2rem))] flex-col border-0 bg-transparent p-0',
     POSITIONS[props.position],
     attrs.class
   )
@@ -119,6 +128,7 @@ const viewportAttrs = computed(() => {
     style: _style,
     'aria-label': _ariaLabel,
     'aria-live': _ariaLive,
+    popover: _popover,
     'data-slot': _dataSlot,
     ...rest
   } = attrs
@@ -206,9 +216,26 @@ function handleWindowFocus() {
   activeController.value.resumeAll('window-blur')
 }
 
+function showTopLayer() {
+  try {
+    viewport.value?.showPopover?.()
+  } catch {
+    // Already open or rejected by a partial Popover API implementation.
+  }
+}
+
+function hideTopLayer() {
+  try {
+    viewport.value?.hidePopover?.()
+  } catch {
+    // Already closed during teardown.
+  }
+}
+
 watch(activeController, subscribe)
 
 onMounted(() => {
+  showTopLayer()
   subscribe(activeController.value)
   document.addEventListener('visibilitychange', handleVisibility)
   window.addEventListener('blur', handleWindowBlur)
@@ -217,6 +244,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  hideTopLayer()
   unsubscribe()
   document.removeEventListener('visibilitychange', handleVisibility)
   window.removeEventListener('blur', handleWindowBlur)
@@ -228,7 +256,9 @@ onBeforeUnmount(() => {
 
 <template>
   <section
+    ref="viewport"
     v-bind="viewportAttrs"
+    popover="manual"
     data-slot="toast-viewport"
     :data-position="position"
     :data-from="resolvedFrom"

--- a/docs/klean-ui/components/toast.md
+++ b/docs/klean-ui/components/toast.md
@@ -489,6 +489,7 @@ The built-in body is deliberately neutral and never maps `success`, `error`, or 
 - New notifications are announced politely and never steal focus.
 - Timers pause while a toast is hovered or focused, and while the page is inactive. They resume with the remaining time.
 - Dismiss controls have specific accessible names. Actions use real links or buttons.
+- The notification shelf stays above other floating application surfaces, so actions and dismissal remain reachable while a tooltip, menu, popover, or dialog is present.
 - `update()` keeps long-running work in one notification.
 - Reduced-motion preferences are respected.
 - Notifications are temporary and are never persisted in storage or the URL.

--- a/docs/klean-ui/sources/toast/Toast.jsx
+++ b/docs/klean-ui/sources/toast/Toast.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { toast } from './toast.js'
 
@@ -104,6 +104,7 @@ export default function Toast({
   children,
   ...viewportProps
 }) {
+  const viewportRef = useRef(null)
   const defaultDirection = position.endsWith('-left') ? 'left' : 'right'
   const resolvedFrom = from ?? defaultDirection
   const resolvedTo = to ?? defaultDirection
@@ -116,6 +117,23 @@ export default function Toast({
     () => motionStyle(resolvedFrom, resolvedTo, position, style),
     [position, resolvedFrom, resolvedTo, style]
   )
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    try {
+      viewport?.showPopover?.()
+    } catch {
+      // Already open or rejected by a partial Popover API implementation.
+    }
+
+    return () => {
+      try {
+        viewport?.hidePopover?.()
+      } catch {
+        // Already closed during teardown.
+      }
+    }
+  }, [])
 
   useEffect(() => {
     function syncInstantMotion() {
@@ -241,7 +259,9 @@ export default function Toast({
 
   return (
     <section
+      ref={viewportRef}
       {...viewportProps}
+      popover="manual"
       data-slot="toast-viewport"
       data-position={position}
       data-from={resolvedFrom}
@@ -251,7 +271,7 @@ export default function Toast({
       aria-atomic="false"
       aria-relevant="additions text"
       className={twMerge(
-        'pointer-events-none fixed z-100 m-0 flex w-[min(24rem,calc(100vw-2rem))] flex-col',
+        'pointer-events-none fixed inset-auto z-100 m-0 flex w-[min(24rem,calc(100vw-2rem))] flex-col border-0 bg-transparent p-0',
         POSITIONS[position],
         className
       )}

--- a/docs/klean-ui/sources/toast/Toast.svelte
+++ b/docs/klean-ui/sources/toast/Toast.svelte
@@ -65,6 +65,7 @@
     ...viewportProps
   } = $props();
 
+  let viewport;
   let items = $state([]);
   let defaultDirection = $derived(
     position.endsWith("-left") ? "left" : "right",
@@ -135,6 +136,12 @@
   }
 
   onMount(() => {
+    try {
+      viewport?.showPopover?.();
+    } catch {
+      // Already open or rejected by a partial Popover API implementation.
+    }
+
     function handleVisibility() {
       if (document.hidden) controller.pauseAll("page-hidden");
       else controller.resumeAll("page-hidden");
@@ -152,6 +159,11 @@
     handleVisibility();
 
     return () => {
+      try {
+        viewport?.hidePopover?.();
+      } catch {
+        // Already closed during teardown.
+      }
       document.removeEventListener("visibilitychange", handleVisibility);
       window.removeEventListener("blur", handleBlur);
       window.removeEventListener("focus", handleFocus);
@@ -162,7 +174,9 @@
 </script>
 
 <section
+  bind:this={viewport}
   {...viewportProps}
+  popover="manual"
   data-slot="toast-viewport"
   data-position={position}
   data-from={resolvedFrom}
@@ -172,7 +186,7 @@
   aria-atomic="false"
   aria-relevant="additions text"
   class={twMerge(
-    "pointer-events-none fixed z-100 m-0 flex w-[min(24rem,calc(100vw-2rem))] flex-col",
+    "pointer-events-none fixed inset-auto z-100 m-0 flex w-[min(24rem,calc(100vw-2rem))] flex-col border-0 bg-transparent p-0",
     POSITIONS[position],
     className,
   )}


### PR DESCRIPTION
## Summary

- sync the canonical Vue, React, and Svelte Toast source with Klean UI
- keep notification actions reachable above tooltips, menus, popovers, and dialogs
- document the capability without changing the public API

## Verification

- npm run build
- Prettier checks for all changed files

Closes #244