### PR TITLE
docs(klean-ui): keep floating actions reachable

### DIFF
--- a/docs/.vitepress/theme/components/klean/toast/Toast.vue
+++ b/docs/.vitepress/theme/components/klean/toast/Toast.vue
@@ -113,6 +113,7 @@ const defaultDirection = computed(() =>
 const resolvedFrom = computed(() => props.from ?? defaultDirection.value)
 const resolvedTo = computed(() => props.to ?? defaultDirection.value)
 let unsubscribe = () => {}
+let promotedItemId
 
 const viewportClasses = computed(() =>
   twMerge(
@@ -170,8 +171,17 @@ function activateAction(item, event) {
 
 function subscribe(controller) {
   unsubscribe()
+  promotedItemId = undefined
   const sync = () => {
-    items.value = controller.getSnapshot()
+    const snapshot = controller.getSnapshot()
+    items.value = snapshot
+
+    const enteringItem = snapshot.findLast((item) => item.state === 'entering')
+    if (enteringItem && enteringItem.id !== promotedItemId) {
+      promotedItemId = enteringItem.id
+      hideTopLayer()
+      showTopLayer()
+    }
 
     if (resolvedFrom.value === 'none' || resolvedTo.value === 'none') {
       queueMicrotask(() => {

--- a/docs/.vitepress/theme/components/klean/tooltip/Tooltip.vue
+++ b/docs/.vitepress/theme/components/klean/tooltip/Tooltip.vue
@@ -82,7 +82,7 @@ const contentAttrs = computed(() => {
 const contentClasses = computed(() =>
   twMerge(
     [
-      'z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
+      'pointer-events-none z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
       'transition-opacity duration-100 starting:opacity-0 motion-reduce:transition-none',
       'dark:border-white dark:bg-white dark:text-gray-950',
       'forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]'
@@ -337,8 +337,6 @@ onBeforeUnmount(() => {
       :hidden="!supportsNative && !isOpen"
       :class="contentClasses"
       :style="[positionStyle, attrs.style]"
-      @pointerenter="clearTimeout(closeTimer)"
-      @pointerleave="scheduleClose"
       @toggle="handleNativeToggle"
     >
       {{ text }}

--- a/docs/klean-ui/components/toast.md
+++ b/docs/klean-ui/components/toast.md
@@ -489,7 +489,7 @@ The built-in body is deliberately neutral and never maps `success`, `error`, or 
 - New notifications are announced politely and never steal focus.
 - Timers pause while a toast is hovered or focused, and while the page is inactive. They resume with the remaining time.
 - Dismiss controls have specific accessible names. Actions use real links or buttons.
-- The notification shelf stays above other floating application surfaces, so actions and dismissal remain reachable while a tooltip, menu, popover, or dialog is present.
+- The notification shelf stays above non-modal floating application surfaces, so actions and dismissal remain reachable while a tooltip, menu, or popover is present. A modal Dialog still owns interaction while it is open.
 - `update()` keeps long-running work in one notification.
 - Reduced-motion preferences are respected.
 - Notifications are temporary and are never persisted in storage or the URL.

--- a/docs/klean-ui/components/tooltip.md
+++ b/docs/klean-ui/components/tooltip.md
@@ -27,7 +27,7 @@ import svelteStylingUsage from '../snippets/tooltip/styling.svelte?raw'
 
 Tooltip adds short supplementary text to one real button or link. Wrap the trigger, provide the text, and keep the trigger's semantics and Tailwind classes where they are visible.
 
-Klean supplies the accessible description, hover and keyboard behavior, collision-safe placement, Escape dismissal, touch behavior, and cleanup. There are no trigger IDs, compound components, providers, visual variants, or configuration ceremony.
+Klean supplies the accessible description, hover and keyboard behavior, collision-safe placement, Escape dismissal, touch behavior, and cleanup. The supplementary text never captures pointer actions from the application beneath it. There are no trigger IDs, compound components, providers, visual variants, or configuration ceremony.
 
 <KleanPreview id="tooltip-source" :source="tooltipSource" filename="Tooltip.vue">
   <template #preview>
@@ -190,7 +190,7 @@ Repeated product treatment can become a small application-owned wrapper. Hagfish
 
 - Pointer hover and keyboard focus reveal the same supplementary text.
 - Escape dismisses an open Tooltip without moving focus away from its trigger.
-- Moving between the trigger and Tooltip does not dismiss it prematurely.
+- Moving away from the trigger dismisses Tooltip after a short delay; the floating text never captures pointer actions.
 - Only one Tooltip is open at a time.
 - Touch activation does not create a sticky synthetic hover surface.
 - Placement flips or shifts when the preferred side would leave the viewport, and the arrow follows the resolved side and clamped cross-axis position.

--- a/docs/klean-ui/sources/toast/Toast.jsx
+++ b/docs/klean-ui/sources/toast/Toast.jsx
@@ -105,6 +105,7 @@ export default function Toast({
   ...viewportProps
 }) {
   const viewportRef = useRef(null)
+  const promotedItemRef = useRef()
   const defaultDirection = position.endsWith('-left') ? 'left' : 'right'
   const resolvedFrom = from ?? defaultDirection
   const resolvedTo = to ?? defaultDirection
@@ -134,6 +135,24 @@ export default function Toast({
       }
     }
   }, [])
+
+  useEffect(() => {
+    const enteringItem = items.findLast((item) => item.state === 'entering')
+    if (!enteringItem || enteringItem.id === promotedItemRef.current) return
+
+    promotedItemRef.current = enteringItem.id
+    const viewport = viewportRef.current
+    try {
+      viewport?.hidePopover?.()
+    } catch {
+      // Not open yet or already closed.
+    }
+    try {
+      viewport?.showPopover?.()
+    } catch {
+      // Rejected by a partial Popover API implementation.
+    }
+  }, [items])
 
   useEffect(() => {
     function syncInstantMotion() {

--- a/docs/klean-ui/sources/toast/Toast.svelte
+++ b/docs/klean-ui/sources/toast/Toast.svelte
@@ -67,6 +67,7 @@
 
   let viewport;
   let items = $state([]);
+  let promotedItemId;
   let defaultDirection = $derived(
     position.endsWith("-left") ? "left" : "right",
   );
@@ -108,8 +109,23 @@
 
   $effect(() => {
     const activeController = controller;
+    promotedItemId = undefined;
     const sync = () => {
       items = activeController.getSnapshot();
+      const enteringItem = items.findLast((item) => item.state === "entering");
+      if (enteringItem && enteringItem.id !== promotedItemId) {
+        promotedItemId = enteringItem.id;
+        try {
+          viewport?.hidePopover?.();
+        } catch {
+          // Not open yet or already closed.
+        }
+        try {
+          viewport?.showPopover?.();
+        } catch {
+          // Rejected by a partial Popover API implementation.
+        }
+      }
       syncInstantMotion();
     };
 

--- a/docs/klean-ui/sources/tooltip/Tooltip.jsx
+++ b/docs/klean-ui/sources/tooltip/Tooltip.jsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 const BASE_CLASSES = [
-  'z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
+  'pointer-events-none z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
   'transition-opacity duration-100 starting:opacity-0 motion-reduce:transition-none',
   'dark:border-white dark:bg-white dark:text-gray-950',
   'forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]'
@@ -294,8 +294,6 @@ export default function Tooltip({
         hidden={!supportsNative && !isOpen}
         className={twMerge(BASE_CLASSES, className)}
         style={{ ...positionStyle, ...style }}
-        onPointerEnter={() => clearTimeout(closeTimer.current)}
-        onPointerLeave={scheduleClose}
         onToggle={(event) => {
           if (event.newState === 'closed' && isOpen) setIsOpen(false)
           contentProps.onToggle?.(event)

--- a/docs/klean-ui/sources/tooltip/Tooltip.svelte
+++ b/docs/klean-ui/sources/tooltip/Tooltip.svelte
@@ -15,7 +15,7 @@
   import { twMerge } from "tailwind-merge";
 
   const BASE_CLASSES = [
-    "z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none",
+    "pointer-events-none z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none",
     "transition-opacity duration-100 starting:opacity-0 motion-reduce:transition-none",
     "dark:border-white dark:bg-white dark:text-gray-950",
     "forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]",
@@ -311,8 +311,6 @@
     hidden={!supportsNative && !isOpen}
     class={twMerge(BASE_CLASSES, className)}
     style={styleString(positionStyle, style)}
-    onpointerenter={() => clearTimeout(closeTimer)}
-    onpointerleave={scheduleClose}
     ontoggle={(event) => {
       if (event.newState === "closed" && isOpen) isOpen = false;
       contentProps.ontoggle?.(event);


### PR DESCRIPTION
## Summary

- sync the corrected Toast and Tooltip source for Vue, React, and Svelte
- document Toast ordering around non-modal floating surfaces
- document that Tooltip is supplementary text and never captures application pointer actions
- keep modal Dialog semantics explicit

## Verification

- npm run build
- Prettier checks for every changed source and page

Closes #244
Closes #246