### PR TITLE
docs(klean-ui): document multiple file uploads

### DIFF
--- a/docs/.vitepress/theme/components/klean/file-upload/FileUpload.vue
+++ b/docs/.vitepress/theme/components/klean/file-upload/FileUpload.vue
@@ -1,11 +1,19 @@
 <script setup>
-import { computed, onBeforeUnmount, ref, useAttrs, watch } from 'vue'
+import {
+  computed,
+  onBeforeUnmount,
+  ref,
+  shallowRef,
+  useAttrs,
+  watch
+} from 'vue'
 
 defineOptions({ inheritAttrs: false })
 
 const props = defineProps({
   accept: { type: String, default: undefined },
   capture: { type: [String, Boolean], default: undefined },
+  multiple: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
   validate: { type: Function, default: () => true }
 })
@@ -15,10 +23,31 @@ const file = defineModel({ default: null })
 const attrs = useAttrs()
 const root = ref()
 const input = ref()
-const previewUrl = ref('')
+const previewEntries = shallowRef([])
 const dragging = ref(false)
 let dragDepth = 0
-let previewFile
+
+const files = computed(() => {
+  const current = file.value
+  if (props.multiple) {
+    return Array.isArray(current)
+      ? current.filter(Boolean)
+      : current
+        ? [current]
+        : []
+  }
+  return current ? [current] : []
+})
+const singleFile = computed(() =>
+  props.multiple ? null : (files.value[0] ?? null)
+)
+const previews = computed(() =>
+  previewEntries.value.map(({ file: candidate, url }) => ({
+    file: candidate,
+    previewUrl: url
+  }))
+)
+const previewUrl = computed(() => previews.value[0]?.previewUrl ?? '')
 
 const rootAttrs = computed(() => {
   const {
@@ -36,27 +65,70 @@ function resetInput() {
   if (input.value) input.value.value = ''
 }
 
-function revokePreview() {
-  if (previewUrl.value && typeof URL.revokeObjectURL === 'function') {
-    URL.revokeObjectURL(previewUrl.value)
+function revokeEntry(entry) {
+  if (entry?.url && typeof URL.revokeObjectURL === 'function') {
+    URL.revokeObjectURL(entry.url)
   }
-  previewUrl.value = ''
-  previewFile = undefined
 }
 
-function syncPreview(candidate) {
-  if (Object.is(candidate, previewFile)) return
-  revokePreview()
-  previewFile = candidate
-
-  if (
+function createPreviewEntry(candidate) {
+  const canPreview =
     candidate &&
     typeof Blob !== 'undefined' &&
     candidate instanceof Blob &&
     typeof URL.createObjectURL === 'function'
-  ) {
-    previewUrl.value = URL.createObjectURL(candidate)
+  return {
+    file: candidate,
+    url: canPreview ? URL.createObjectURL(candidate) : ''
   }
+}
+
+function syncPreviews(candidates) {
+  const remaining = [...previewEntries.value]
+  const next = candidates.map((candidate) => {
+    const index = remaining.findIndex((entry) =>
+      Object.is(entry.file, candidate)
+    )
+    if (index === -1) return createPreviewEntry(candidate)
+    return remaining.splice(index, 1)[0]
+  })
+  for (const entry of remaining) revokeEntry(entry)
+  previewEntries.value = next
+}
+
+function revokePreviews() {
+  for (const entry of previewEntries.value) revokeEntry(entry)
+  previewEntries.value = []
+}
+
+function validationResult(candidate, acceptedFiles) {
+  if (!acceptedByAttribute(candidate)) {
+    reject(candidate, 'accept', 'That file type is not accepted.')
+    return false
+  }
+
+  let result
+  try {
+    result = props.validate(candidate, {
+      files: [...acceptedFiles],
+      multiple: props.multiple
+    })
+  } catch {
+    reject(candidate, 'validate', 'That file could not be validated.')
+    return false
+  }
+
+  if (result === true || result === undefined) return true
+  reject(
+    candidate,
+    typeof result === 'object' && result?.reason ? result.reason : 'validate',
+    typeof result === 'string' && result
+      ? result
+      : typeof result === 'object' && result?.message
+        ? result.message
+        : 'That file is not valid.'
+  )
+  return false
 }
 
 function acceptedByAttribute(candidate) {
@@ -90,44 +162,30 @@ function setFile(candidate) {
   return true
 }
 
-function select(files) {
+function select(selection) {
   if (props.disabled) return false
-  const candidates = Array.from(files ?? [])
+  const candidates = Array.from(selection ?? [])
   if (!candidates.length) return false
-  if (candidates.length > 1) {
-    return reject(
-      candidates[0],
-      'multiple',
-      'Choose one file at a time.',
-      candidates
-    )
+  if (!props.multiple && candidates.length > 1) {
+    reject(candidates[0], 'multiple', 'Choose one file at a time.', candidates)
+    resetInput()
+    return false
   }
 
-  const candidate = candidates[0]
-  if (!acceptedByAttribute(candidate)) {
-    return reject(candidate, 'accept', 'That file type is not accepted.')
+  const accepted = []
+  const current = props.multiple ? [...files.value] : []
+  for (const candidate of candidates) {
+    if (validationResult(candidate, [...current, ...accepted])) {
+      accepted.push(candidate)
+    }
   }
 
-  let result
-  try {
-    result = props.validate(candidate)
-  } catch {
-    return reject(candidate, 'validate', 'That file could not be validated.')
+  if (!accepted.length) {
+    resetInput()
+    return false
   }
 
-  if (result !== true && result !== undefined) {
-    return reject(
-      candidate,
-      typeof result === 'object' && result?.reason ? result.reason : 'validate',
-      typeof result === 'string' && result
-        ? result
-        : typeof result === 'object' && result?.message
-          ? result.message
-          : 'That file is not valid.'
-    )
-  }
-
-  return setFile(candidate)
+  return setFile(props.multiple ? [...current, ...accepted] : accepted[0])
 }
 
 function choose() {
@@ -146,7 +204,17 @@ function choose() {
 
 function clear() {
   if (props.disabled) return
-  setFile(null)
+  setFile(props.multiple ? [] : null)
+}
+
+function remove(candidate) {
+  if (props.disabled) return false
+  if (!props.multiple) return setFile(null)
+  const index = files.value.findIndex((entry) => Object.is(entry, candidate))
+  if (index === -1) return false
+  const next = [...files.value]
+  next.splice(index, 1)
+  return setFile(next)
 }
 
 function hasFiles(event) {
@@ -192,18 +260,18 @@ const dropzone = computed(() => ({
 }))
 
 watch(
-  file,
-  (candidate) => {
-    syncPreview(candidate)
+  files,
+  (candidates) => {
+    syncPreviews(candidates)
   },
   { immediate: true, flush: 'sync' }
 )
 
 onBeforeUnmount(() => {
-  revokePreview()
+  revokePreviews()
 })
 
-defineExpose({ root, choose, clear })
+defineExpose({ root, choose, clear, remove })
 </script>
 
 <template>
@@ -211,7 +279,7 @@ defineExpose({ root, choose, clear })
     ref="root"
     v-bind="rootAttrs"
     data-slot="file-upload"
-    :data-state="file ? 'ready' : 'empty'"
+    :data-state="files.length ? 'ready' : 'empty'"
     :data-dragging="dragging ? '' : undefined"
     :data-disabled="disabled ? '' : undefined"
     :class="attrs.class"
@@ -223,15 +291,19 @@ defineExpose({ root, choose, clear })
       data-part="input"
       :accept="accept"
       :capture="capture"
+      :multiple="multiple"
       :disabled="disabled"
       @change="select($event.currentTarget.files)"
     />
     <slot
-      :file="file"
+      :file="singleFile"
+      :files="files"
       :preview-url="previewUrl"
+      :previews="previews"
       :dragging="dragging"
       :choose="choose"
       :clear="clear"
+      :remove="remove"
       :dropzone="dropzone"
     />
   </div>

--- a/docs/.vitepress/theme/components/klean/file-upload/FileUploadRecipes.vue
+++ b/docs/.vitepress/theme/components/klean/file-upload/FileUploadRecipes.vue
@@ -10,6 +10,8 @@ const logo = shallowRef(null)
 const removeCurrentLogo = ref(false)
 const receipt = shallowRef(null)
 const receiptError = ref('')
+const images = shallowRef([])
+const imagesError = ref('')
 
 const portraitMarkup = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
   <rect width="160" height="160" fill="#dbeafe"/>
@@ -35,6 +37,27 @@ function validateReceipt(candidate) {
   return candidate.size <= 5 * 1024 * 1024
     ? true
     : 'Receipts must be 5 MB or smaller.'
+}
+
+function imageSignature(candidate) {
+  return [
+    candidate.name,
+    candidate.size,
+    candidate.type,
+    candidate.lastModified
+  ].join(':')
+}
+
+function validateImage(candidate, { files }) {
+  if (candidate.size > 5 * 1024 * 1024) {
+    return 'Each image must be 5 MB or smaller.'
+  }
+  if (
+    files.some((file) => imageSignature(file) === imageSignature(candidate))
+  ) {
+    return { reason: 'duplicate', message: 'That image is already attached.' }
+  }
+  return files.length < 4 ? true : 'Attach up to 4 images.'
 }
 </script>
 
@@ -187,6 +210,124 @@ function validateReceipt(candidate) {
         </div>
       </div>
     </div>
+  </FileUpload>
+
+  <FileUpload
+    v-else-if="recipe === 'attachments'"
+    v-model="images"
+    multiple
+    accept="image/avif,image/gif,image/jpeg,image/png,image/webp"
+    :validate="validateImage"
+    @change="imagesError = ''"
+    @reject="imagesError = $event.message"
+    v-slot="upload"
+    class="mx-auto max-w-3xl"
+  >
+    <section
+      class="rounded-2xl border border-gray-200 bg-white p-5 text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-white sm:p-7"
+      aria-labelledby="file-upload-attachments-title"
+    >
+      <h3
+        id="file-upload-attachments-title"
+        class="m-0 text-xl font-semibold tracking-tight"
+      >
+        Attach screenshots
+      </h3>
+      <p
+        class="m-0 mt-2 max-w-xl text-sm leading-6 text-gray-500 dark:text-gray-400"
+      >
+        Add up to four images. Paste can update this same file array.
+      </p>
+
+      <div
+        v-bind="upload.dropzone"
+        :class="[
+          'mt-6 rounded-xl border border-dashed p-5 transition-colors duration-150 motion-reduce:transition-none',
+          upload.dragging
+            ? 'border-gray-950 bg-gray-50 dark:border-white dark:bg-gray-900'
+            : 'border-gray-300 dark:border-gray-700'
+        ]"
+      >
+        <div
+          v-if="upload.previews.length"
+          class="grid grid-cols-2 gap-3 sm:grid-cols-4"
+        >
+          <figure
+            v-for="preview in upload.previews"
+            :key="preview.file.name + preview.file.lastModified"
+            class="group relative m-0 min-w-0 overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-900"
+          >
+            <img
+              :src="preview.previewUrl"
+              :alt="preview.file.name"
+              class="m-0 aspect-square w-full object-cover"
+            />
+            <figcaption
+              class="absolute inset-x-0 bottom-0 flex items-center gap-2 bg-gray-950/80 px-2 py-1.5 text-white backdrop-blur-sm"
+            >
+              <span class="min-w-0 flex-1 truncate text-xs">
+                {{ preview.file.name }}
+              </span>
+              <button
+                type="button"
+                class="grid size-8 shrink-0 cursor-pointer place-items-center rounded-md no-underline hover:bg-white/15 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-white"
+                :aria-label="`Remove ${preview.file.name}`"
+                @click="upload.remove(preview.file)"
+              >
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 20 20"
+                  class="size-4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                >
+                  <path d="m6 6 8 8m0-8-8 8" stroke-linecap="round" />
+                </svg>
+              </button>
+            </figcaption>
+          </figure>
+        </div>
+
+        <div
+          :class="
+            upload.previews.length
+              ? 'mt-5 flex flex-wrap items-center justify-between gap-3'
+              : 'py-7 text-center'
+          "
+        >
+          <div :class="upload.previews.length ? '' : 'mx-auto'">
+            <p class="m-0 text-sm font-medium">
+              {{
+                upload.previews.length
+                  ? `${upload.files.length} of 4 attached`
+                  : 'Drop screenshots here'
+              }}
+            </p>
+            <p class="m-0 mt-1 text-xs text-gray-500 dark:text-gray-400">
+              AVIF, GIF, JPEG, PNG, or WebP · 5 MB each
+            </p>
+          </div>
+          <button
+            type="button"
+            :class="[
+              'inline-flex min-h-11 cursor-pointer items-center justify-center rounded-lg bg-gray-950 px-4 text-sm font-medium text-white no-underline hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white',
+              upload.previews.length ? 'mt-0' : 'mt-4'
+            ]"
+            @click="upload.choose"
+          >
+            {{ upload.previews.length ? 'Add more' : 'Choose images' }}
+          </button>
+        </div>
+      </div>
+      <p
+        v-if="imagesError"
+        role="alert"
+        class="m-0 mt-3 text-sm font-medium text-red-700 dark:text-red-400"
+      >
+        {{ imagesError }}
+      </p>
+    </section>
   </FileUpload>
 
   <FileUpload

--- a/docs/klean-ui/components/file-upload.md
+++ b/docs/klean-ui/components/file-upload.md
@@ -1,7 +1,7 @@
 ---
 title: FileUpload
 titleTemplate: Klean UI
-description: One native file-selection bridge with honest validation, previews, drop behavior, and caller-owned Tailwind across Vue, React, and Svelte.
+description: Native single- and multiple-file selection with honest validation, previews, drop behavior, and caller-owned Tailwind across Vue, React, and Svelte.
 outline: [2, 3]
 ---
 
@@ -18,11 +18,12 @@ import reactUsage from '../snippets/file-upload/usage.jsx?raw'
 import svelteUsage from '../snippets/file-upload/usage.svelte?raw'
 import logoSource from '../snippets/file-upload/logo.vue?raw'
 import receiptSource from '../snippets/file-upload/receipt.vue?raw'
+import attachmentsSource from '../snippets/file-upload/attachments.vue?raw'
 </script>
 
 # FileUpload
 
-FileUpload turns one native file picker into calm application state. It chooses or drops one file, keeps the last accepted value when a candidate is rejected, supplies a temporary preview URL, and cleans that preview up when it is replaced or removed.
+FileUpload turns one native file picker into calm application state. It chooses or drops one file by default, opts into the platform's `multiple` selection when the product needs it, keeps accepted values when another candidate is rejected, and supplies previews that disappear when their files are removed.
 
 The application writes every visible element: the real choose button, drop surface, filename, preview, remove action, error, and Tailwind classes. It also owns the eventual upload request. There is no visual variant, upload runtime, anatomy package, or hidden storage decision.
 
@@ -37,7 +38,7 @@ The application writes every visible element: the real choose button, drop surfa
 
 ## Installation
 
-One command detects Vue, React, or Svelte and writes the matching one-file source into the conventional component directory:
+One command detects Vue, React, or Svelte and writes the matching source into the conventional component directory:
 
 <KleanInstallation
   id="file-upload-installation"
@@ -51,7 +52,7 @@ There is no provider, initializer, `klean-ui.json`, upload SDK, class helper, ba
 
 ## Usage
 
-The framework-native binding contains a `File` or `null`. The content slot or render function receives the same small API in each framework.
+The framework-native binding contains a `File` or `null`. Add the native `multiple` prop and the binding becomes `File[]`. The content slot or render function receives the same small API in each framework.
 
 ### Vue
 
@@ -69,34 +70,38 @@ The framework-native binding contains a `File` or `null`. The content slot or re
 
 ### Inputs and events
 
-| Input or event           | Default | Purpose                                                                                                       |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------- |
-| bound file               | `null`  | Vue `v-model`, React `value`/`onChange`, or Svelte `bind:file`; the selected `File` is the application truth. |
-| `accept`                 | —       | Native accept expression, also checked for dropped files: MIME types, wildcards such as `image/*`, or `.ext`. |
-| `capture`                | —       | Native mobile capture hint such as `environment`.                                                             |
-| `disabled`               | `false` | Prevents browse, drop, replace, and clear.                                                                    |
-| `validate(file)`         | accept  | Returns `true`/`undefined` to accept, a message to reject, or `{ reason, message }` for a named policy.       |
-| `change` / `onChange`    | —       | Receives the accepted `File` or `null` after clear.                                                           |
-| `reject` / `onReject`    | —       | Receives `{ file, reason, message }`; a multiple drop also includes `files`.                                  |
-| `class` / `className`    | —       | Ordinary classes on the neutral FileUpload root.                                                              |
-| native/global attributes | —       | IDs, titles, data hooks, and accessible relationships for the root.                                           |
+| Input or event            | Default | Purpose                                                                                                                                                     |
+| ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bound value               | `null`  | A `File` or `null`; with `multiple`, a `File[]`. Vue uses `v-model`, React uses `value`/`onChange`, and Svelte uses `bind:file`.                            |
+| `accept`                  | —       | Native accept expression, also checked for dropped files: MIME types, wildcards such as `image/*`, or `.ext`.                                               |
+| `capture`                 | —       | Native mobile capture hint such as `environment`.                                                                                                           |
+| `multiple`                | `false` | Uses the native multiple-file picker and appends accepted candidates to the bound file array.                                                               |
+| `disabled`                | `false` | Prevents browse, drop, replace, and clear.                                                                                                                  |
+| `validate(file, context)` | accept  | Returns `true`/`undefined` to accept, a message to reject, or `{ reason, message }`. `context.files` contains files already accepted before this candidate. |
+| `change` / `onChange`     | —       | Receives the next `File`, `null`, or `File[]` after an accepted selection, removal, or clear.                                                               |
+| `reject` / `onReject`     | —       | Receives `{ file, reason, message }`; a multi-file mistake in single mode also includes the attempted `files`.                                              |
+| `class` / `className`     | —       | Ordinary classes on the neutral FileUpload root.                                                                                                            |
+| native/global attributes  | —       | IDs, titles, data hooks, and accessible relationships for the root.                                                                                         |
 
 ### Content API
 
-| Value        | Purpose                                                                                                               |
-| ------------ | --------------------------------------------------------------------------------------------------------------------- |
-| `file`       | The current accepted `File` or `null`.                                                                                |
-| `previewUrl` | A temporary local URL for the current file. Render it only in an element appropriate for the file type.               |
-| `dragging`   | Whether a file drag is currently over the bound drop surface.                                                         |
-| `choose()`   | Opens the platform file picker. Call it from a real visible button.                                                   |
-| `clear()`    | Returns the bound file to `null` and releases its preview.                                                            |
-| `dropzone`   | Additive drag/drop event and data bindings for an ordinary caller-owned element. It does not invent button semantics. |
+| Value          | Purpose                                                                                                               |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `file`         | The current accepted `File` in single mode, otherwise `null`.                                                         |
+| `files`        | A normalized array of accepted files in both single and multiple modes.                                               |
+| `previewUrl`   | The current single-file preview address. Render it only in an element appropriate for the file type.                  |
+| `previews`     | Ordered `{ file, previewUrl }` entries for rendering multiple previews without matching arrays by hand.               |
+| `dragging`     | Whether a file drag is currently over the bound drop surface.                                                         |
+| `choose()`     | Opens the platform file picker. Call it from a real visible button.                                                   |
+| `remove(file)` | Removes one accepted file. In single mode it clears the current value.                                                |
+| `clear()`      | Returns the bound value to `null` or `[]` and releases its previews.                                                  |
+| `dropzone`     | Additive drag/drop event and data bindings for an ordinary caller-owned element. It does not invent button semantics. |
 
-There is deliberately no `variant`, `multiple`, `maxSize`, `upload`, `progress`, `retry`, `endpoint`, `existingUrl`, or preview-kind prop. Validation and visible presentation are clearer where the product rule is written.
+There is deliberately no `variant`, `maxSize`, `maxFiles`, `upload`, `progress`, `retry`, `endpoint`, `existingUrl`, or preview-kind prop. The native `multiple` switch changes selection cardinality; validation and visible presentation remain clearer where the product rule is written.
 
 ## Browse and drop are one path
 
-`accept` affects the platform picker and is also checked when a file is dropped. A drop of several files is rejected instead of silently choosing one. A rejected candidate never destroys the current accepted file.
+`accept` affects the platform picker and is also checked when files are dropped. Single mode rejects a several-file drop instead of silently choosing one. Multiple mode considers each candidate in order, appends the accepted files, and reports rejected files without discarding the successful part of the batch or an earlier selection.
 
 Drop remains additive. The drop surface is not given a button role or tab stop because a real visible button already invokes `choose()`. Users who cannot or do not drag receive the same capability with native keyboard activation and an honest accessible name.
 
@@ -104,11 +109,28 @@ Client checks are convenience, not trust. MIME metadata and filenames can be wro
 
 ## Native form boundary
 
-FileUpload resets its internal picker after selection so choosing the same file again is observable. The bound `File` is therefore the source of truth and the application builds the multipart request explicitly.
+FileUpload resets its internal picker after selection so choosing the same file again is observable. The bound `File` or `File[]` is therefore the source of truth and the application builds the multipart request explicitly.
 
 That is why FileUpload does not accept `name`, `form`, or `required`: those props would falsely imply that the browser submits the hidden picker for you. Keep required validation next to the rest of the form state. Use [Input](/klean-ui/components/input) with `type="file"` when ordinary native form serialization—not a custom preview or drop experience—is the actual requirement.
 
 Upload progress, cancellation, retry, scanning, storage, and server errors also belong to the request layer. Compose [Spinner](/klean-ui/components/spinner), [Alert](/klean-ui/components/alert), and a real status region around FileUpload when those states exist.
+
+## Multiple attachments
+
+Use `multiple` when the product evidence is genuinely plural: feedback screenshots, supporting documents, or a small attachment set. Keep count, duplicate, and size policy in `validate(file, { files })`; do not turn those product decisions into Klean props.
+
+<KleanPreview id="file-upload-attachments" :source="attachmentsSource" filename="FeedbackAttachments.vue">
+  <template #preview>
+    <FileUploadRecipes recipe="attachments" />
+  </template>
+  <template #caption>
+    Native multiple selection, partial rejection, wrapping previews, and per-file removal share one file array. Paste handling and the upload request remain application composition.
+  </template>
+</KleanPreview>
+
+`files` is useful for count and submission. `previews` pairs each accepted file with its temporary preview, so reordering or removing files does not require matching parallel arrays. `remove(file)` removes one; `clear()` removes all.
+
+The component appends an accepted browse or drop selection. If the product supports paste, read the clipboard files in the application and update the same bound array. If the product supports drag-to-reorder, write that ordering UI around the array; FileUpload is selection state, not a gallery manager.
 
 ## Hagfish business logo
 
@@ -144,7 +166,7 @@ The receipt flow accepts camera-friendly images and PDF documents, validates the
 
 An unsubmitted local `File` cannot be reconstructed after refresh, Back/Forward restoration, SSR, or on another device. FileUpload does not pretend otherwise. On refresh, show the server-owned current asset or ask the user to select the file again.
 
-Form drafts may safely remember application metadata such as “a receipt still needs to be reselected,” but must not persist a temporary preview URL or fake a file handle. When a candidate is replaced, cleared, externally changed, or its owner unmounts, its temporary preview is released.
+Form drafts may safely remember application metadata such as “a receipt still needs to be reselected,” but must not persist a temporary preview address or fake a file handle. When a candidate is replaced, cleared, externally changed, or its owner unmounts, its temporary preview is released.
 
 Persisted assets become durable only after the server accepts them and returns authoritative record data or a URL. Navigation and rollback should then use that server truth.
 
@@ -152,7 +174,7 @@ Persisted assets become durable only after the server accepts them and returns a
 
 - Always provide a real visible `button type="button"` for `choose()`; drag and drop is never the only path.
 - Name the button for the action and context: “Choose receipt,” “Replace business logo,” or equivalent visible text.
-- Keep rejection text visible and use `role="alert"` when it appears as the immediate result of the user's choice.
+- Keep rejection text visible and use `role="alert"` when it appears as the immediate result of the user's choice. In multiple mode, announce both accepted and rejected counts when that distinction matters.
 - Give image previews useful alt text such as “Selected receipt preview.” Do not use an image element for PDFs or unknown file types.
 - Include filename and size as text. Do not rely on a thumbnail, color, or icon alone.
 - Keep disabled styling and behavior aligned on the visible controls and FileUpload.
@@ -161,7 +183,7 @@ Persisted assets become durable only after the server accepts them and returns a
 
 ## Styling with Tailwind
 
-FileUpload renders no opinionated visible surface. Style the application markup directly: a quiet rounded dropzone, a compact logo tile, a Hagfish border and shadow, or a dense receipt row are all Tailwind recipes.
+FileUpload renders no opinionated visible surface. Style the application markup directly: a quiet rounded dropzone, a wrapping attachment grid, a compact logo tile, a Hagfish border and shadow, or a dense receipt row are all Tailwind recipes.
 
 When one product repeats the same treatment, keep a small product wrapper such as `ReceiptField.vue`. That wrapper may own copy and policy without turning them into global Klean variants.
 
@@ -169,7 +191,7 @@ When one product repeats the same treatment, keep a small product wrapper such a
 
 - Use [Input](/klean-ui/components/input) with `type="file"` for an ordinary native file field submitted by its form.
 - Use [Avatar](/klean-ui/components/avatar) to render resilient identity, not to select or upload its source.
-- Use a dedicated evidenced component for multiple-file queues, reorderable galleries, image cropping, or resumable uploads.
+- Keep queue progress, drag-to-reorder galleries, image cropping, and resumable upload workflows in application composition; `multiple` only owns selection state and preview lifecycle.
 - Keep upload transport, storage SDKs, antivirus scanning, and server validation outside FileUpload.
 - Do not persist `File`, blob URLs, or client MIME metadata as durable truth.
 

--- a/docs/klean-ui/snippets/file-upload/attachments.vue
+++ b/docs/klean-ui/snippets/file-upload/attachments.vue
@@ -1,0 +1,51 @@
+<script setup>
+import { ref, shallowRef } from 'vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
+
+const images = shallowRef([])
+const error = ref('')
+
+function signature(file) {
+  return [file.name, file.size, file.type, file.lastModified].join(':')
+}
+
+function validateImage(file, { files }) {
+  if (file.size > 5 * 1024 * 1024) return 'Each image must be 5 MB or smaller.'
+  if (files.some((current) => signature(current) === signature(file))) {
+    return { reason: 'duplicate', message: 'That image is already attached.' }
+  }
+  return files.length < 4 ? true : 'Attach up to 4 images.'
+}
+</script>
+
+<template>
+  <FileUpload
+    v-model="images"
+    multiple
+    accept="image/avif,image/gif,image/jpeg,image/png,image/webp"
+    :validate="validateImage"
+    @change="error = ''"
+    @reject="error = $event.message"
+    v-slot="upload"
+  >
+    <div v-bind="upload.dropzone" class="rounded-xl border border-dashed p-5">
+      <div class="flex flex-wrap gap-3">
+        <figure v-for="preview in upload.previews" :key="preview.file.name">
+          <img
+            :src="preview.previewUrl"
+            :alt="preview.file.name"
+            class="size-24 rounded-lg object-cover"
+          />
+          <button type="button" @click="upload.remove(preview.file)">
+            Remove {{ preview.file.name }}
+          </button>
+        </figure>
+      </div>
+
+      <button type="button" @click="upload.choose">
+        {{ upload.files.length ? 'Add more' : 'Choose images' }}
+      </button>
+    </div>
+    <p v-if="error" role="alert">{{ error }}</p>
+  </FileUpload>
+</template>

--- a/docs/klean-ui/sources/file-upload/FileUpload.jsx
+++ b/docs/klean-ui/sources/file-upload/FileUpload.jsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState
 } from 'react'
@@ -31,6 +32,7 @@ const FileUpload = forwardRef(function FileUpload(
     onReject,
     accept,
     capture,
+    multiple = false,
     disabled = false,
     validate = () => true,
     className,
@@ -46,20 +48,33 @@ const FileUpload = forwardRef(function FileUpload(
   const rootRef = useRef(null)
   const inputRef = useRef(null)
   const dragDepth = useRef(0)
+  const previewEntriesRef = useRef([])
   const controlled = value !== undefined
-  const [localFile, setLocalFile] = useState(defaultValue)
-  const [previewUrl, setPreviewUrl] = useState('')
+  const [localValue, setLocalValue] = useState(defaultValue)
+  const [previews, setPreviews] = useState([])
   const [dragging, setDragging] = useState(false)
-  const file = controlled ? value : localFile
+  const selectedValue = controlled ? value : localValue
+  const files = useMemo(() => {
+    if (multiple) {
+      return Array.isArray(selectedValue)
+        ? selectedValue.filter(Boolean)
+        : selectedValue
+          ? [selectedValue]
+          : []
+    }
+    return selectedValue ? [selectedValue] : []
+  }, [multiple, selectedValue])
+  const file = multiple ? null : (files[0] ?? null)
+  const previewUrl = previews[0]?.previewUrl ?? ''
 
   const resetInput = useCallback(() => {
     if (inputRef.current) inputRef.current.value = ''
   }, [])
 
-  const setFile = useCallback(
-    (candidate) => {
-      if (!controlled) setLocalFile(candidate)
-      onChange?.(candidate)
+  const setSelection = useCallback(
+    (selection) => {
+      if (!controlled) setLocalValue(selection)
+      onChange?.(selection)
       resetInput()
       return true
     },
@@ -78,52 +93,75 @@ const FileUpload = forwardRef(function FileUpload(
   )
 
   const select = useCallback(
-    (files) => {
+    (selection) => {
       if (disabled) return false
-      const candidates = Array.from(files ?? [])
+      const candidates = Array.from(selection ?? [])
       if (!candidates.length) return false
-      if (candidates.length > 1) {
-        return reject(
+      if (!multiple && candidates.length > 1) {
+        reject(
           candidates[0],
           'multiple',
           'Choose one file at a time.',
           candidates
         )
+        resetInput()
+        return false
       }
 
-      const candidate = candidates[0]
-      if (!acceptedByAttribute(candidate, accept)) {
-        return reject(candidate, 'accept', 'That file type is not accepted.')
+      const accepted = []
+      const current = multiple ? [...files] : []
+      for (const candidate of candidates) {
+        if (!acceptedByAttribute(candidate, accept)) {
+          reject(candidate, 'accept', 'That file type is not accepted.')
+          continue
+        }
+
+        let result
+        try {
+          result = validate(candidate, {
+            files: [...current, ...accepted],
+            multiple
+          })
+        } catch {
+          reject(candidate, 'validate', 'That file could not be validated.')
+          continue
+        }
+
+        if (result !== true && result !== undefined) {
+          reject(
+            candidate,
+            typeof result === 'object' && result?.reason
+              ? result.reason
+              : 'validate',
+            typeof result === 'string' && result
+              ? result
+              : typeof result === 'object' && result?.message
+                ? result.message
+                : 'That file is not valid.'
+          )
+          continue
+        }
+
+        accepted.push(candidate)
       }
 
-      let result
-      try {
-        result = validate(candidate)
-      } catch {
-        return reject(
-          candidate,
-          'validate',
-          'That file could not be validated.'
-        )
+      if (!accepted.length) {
+        resetInput()
+        return false
       }
 
-      if (result !== true && result !== undefined) {
-        return reject(
-          candidate,
-          typeof result === 'object' && result?.reason
-            ? result.reason
-            : 'validate',
-          typeof result === 'string' && result
-            ? result
-            : typeof result === 'object' && result?.message
-              ? result.message
-              : 'That file is not valid.'
-        )
-      }
-
-      return setFile(candidate)
+      return setSelection(multiple ? [...current, ...accepted] : accepted[0])
     },
-    [accept, disabled, reject, setFile, validate]
+    [
+      accept,
+      disabled,
+      files,
+      multiple,
+      reject,
+      resetInput,
+      setSelection,
+      validate
+    ]
   )
 
   const choose = useCallback(() => {
@@ -142,8 +180,21 @@ const FileUpload = forwardRef(function FileUpload(
   }, [disabled, resetInput])
 
   const clear = useCallback(() => {
-    if (!disabled) setFile(null)
-  }, [disabled, setFile])
+    if (!disabled) setSelection(multiple ? [] : null)
+  }, [disabled, multiple, setSelection])
+
+  const remove = useCallback(
+    (candidate) => {
+      if (disabled) return false
+      if (!multiple) return setSelection(null)
+      const index = files.findIndex((entry) => Object.is(entry, candidate))
+      if (index === -1) return false
+      const next = [...files]
+      next.splice(index, 1)
+      return setSelection(next)
+    },
+    [disabled, files, multiple, setSelection]
+  )
 
   function hasFiles(event) {
     return Array.from(event.dataTransfer?.types ?? []).includes('Files')
@@ -179,20 +230,37 @@ const FileUpload = forwardRef(function FileUpload(
   }
 
   useEffect(() => {
-    if (
-      !file ||
-      typeof Blob === 'undefined' ||
-      !(file instanceof Blob) ||
-      typeof URL.createObjectURL !== 'function'
-    ) {
-      setPreviewUrl('')
-      return undefined
+    const remaining = [...previewEntriesRef.current]
+    const next = files.map((candidate) => {
+      const index = remaining.findIndex((entry) =>
+        Object.is(entry.file, candidate)
+      )
+      if (index !== -1) return remaining.splice(index, 1)[0]
+      const canPreview =
+        typeof Blob !== 'undefined' &&
+        candidate instanceof Blob &&
+        typeof URL.createObjectURL === 'function'
+      return {
+        file: candidate,
+        previewUrl: canPreview ? URL.createObjectURL(candidate) : ''
+      }
+    })
+    for (const entry of remaining) {
+      if (entry.previewUrl) URL.revokeObjectURL?.(entry.previewUrl)
     }
+    previewEntriesRef.current = next
+    setPreviews(next)
+  }, [files])
 
-    const url = URL.createObjectURL(file)
-    setPreviewUrl(url)
-    return () => URL.revokeObjectURL?.(url)
-  }, [file])
+  useEffect(
+    () => () => {
+      for (const entry of previewEntriesRef.current) {
+        if (entry.previewUrl) URL.revokeObjectURL?.(entry.previewUrl)
+      }
+      previewEntriesRef.current = []
+    },
+    []
+  )
 
   const dropzone = {
     'data-dragging': dragging ? '' : undefined,
@@ -209,11 +277,18 @@ const FileUpload = forwardRef(function FileUpload(
     get previewUrl() {
       return previewUrl
     },
+    get files() {
+      return files
+    },
+    get previews() {
+      return previews
+    },
     get dragging() {
       return dragging
     },
     choose,
     clear,
+    remove,
     get dropzone() {
       return dropzone
     }
@@ -222,7 +297,8 @@ const FileUpload = forwardRef(function FileUpload(
   useImperativeHandle(forwardedRef, () => ({
     root: rootRef.current,
     choose,
-    clear
+    clear,
+    remove
   }))
 
   return (
@@ -230,7 +306,7 @@ const FileUpload = forwardRef(function FileUpload(
       {...props}
       ref={rootRef}
       data-slot="file-upload"
-      data-state={file ? 'ready' : 'empty'}
+      data-state={files.length ? 'ready' : 'empty'}
       data-dragging={dragging ? '' : undefined}
       data-disabled={disabled ? '' : undefined}
       className={className}
@@ -242,6 +318,7 @@ const FileUpload = forwardRef(function FileUpload(
         data-part="input"
         accept={accept}
         capture={capture}
+        multiple={multiple}
         disabled={disabled}
         onChange={(event) => select(event.currentTarget.files)}
       />

--- a/docs/klean-ui/sources/file-upload/FileUpload.svelte
+++ b/docs/klean-ui/sources/file-upload/FileUpload.svelte
@@ -1,10 +1,13 @@
 <script>
+  import { untrack } from "svelte";
+
   let {
     file = $bindable(null),
     onchange,
     onreject,
     accept,
     capture,
+    multiple = false,
     disabled = false,
     validate = () => true,
     class: className,
@@ -18,12 +21,65 @@
 
   let root = $state();
   let input = $state();
-  let previewUrl = $state("");
+  let previewEntries = $state([]);
   let dragging = $state(false);
   let dragDepth = 0;
+  let files = $derived(
+    multiple
+      ? Array.isArray(file)
+        ? file.filter(Boolean)
+        : file
+          ? [file]
+          : []
+      : file
+        ? [file]
+        : [],
+  );
+  let singleFile = $derived(multiple ? null : (files[0] ?? null));
+  let previews = $derived(
+    previewEntries.map((entry) => ({
+      file: entry.file,
+      previewUrl: entry.url,
+    })),
+  );
+  let previewUrl = $derived(previews[0]?.previewUrl ?? "");
 
   function resetInput() {
     if (input) input.value = "";
+  }
+
+  function revokeEntry(entry) {
+    if (entry?.url) URL.revokeObjectURL?.(entry.url);
+  }
+
+  function createPreviewEntry(candidate) {
+    const canPreview =
+      candidate &&
+      typeof Blob !== "undefined" &&
+      candidate instanceof Blob &&
+      typeof URL.createObjectURL === "function";
+    return {
+      file: candidate,
+      url: canPreview ? URL.createObjectURL(candidate) : "",
+    };
+  }
+
+  function syncPreviews(candidates) {
+    const remaining = [...previewEntries];
+    const next = candidates.map((candidate) => {
+      const index = remaining.findIndex((entry) =>
+        Object.is(entry.file, candidate),
+      );
+      if (index === -1) return createPreviewEntry(candidate);
+      return remaining.splice(index, 1)[0];
+    });
+    for (const entry of remaining) revokeEntry(entry);
+    previewEntries = next;
+  }
+
+  function revokePreviews() {
+    for (const entry of previewEntries) revokeEntry(entry);
+    previewEntries = [];
   }
 
   function acceptedByAttribute(candidate) {
@@ -50,53 +106,71 @@
     return false;
   }
 
-  function setFile(candidate) {
-    file = candidate;
-    onchange?.(candidate);
+  function setSelection(selection) {
+    file = selection;
+    onchange?.(selection);
     resetInput();
     return true;
   }
 
-  function select(files) {
+  function select(selection) {
     if (disabled) return false;
-    const candidates = Array.from(files ?? []);
+    const candidates = Array.from(selection ?? []);
     if (!candidates.length) return false;
-    if (candidates.length > 1) {
-      return reject(
+    if (!multiple && candidates.length > 1) {
+      reject(
         candidates[0],
         "multiple",
         "Choose one file at a time.",
         candidates,
       );
+      resetInput();
+      return false;
     }
 
-    const candidate = candidates[0];
-    if (!acceptedByAttribute(candidate)) {
-      return reject(candidate, "accept", "That file type is not accepted.");
+    const accepted = [];
+    const current = multiple ? [...files] : [];
+    for (const candidate of candidates) {
+      if (!acceptedByAttribute(candidate)) {
+        reject(candidate, "accept", "That file type is not accepted.");
+        continue;
+      }
+
+      let result;
+      try {
+        result = validate(candidate, {
+          files: [...current, ...accepted],
+          multiple,
+        });
+      } catch {
+        reject(candidate, "validate", "That file could not be validated.");
+        continue;
+      }
+
+      if (result !== true && result !== undefined) {
+        reject(
+          candidate,
+          typeof result === "object" && result?.reason
+            ? result.reason
+            : "validate",
+          typeof result === "string" && result
+            ? result
+            : typeof result === "object" && result?.message
+              ? result.message
+              : "That file is not valid.",
+        );
+        continue;
+      }
+
+      accepted.push(candidate);
     }
 
-    let result;
-    try {
-      result = validate(candidate);
-    } catch {
-      return reject(candidate, "validate", "That file could not be validated.");
+    if (!accepted.length) {
+      resetInput();
+      return false;
     }
 
-    if (result !== true && result !== undefined) {
-      return reject(
-        candidate,
-        typeof result === "object" && result?.reason
-          ? result.reason
-          : "validate",
-        typeof result === "string" && result
-          ? result
-          : typeof result === "object" && result?.message
-            ? result.message
-            : "That file is not valid.",
-      );
-    }
-
-    return setFile(candidate);
+    return setSelection(multiple ? [...current, ...accepted] : accepted[0]);
   }
 
   export function choose() {
@@ -114,7 +188,17 @@
   }
 
   export function clear() {
-    if (!disabled) setFile(null);
+    if (!disabled) setSelection(multiple ? [] : null);
+  }
+
+  export function remove(candidate) {
+    if (disabled) return false;
+    if (!multiple) return setSelection(null);
+    const index = files.findIndex((entry) => Object.is(entry, candidate));
+    if (index === -1) return false;
+    const next = [...files];
+    next.splice(index, 1);
+    return setSelection(next);
   }
 
   export function getRoot() {
@@ -165,10 +249,16 @@
 
   let api = {
     get file() {
-      return file;
+      return singleFile;
     },
     get previewUrl() {
       return previewUrl;
+    },
+    get files() {
+      return files;
+    },
+    get previews() {
+      return previews;
     },
     get dragging() {
       return dragging;
@@ -178,23 +268,16 @@
     },
     choose,
     clear,
+    remove,
   };
 
   $effect(() => {
-    const candidate = file;
-    if (
-      !candidate ||
-      typeof Blob === "undefined" ||
-      !(candidate instanceof Blob) ||
-      typeof URL.createObjectURL !== "function"
-    ) {
-      previewUrl = "";
-      return;
-    }
+    const candidates = files;
+    untrack(() => syncPreviews(candidates));
+  });
 
-    const url = URL.createObjectURL(candidate);
-    previewUrl = url;
-    return () => URL.revokeObjectURL?.(url);
+  $effect(() => {
+    return () => untrack(revokePreviews);
   });
 </script>
 
@@ -202,7 +285,7 @@
   {...props}
   bind:this={root}
   data-slot="file-upload"
-  data-state={file ? "ready" : "empty"}
+  data-state={files.length ? "ready" : "empty"}
   data-dragging={dragging ? "" : undefined}
   data-disabled={disabled ? "" : undefined}
   class={className}
@@ -214,6 +297,7 @@
     data-part="input"
     {accept}
     {capture}
+    {multiple}
     {disabled}
     onchange={(event) => select(event.currentTarget.files)}
   />


### PR DESCRIPTION
Closes #220

Upstream: sailscastshq/klean-ui#143

## Summary
- keep docs.sailscasts.com as the canonical FileUpload documentation
- document the single-file and native multiple-file contracts across Vue, React, and Svelte
- add a live, copyable attachment recipe with wrapping previews and per-file removal
- explain partial rejection, caller-owned policy, accessible browse/drop parity, and the transport boundary

## Verification
- targeted Prettier checks pass for every changed FileUpload file
- VitePress production build passes
- live recipe reviewed at desktop width

The repository-wide formatter still reports six unrelated pre-existing files outside this change.