### PR TITLE
docs(klean-ui): complete form framework parity

### DIFF
--- a/docs/.vitepress/theme/components/KleanFrameworkCode.vue
+++ b/docs/.vitepress/theme/components/KleanFrameworkCode.vue
@@ -1,0 +1,151 @@
+<script setup>
+import { nextTick, ref, toRef } from 'vue'
+import { useKleanFramework } from '../composables/useKleanFramework.js'
+import CopyCode from './CopyCode.vue'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  frameworks: {
+    type: Array,
+    required: true
+  },
+  label: {
+    type: String,
+    default: 'Framework example'
+  }
+})
+
+const tabs = toRef(props, 'frameworks')
+const tabRefs = ref([])
+const { activeFramework, selectFramework } = useKleanFramework(tabs)
+
+function tabId(framework) {
+  return `${props.id}-${framework}-tab`
+}
+
+function panelId(framework) {
+  return `${props.id}-${framework}-panel`
+}
+
+async function select(framework, focusTab = false) {
+  selectFramework(framework)
+  if (!focusTab) return
+
+  await nextTick()
+  tabRefs.value[
+    props.frameworks.findIndex(({ id }) => id === framework)
+  ]?.focus()
+}
+
+function handleKeydown(event, index) {
+  let nextIndex
+
+  if (event.key === 'ArrowRight') {
+    nextIndex = (index + 1) % props.frameworks.length
+  } else if (event.key === 'ArrowLeft') {
+    nextIndex = (index - 1 + props.frameworks.length) % props.frameworks.length
+  } else if (event.key === 'Home') nextIndex = 0
+  else if (event.key === 'End') nextIndex = props.frameworks.length - 1
+  else return
+
+  event.preventDefault()
+  select(props.frameworks[nextIndex].id, true)
+}
+</script>
+
+<template>
+  <div class="klean-framework-code">
+    <div role="tablist" :aria-label="label">
+      <button
+        v-for="(framework, index) in frameworks"
+        :id="tabId(framework.id)"
+        :key="framework.id"
+        :ref="(element) => (tabRefs[index] = element)"
+        type="button"
+        role="tab"
+        :aria-selected="activeFramework === framework.id"
+        :aria-controls="panelId(framework.id)"
+        :tabindex="activeFramework === framework.id ? 0 : -1"
+        @click="select(framework.id)"
+        @keydown="handleKeydown($event, index)"
+      >
+        {{ framework.label }}
+      </button>
+    </div>
+
+    <section
+      v-for="framework in frameworks"
+      v-show="activeFramework === framework.id"
+      :id="panelId(framework.id)"
+      :key="framework.id"
+      role="tabpanel"
+      :aria-labelledby="tabId(framework.id)"
+      tabindex="0"
+    >
+      <CopyCode
+        :code="framework.code"
+        :label="framework.filename"
+        :language="framework.language"
+      />
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.klean-framework-code {
+  margin: 1rem 0 2.75rem;
+}
+
+.klean-framework-code > [role='tablist'] {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  gap: 0.25rem;
+  overflow-x: auto;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.65rem;
+  background: var(--vp-c-bg-soft);
+  padding: 0.25rem;
+}
+
+.klean-framework-code [role='tab'] {
+  min-height: 2.5rem;
+  border: 0;
+  border-radius: 0.45rem;
+  background: transparent;
+  padding: 0 0.85rem;
+  color: var(--vp-c-text-2);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.klean-framework-code [role='tab']:hover {
+  color: var(--vp-c-text-1);
+}
+
+.klean-framework-code [role='tab'][aria-selected='true'] {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+}
+
+.klean-framework-code [role='tab']:focus-visible,
+.klean-framework-code [role='tabpanel']:focus-visible {
+  outline: 2px solid var(--vp-c-text-2);
+  outline-offset: 2px;
+}
+
+.klean-framework-code [role='tabpanel'] {
+  outline: none;
+}
+
+.klean-framework-code :deep(.copy-code) {
+  margin-top: 0.75rem;
+  margin-bottom: 0;
+}
+</style>

--- a/docs/.vitepress/theme/components/KleanInstallation.vue
+++ b/docs/.vitepress/theme/components/KleanInstallation.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, nextTick, ref } from 'vue'
+import { useKleanFramework } from '../composables/useKleanFramework.js'
 import CopyCode from './CopyCode.vue'
 
 const props = defineProps({
@@ -9,7 +10,11 @@ const props = defineProps({
   },
   source: {
     type: String,
-    required: true
+    default: ''
+  },
+  frameworks: {
+    type: Array,
+    default: undefined
   },
   component: {
     type: String,
@@ -61,7 +66,7 @@ const packageManagers = computed(() => [
   }
 ])
 
-const sourceFiles = computed(() =>
+const fallbackSourceFiles = computed(() =>
   props.files?.length
     ? props.files
     : [
@@ -69,6 +74,29 @@ const sourceFiles = computed(() =>
           filename: props.filename,
           destination: props.destination,
           source: props.source
+        }
+      ]
+)
+
+const frameworkOptions = computed(() =>
+  props.frameworks?.length
+    ? props.frameworks.map((framework) => ({
+        ...framework,
+        files: framework.files?.length
+          ? framework.files
+          : [
+              {
+                filename: framework.filename,
+                destination: framework.destination,
+                source: framework.source ?? framework.code
+              }
+            ]
+      }))
+    : [
+        {
+          id: 'vue',
+          label: 'Vue',
+          files: fallbackSourceFiles.value
         }
       ]
 )
@@ -81,6 +109,8 @@ const activeMethod = ref('command')
 const activePackageManager = ref('npm')
 const methodRefs = ref([])
 const packageManagerRefs = ref([])
+const frameworkRefs = ref([])
+const { activeFramework, selectFramework } = useKleanFramework(frameworkOptions)
 
 function methodTabId(method) {
   return `${props.id}-${method}-tab`
@@ -96,6 +126,14 @@ function packageManagerTabId(packageManager) {
 
 function packageManagerPanelId(packageManager) {
   return `${props.id}-${packageManager}-panel`
+}
+
+function frameworkTabId(framework) {
+  return `${props.id}-${framework}-framework-tab`
+}
+
+function frameworkPanelId(framework) {
+  return `${props.id}-${framework}-framework-panel`
 }
 
 async function selectTab(value, refs, options, focusTab) {
@@ -127,6 +165,11 @@ function selectMethod(method, focusTab = false) {
 function selectPackageManager(packageManager, focusTab = false) {
   activePackageManager.value = packageManager
   selectTab(packageManager, packageManagerRefs, packageManagers.value, focusTab)
+}
+
+function chooseFramework(framework, focusTab = false) {
+  selectFramework(framework)
+  selectTab(framework, frameworkRefs, frameworkOptions.value, focusTab)
 }
 </script>
 
@@ -224,17 +267,55 @@ function selectPackageManager(packageManager, focusTab = false) {
       tabindex="0"
       class="klean-installation__panel"
     >
-      <ol class="klean-installation__steps">
-        <li>
-          <h3>Install direct dependencies</h3>
-          <CopyCode :code="dependencyCommand" label="Terminal" />
-        </li>
-        <li v-for="file in sourceFiles" :key="file.destination">
-          <h3>Copy {{ file.filename }}</h3>
-          <CopyCode :code="file.source" :label="file.filename" />
-          <CopyCode :code="file.destination" label="Destination" />
-        </li>
-      </ol>
+      <div
+        v-if="frameworkOptions.length > 1"
+        class="klean-installation__frameworks"
+        role="tablist"
+        aria-label="Manual installation framework"
+      >
+        <button
+          v-for="(framework, index) in frameworkOptions"
+          :id="frameworkTabId(framework.id)"
+          :key="framework.id"
+          :ref="(element) => (frameworkRefs[index] = element)"
+          type="button"
+          role="tab"
+          :aria-selected="activeFramework === framework.id"
+          :aria-controls="frameworkPanelId(framework.id)"
+          :tabindex="activeFramework === framework.id ? 0 : -1"
+          @click="chooseFramework(framework.id)"
+          @keydown="
+            handleTabKeydown($event, index, frameworkOptions, chooseFramework)
+          "
+        >
+          {{ framework.label }}
+        </button>
+      </div>
+
+      <div
+        v-for="framework in frameworkOptions"
+        v-show="activeFramework === framework.id"
+        :id="frameworkPanelId(framework.id)"
+        :key="framework.id"
+        :role="frameworkOptions.length > 1 ? 'tabpanel' : undefined"
+        :aria-labelledby="
+          frameworkOptions.length > 1 ? frameworkTabId(framework.id) : undefined
+        "
+        :tabindex="frameworkOptions.length > 1 ? 0 : undefined"
+        class="klean-installation__framework-panel"
+      >
+        <ol class="klean-installation__steps">
+          <li>
+            <h3>Install direct dependencies</h3>
+            <CopyCode :code="dependencyCommand" label="Terminal" />
+          </li>
+          <li v-for="file in framework.files" :key="file.destination">
+            <h3>Copy {{ file.filename }}</h3>
+            <CopyCode :code="file.source" :label="file.filename" />
+            <CopyCode :code="file.destination" label="Destination" />
+          </li>
+        </ol>
+      </div>
     </section>
   </div>
 </template>
@@ -258,7 +339,8 @@ function selectPackageManager(packageManager, focusTab = false) {
 }
 
 .klean-installation__methods button,
-.klean-installation__packages button {
+.klean-installation__packages button,
+.klean-installation__frameworks button {
   position: relative;
   border: 0;
   background: transparent;
@@ -317,7 +399,21 @@ function selectPackageManager(packageManager, focusTab = false) {
   margin-bottom: 0.75rem;
 }
 
-.klean-installation__packages button {
+.klean-installation__frameworks {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  gap: 0.25rem;
+  overflow-x: auto;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.65rem;
+  background: var(--vp-c-bg-soft);
+  padding: 0.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.klean-installation__packages button,
+.klean-installation__frameworks button {
   min-height: 2.5rem;
   border-radius: 0.5rem;
   padding: 0 0.8rem;
@@ -329,15 +425,31 @@ function selectPackageManager(packageManager, focusTab = false) {
   color: var(--vp-c-text-1);
 }
 
+.klean-installation__frameworks button:hover {
+  color: var(--vp-c-text-1);
+}
+
 .klean-installation__packages button[aria-selected='true'] {
   background: var(--vp-c-bg-mute);
   color: var(--vp-c-text-1);
 }
 
+.klean-installation__frameworks button[aria-selected='true'] {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+}
+
 .klean-installation__methods button:focus-visible,
-.klean-installation__packages button:focus-visible {
+.klean-installation__packages button:focus-visible,
+.klean-installation__frameworks button:focus-visible,
+.klean-installation__framework-panel:focus-visible {
   outline: 2px solid var(--vp-c-text-2);
   outline-offset: 2px;
+}
+
+.klean-installation__framework-panel {
+  outline: none;
 }
 
 .klean-installation__summary {

--- a/docs/.vitepress/theme/composables/useKleanFramework.js
+++ b/docs/.vitepress/theme/composables/useKleanFramework.js
@@ -1,0 +1,64 @@
+import { computed, onBeforeUnmount, onMounted, ref, unref } from 'vue'
+
+const STORAGE_KEY = 'klean-ui-docs-framework'
+const selectedFramework = ref('vue')
+
+let preferenceLoaded = false
+let listenerCount = 0
+
+function readStoredFramework() {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return undefined
+  }
+}
+
+function storeFramework(framework) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, framework)
+  } catch {
+    // The selector still works for this page when storage is unavailable.
+  }
+}
+
+function handleStorage(event) {
+  if (event.key === STORAGE_KEY && event.newValue) {
+    selectedFramework.value = event.newValue
+  }
+}
+
+export function useKleanFramework(frameworks) {
+  const options = computed(() => unref(frameworks) ?? [])
+  const activeFramework = computed(() => {
+    const available = options.value.map(({ id }) => id)
+    return available.includes(selectedFramework.value)
+      ? selectedFramework.value
+      : available[0]
+  })
+
+  onMounted(() => {
+    if (!preferenceLoaded) {
+      selectedFramework.value = readStoredFramework() ?? 'vue'
+      preferenceLoaded = true
+    }
+
+    listenerCount += 1
+    if (listenerCount === 1) window.addEventListener('storage', handleStorage)
+  })
+
+  onBeforeUnmount(() => {
+    listenerCount -= 1
+    if (listenerCount === 0) {
+      window.removeEventListener('storage', handleStorage)
+    }
+  })
+
+  function selectFramework(framework) {
+    if (!options.value.some(({ id }) => id === framework)) return
+    selectedFramework.value = framework
+    storeFramework(framework)
+  }
+
+  return { activeFramework, selectFramework }
+}

--- a/docs/klean-ui/components/button.md
+++ b/docs/klean-ui/components/button.md
@@ -1,22 +1,56 @@
 ---
 title: Button
 titleTemplate: Klean UI
-description: A native-first Klean UI action primitive with behavioral props and Tailwind as its visual API.
+description: A native-first Klean UI action primitive for Vue, React, and Svelte with behavioral props and Tailwind as its visual API.
 outline: [2, 3]
 ---
 
 <script setup>
-import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanFrameworkCode from '../../.vitepress/theme/components/KleanFrameworkCode.vue'
 import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
 import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
 import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
 import ProductLoader from '../../.vitepress/theme/components/klean/spinner/ProductLoader.vue'
 import KleanSpinner from '../../.vitepress/theme/components/klean/spinner/Spinner.vue'
 import buttonSource from '../../.vitepress/theme/components/klean/Button.vue?raw'
-import basicUsage from '../snippets/button/usage.vue?raw'
+import reactSource from '../sources/button/Button.jsx?raw'
+import svelteSource from '../sources/button/Button.svelte?raw'
+import vueUsage from '../snippets/button/usage.vue?raw'
+import reactUsage from '../snippets/button/usage.jsx?raw'
+import svelteUsage from '../snippets/button/usage.svelte?raw'
 import pendingUsage from '../snippets/button/pending.vue?raw'
 import semanticUsage from '../snippets/button/semantics.vue?raw'
 import productRecipes from '../snippets/button/products.vue?raw'
+
+const buttonFrameworks = [
+  {
+    id: 'vue',
+    label: 'Vue',
+    code: buttonSource,
+    filename: 'Button.vue',
+    destination: 'assets/js/components/ui/button/Button.vue'
+  },
+  {
+    id: 'react',
+    label: 'React',
+    code: reactSource,
+    filename: 'Button.jsx',
+    destination: 'assets/js/components/ui/button/Button.jsx'
+  },
+  {
+    id: 'svelte',
+    label: 'Svelte',
+    code: svelteSource,
+    filename: 'Button.svelte',
+    destination: 'assets/js/components/ui/button/Button.svelte'
+  }
+]
+
+const buttonUsage = [
+  { id: 'vue', label: 'Vue', code: vueUsage, filename: 'SaveButton.vue' },
+  { id: 'react', label: 'React', code: reactUsage, filename: 'SaveButton.jsx' },
+  { id: 'svelte', label: 'Svelte', code: svelteUsage, filename: 'SaveButton.svelte' }
+]
 </script>
 
 # Button
@@ -48,11 +82,21 @@ There are intentionally no `variant`, `size`, `color`, `tone`, `radius`, `elevat
 
 The standard Boring Stack path requires no `init`, `klean-ui.json`, alias prompt, or generated `cn.js`. The installer detects the framework and conventional source paths.
 
-<KleanInstallation id="button-installation" :source="buttonSource" />
+<KleanInstallation
+  id="button-installation"
+  component="button"
+  :frameworks="buttonFrameworks"
+/>
 
 ## Usage
 
-<CopyCode :code="basicUsage" label="usage.vue" />
+Choose a framework. The preference is remembered across Klean component pages, while the command remains the same because the CLI detects the application.
+
+<KleanFrameworkCode
+  id="button-usage"
+  :frameworks="buttonUsage"
+  label="Button usage framework"
+/>
 
 Visual styling stays in the framework's ordinary class API. If the same product treatment repeats, create an application-owned component such as `PrimaryButton.vue` using Button as its semantic base.
 
@@ -154,6 +198,16 @@ Klean's neutral default stays motionless and uses tonal feedback. Hagfish delibe
 - Disabled links leave the tab order and cannot activate.
 - Processing indicators are decorative when the visible label already describes the state.
 - Base interaction is motionless, and transitions are removed for reduced-motion preferences.
+
+## Complete framework source
+
+The live preview demonstrates the shared semantic contract. Copy the complete framework-native source that belongs in your application:
+
+<KleanFrameworkCode
+  id="button-complete-source"
+  :frameworks="buttonFrameworks"
+  label="Button source framework"
+/>
 
 ## Related components
 

--- a/docs/klean-ui/components/input.md
+++ b/docs/klean-ui/components/input.md
@@ -1,19 +1,53 @@
 ---
 title: Input
 titleTemplate: Klean UI
-description: A styled native Klean UI input with caller-owned form markup and Tailwind styling.
+description: A styled native Klean UI input for Vue, React, and Svelte with caller-owned form markup and Tailwind styling.
 outline: [2, 3]
 ---
 
 <script setup>
 import { computed, ref } from 'vue'
-import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanFrameworkCode from '../../.vitepress/theme/components/KleanFrameworkCode.vue'
 import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
 import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
 import KleanButton from '../../.vitepress/theme/components/klean/Button.vue'
 import KleanInput from '../../.vitepress/theme/components/klean/input/Input.vue'
 import inputSource from '../../.vitepress/theme/components/klean/input/Input.vue?raw'
-import usageSource from '../snippets/input/usage.vue?raw'
+import reactSource from '../sources/input/Input.jsx?raw'
+import svelteSource from '../sources/input/Input.svelte?raw'
+import vueUsage from '../snippets/input/usage.vue?raw'
+import reactUsage from '../snippets/input/usage.jsx?raw'
+import svelteUsage from '../snippets/input/usage.svelte?raw'
+
+const inputFrameworks = [
+  {
+    id: 'vue',
+    label: 'Vue',
+    code: inputSource,
+    filename: 'Input.vue',
+    destination: 'assets/js/components/ui/input/Input.vue'
+  },
+  {
+    id: 'react',
+    label: 'React',
+    code: reactSource,
+    filename: 'Input.jsx',
+    destination: 'assets/js/components/ui/input/Input.jsx'
+  },
+  {
+    id: 'svelte',
+    label: 'Svelte',
+    code: svelteSource,
+    filename: 'Input.svelte',
+    destination: 'assets/js/components/ui/input/Input.svelte'
+  }
+]
+
+const inputUsage = [
+  { id: 'vue', label: 'Vue', code: vueUsage, filename: 'EmailField.vue' },
+  { id: 'react', label: 'React', code: reactUsage, filename: 'EmailField.jsx' },
+  { id: 'svelte', label: 'Svelte', code: svelteUsage, filename: 'EmailField.svelte' }
+]
 
 const email = ref('kelvin@')
 const submitted = ref(false)
@@ -79,14 +113,16 @@ One command installs one framework-native source file. There is no initializer, 
 <KleanInstallation
   id="input-installation"
   component="input"
-  :source="inputSource"
-  filename="Input.vue"
-  destination="assets/js/components/ui/input/Input.vue"
+  :frameworks="inputFrameworks"
 />
 
 ## Native form recipe
 
-<CopyCode :code="usageSource" label="usage.vue" />
+<KleanFrameworkCode
+  id="input-usage"
+  :frameworks="inputUsage"
+  label="Input usage framework"
+/>
 
 The application owns the visible label, deterministic IDs, help and error elements, validation timing, and submitted value. Help and error nodes keep stable IDs, so `aria-describedby` never needs conditional string building. `aria-invalid="false"` is valid, and `empty:hidden` collapses an empty error. When an error appears, the existing relationship becomes useful automatically.
 
@@ -118,6 +154,16 @@ If that dense treatment is a recurring product concept, create an application-ow
 - Focus remains visible in light, dark, and high-contrast contexts.
 - Validation waits for blur or submission instead of punishing untouched input.
 - A failed submission that needs announcement uses one application-owned error summary and focus recovery, not `role="alert"` on every inline error.
+
+## Complete framework source
+
+The live preview demonstrates the shared native form contract. Copy the complete framework-native source for your application:
+
+<KleanFrameworkCode
+  id="input-complete-source"
+  :frameworks="inputFrameworks"
+  label="Input source framework"
+/>
 
 ## Related components
 

--- a/docs/klean-ui/components/textarea.md
+++ b/docs/klean-ui/components/textarea.md
@@ -1,18 +1,52 @@
 ---
 title: Textarea
 titleTemplate: Klean UI
-description: A styled native Klean UI textarea that grows from current content while caller Tailwind stays in control.
+description: A styled native Klean UI textarea for Vue, React, and Svelte that grows from current content while caller Tailwind stays in control.
 outline: [2, 3]
 ---
 
 <script setup>
 import { ref } from 'vue'
-import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanFrameworkCode from '../../.vitepress/theme/components/KleanFrameworkCode.vue'
 import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
 import KleanPreview from '../../.vitepress/theme/components/KleanPreview.vue'
 import KleanTextarea from '../../.vitepress/theme/components/klean/textarea/Textarea.vue'
 import textareaSource from '../../.vitepress/theme/components/klean/textarea/Textarea.vue?raw'
-import usageSource from '../snippets/textarea/usage.vue?raw'
+import reactSource from '../sources/textarea/Textarea.jsx?raw'
+import svelteSource from '../sources/textarea/Textarea.svelte?raw'
+import vueUsage from '../snippets/textarea/usage.vue?raw'
+import reactUsage from '../snippets/textarea/usage.jsx?raw'
+import svelteUsage from '../snippets/textarea/usage.svelte?raw'
+
+const textareaFrameworks = [
+  {
+    id: 'vue',
+    label: 'Vue',
+    code: textareaSource,
+    filename: 'Textarea.vue',
+    destination: 'assets/js/components/ui/textarea/Textarea.vue'
+  },
+  {
+    id: 'react',
+    label: 'React',
+    code: reactSource,
+    filename: 'Textarea.jsx',
+    destination: 'assets/js/components/ui/textarea/Textarea.jsx'
+  },
+  {
+    id: 'svelte',
+    label: 'Svelte',
+    code: svelteSource,
+    filename: 'Textarea.svelte',
+    destination: 'assets/js/components/ui/textarea/Textarea.svelte'
+  }
+]
+
+const textareaUsage = [
+  { id: 'vue', label: 'Vue', code: vueUsage, filename: 'NoteField.vue' },
+  { id: 'react', label: 'React', code: reactUsage, filename: 'NoteField.jsx' },
+  { id: 'svelte', label: 'Svelte', code: svelteUsage, filename: 'NoteField.svelte' }
+]
 
 const note = ref(
   'This value represents a draft restored by the application.\n\nTextarea derives its height from the value already rendered.'
@@ -61,14 +95,16 @@ Textarea is a styled native control with one durable behavior: its presentation 
 <KleanInstallation
   id="textarea-installation"
   component="textarea"
-  :source="textareaSource"
-  filename="Textarea.vue"
-  destination="assets/js/components/ui/textarea/Textarea.vue"
+  :frameworks="textareaFrameworks"
 />
 
 ## Native form recipe
 
-<CopyCode :code="usageSource" label="usage.vue" />
+<KleanFrameworkCode
+  id="textarea-usage"
+  :frameworks="textareaUsage"
+  label="Textarea usage framework"
+/>
 
 The surrounding label, help, error, IDs, validation, and value source remain ordinary application markup. Keep help and error nodes stable, bind `aria-invalid` to the boolean error state, and hide an empty error with `empty:hidden`. There is no Field context, accessibility helper, or `autoGrow` switch.
 
@@ -97,6 +133,16 @@ Textarea accepts native textarea attributes, framework-native value binding, and
 - Do not use placeholder text as the label.
 - Caller-owned fixed sizing must preserve usable content access and keyboard operation.
 - Focus remains visible and decorative transitions respect reduced motion.
+
+## Complete framework source
+
+The live preview demonstrates the shared native and content-derived sizing contract. Copy the complete framework-native source for your application:
+
+<KleanFrameworkCode
+  id="textarea-complete-source"
+  :frameworks="textareaFrameworks"
+  label="Textarea source framework"
+/>
 
 ## Related components
 

--- a/docs/klean-ui/snippets/button/usage.jsx
+++ b/docs/klean-ui/snippets/button/usage.jsx
@@ -1,0 +1,5 @@
+import Button from '@/components/ui/button/Button.jsx'
+
+export default function SaveButton() {
+  return <Button type="submit">Save changes</Button>
+}

--- a/docs/klean-ui/snippets/button/usage.svelte
+++ b/docs/klean-ui/snippets/button/usage.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Button from '@/components/ui/button/Button.svelte'
+</script>
+
+<Button type="submit">Save changes</Button>

--- a/docs/klean-ui/snippets/input/usage.jsx
+++ b/docs/klean-ui/snippets/input/usage.jsx
@@ -1,0 +1,24 @@
+import Input from '@/components/ui/input/Input.jsx'
+
+export default function EmailField({ value, onChange, error = '' }) {
+  return (
+    <div className="grid gap-2">
+      <label htmlFor="email">Email address</label>
+      <Input
+        id="email"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        name="email"
+        type="email"
+        autoComplete="email"
+        required
+        aria-invalid={Boolean(error)}
+        aria-describedby="email-help email-error"
+      />
+      <p id="email-help">We only use this for account messages.</p>
+      <p id="email-error" className="empty:hidden text-sm text-red-700">
+        {error}
+      </p>
+    </div>
+  )
+}

--- a/docs/klean-ui/snippets/input/usage.svelte
+++ b/docs/klean-ui/snippets/input/usage.svelte
@@ -1,0 +1,23 @@
+<script>
+  import Input from '@/components/ui/input/Input.svelte'
+
+  let { value = $bindable(''), error = '' } = $props()
+</script>
+
+<div class="grid gap-2">
+  <label for="email">Email address</label>
+  <Input
+    id="email"
+    bind:value
+    name="email"
+    type="email"
+    autocomplete="email"
+    required
+    aria-invalid={Boolean(error)}
+    aria-describedby="email-help email-error"
+  />
+  <p id="email-help">We only use this for account messages.</p>
+  <p id="email-error" class="empty:hidden text-sm text-red-700">
+    {error}
+  </p>
+</div>

--- a/docs/klean-ui/snippets/textarea/usage.jsx
+++ b/docs/klean-ui/snippets/textarea/usage.jsx
@@ -1,0 +1,22 @@
+import Textarea from '@/components/ui/textarea/Textarea.jsx'
+
+export default function NoteField({ value, onChange, error = '' }) {
+  return (
+    <div className="grid gap-2">
+      <label htmlFor="note">Internal note</label>
+      <Textarea
+        id="note"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        name="note"
+        rows={3}
+        aria-invalid={Boolean(error)}
+        aria-describedby="note-help note-error"
+      />
+      <p id="note-help">Plain text, up to 2,000 characters.</p>
+      <p id="note-error" className="empty:hidden text-sm text-red-700">
+        {error}
+      </p>
+    </div>
+  )
+}

--- a/docs/klean-ui/snippets/textarea/usage.svelte
+++ b/docs/klean-ui/snippets/textarea/usage.svelte
@@ -1,0 +1,21 @@
+<script>
+  import Textarea from '@/components/ui/textarea/Textarea.svelte'
+
+  let { value = $bindable(''), error = '' } = $props()
+</script>
+
+<div class="grid gap-2">
+  <label for="note">Internal note</label>
+  <Textarea
+    id="note"
+    bind:value
+    name="note"
+    rows="3"
+    aria-invalid={Boolean(error)}
+    aria-describedby="note-help note-error"
+  />
+  <p id="note-help">Plain text, up to 2,000 characters.</p>
+  <p id="note-error" class="empty:hidden text-sm text-red-700">
+    {error}
+  </p>
+</div>

--- a/docs/klean-ui/sources/button/Button.jsx
+++ b/docs/klean-ui/sources/button/Button.jsx
@@ -1,0 +1,74 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES = [
+  'inline-flex min-h-11 min-w-11 cursor-pointer select-none items-center justify-center gap-2 rounded-md no-underline',
+  'bg-gray-950 px-4 py-2 text-sm font-medium text-nowrap text-white',
+  'transition-colors duration-150 ease-out',
+  'hover:bg-gray-800 active:bg-gray-700',
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:focus-visible:outline-gray-400',
+  'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+  'dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100 dark:active:bg-gray-200',
+  'motion-reduce:transition-none'
+]
+
+const Button = forwardRef(function Button(
+  {
+    as: Component = 'button',
+    type = 'button',
+    disabled = false,
+    className,
+    onClick,
+    onKeyDown,
+    tabIndex,
+    'aria-disabled': ariaDisabled,
+    children,
+    ...props
+  },
+  ref
+) {
+  const isNativeButton = Component === 'button'
+
+  function handleClick(event) {
+    if (disabled && !isNativeButton) {
+      event.preventDefault()
+      event.stopPropagation()
+      return
+    }
+
+    onClick?.(event)
+  }
+
+  function handleKeyDown(event) {
+    if (disabled && !isNativeButton && ['Enter', ' '].includes(event.key)) {
+      event.preventDefault()
+      event.stopPropagation()
+      return
+    }
+
+    onKeyDown?.(event)
+  }
+
+  return (
+    <Component
+      {...props}
+      ref={ref}
+      type={isNativeButton ? type : undefined}
+      disabled={isNativeButton ? disabled : undefined}
+      aria-disabled={
+        isNativeButton ? undefined : disabled ? true : ariaDisabled
+      }
+      tabIndex={!isNativeButton && disabled ? -1 : tabIndex}
+      data-disabled={disabled ? '' : undefined}
+      data-slot="button"
+      className={twMerge(BASE_CLASSES, className)}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+    </Component>
+  )
+})
+
+export default Button

--- a/docs/klean-ui/sources/button/Button.svelte
+++ b/docs/klean-ui/sources/button/Button.svelte
@@ -1,0 +1,88 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES = [
+    "inline-flex min-h-11 min-w-11 cursor-pointer select-none items-center justify-center gap-2 rounded-md no-underline",
+    "bg-gray-950 px-4 py-2 text-sm font-medium text-nowrap text-white",
+    "transition-colors duration-150 ease-out",
+    "hover:bg-gray-800 active:bg-gray-700",
+    "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:focus-visible:outline-gray-400",
+    "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+    "aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
+    "dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100 dark:active:bg-gray-200",
+    "motion-reduce:transition-none",
+  ];
+
+  let {
+    as = "button",
+    type = "button",
+    disabled = false,
+    class: className,
+    onclick,
+    onkeydown,
+    tabindex,
+    "aria-disabled": ariaDisabled,
+    children,
+    ...props
+  } = $props();
+
+  let isNativeButton = $derived(as === "button");
+
+  function handleClick(event) {
+    if (disabled && !isNativeButton) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    onclick?.(event);
+  }
+
+  function handleKeydown(event) {
+    if (disabled && !isNativeButton && ["Enter", " "].includes(event.key)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    onkeydown?.(event);
+  }
+</script>
+
+{#if typeof as === "string"}
+  <svelte:element
+    this={as}
+    {...props}
+    type={isNativeButton ? type : undefined}
+    disabled={isNativeButton ? disabled : undefined}
+    aria-disabled={isNativeButton
+      ? undefined
+      : disabled
+        ? "true"
+        : ariaDisabled}
+    tabindex={!isNativeButton && disabled ? -1 : tabindex}
+    data-disabled={disabled ? "" : undefined}
+    data-slot="button"
+    class={twMerge(BASE_CLASSES, className)}
+    onclick={handleClick}
+    onkeydown={handleKeydown}
+  >
+    {@render children?.()}
+  </svelte:element>
+{:else}
+  {@const Component = as}
+  <Component
+    {...props}
+    type={undefined}
+    disabled={undefined}
+    aria-disabled={disabled ? "true" : ariaDisabled}
+    tabindex={disabled ? -1 : tabindex}
+    data-disabled={disabled ? "" : undefined}
+    data-slot="button"
+    class={twMerge(BASE_CLASSES, className)}
+    onclick={handleClick}
+    onkeydown={handleKeydown}
+  >
+    {@render children?.()}
+  </Component>
+{/if}

--- a/docs/klean-ui/sources/input/Input.jsx
+++ b/docs/klean-ui/sources/input/Input.jsx
@@ -1,0 +1,29 @@
+import { forwardRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES = [
+  'block min-h-11 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-base text-gray-950 shadow-sm outline-none transition-colors duration-150',
+  'placeholder:text-gray-500 hover:border-gray-400',
+  'focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950',
+  'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500',
+  'aria-invalid:border-red-600 aria-invalid:focus-visible:outline-red-600',
+  'dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-400 dark:hover:border-gray-600 dark:focus-visible:border-white dark:focus-visible:outline-white dark:disabled:bg-gray-900 dark:disabled:text-gray-500 dark:aria-invalid:border-red-500 dark:aria-invalid:focus-visible:outline-red-500',
+  'motion-reduce:transition-none'
+]
+
+const Input = forwardRef(function Input(
+  { type = 'text', className, ...props },
+  ref
+) {
+  return (
+    <input
+      {...props}
+      ref={ref}
+      type={type}
+      data-slot="input"
+      className={twMerge(BASE_CLASSES, className)}
+    />
+  )
+})
+
+export default Input

--- a/docs/klean-ui/sources/input/Input.svelte
+++ b/docs/klean-ui/sources/input/Input.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES = [
+    "block min-h-11 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-base text-gray-950 shadow-sm outline-none transition-colors duration-150",
+    "placeholder:text-gray-500 hover:border-gray-400",
+    "focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950",
+    "disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500",
+    "aria-invalid:border-red-600 aria-invalid:focus-visible:outline-red-600",
+    "dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-400 dark:hover:border-gray-600 dark:focus-visible:border-white dark:focus-visible:outline-white dark:disabled:bg-gray-900 dark:disabled:text-gray-500 dark:aria-invalid:border-red-500 dark:aria-invalid:focus-visible:outline-red-500",
+    "motion-reduce:transition-none",
+  ];
+
+  let {
+    type = "text",
+    value = $bindable(),
+    class: className,
+    ...props
+  } = $props();
+
+  let element;
+
+  export function getElement() {
+    return element;
+  }
+
+  export function focus(options) {
+    element?.focus(options);
+  }
+</script>
+
+<input
+  {...props}
+  bind:this={element}
+  {type}
+  bind:value
+  data-slot="input"
+  class={twMerge(BASE_CLASSES, className)}
+/>

--- a/docs/klean-ui/sources/textarea/Textarea.jsx
+++ b/docs/klean-ui/sources/textarea/Textarea.jsx
@@ -1,0 +1,72 @@
+import { forwardRef, useCallback, useLayoutEffect, useRef } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+const BASE_CLASSES = [
+  'block h-(--klean-textarea-height) min-h-28 w-full resize-none overflow-y-hidden rounded-md border border-gray-300 bg-white px-3 py-2 text-base text-gray-950 shadow-sm outline-none transition-colors duration-150',
+  'placeholder:text-gray-500 hover:border-gray-400',
+  'focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950',
+  'disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500',
+  'aria-invalid:border-red-600 aria-invalid:focus-visible:outline-red-600',
+  'dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-400 dark:hover:border-gray-600 dark:focus-visible:border-white dark:focus-visible:outline-white dark:disabled:bg-gray-900 dark:disabled:text-gray-500 dark:aria-invalid:border-red-500 dark:aria-invalid:focus-visible:outline-red-500',
+  'motion-reduce:transition-none'
+]
+
+const Textarea = forwardRef(function Textarea(
+  { value, defaultValue, className, onInput, ...props },
+  ref
+) {
+  const element = useRef(null)
+
+  const setRefs = useCallback(
+    (node) => {
+      element.current = node
+      if (typeof ref === 'function') ref(node)
+      else if (ref) ref.current = node
+    },
+    [ref]
+  )
+
+  const resizeToContent = useCallback(() => {
+    if (!element.current) return
+    element.current.style.removeProperty('--klean-textarea-height')
+    element.current.style.setProperty(
+      '--klean-textarea-height',
+      `${element.current.scrollHeight}px`
+    )
+  }, [])
+
+  useLayoutEffect(() => {
+    resizeToContent()
+  }, [value, defaultValue, resizeToContent])
+
+  useLayoutEffect(() => {
+    if (!element.current || typeof ResizeObserver === 'undefined') return
+    let width = element.current.offsetWidth
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry.contentRect.width === width) return
+      width = entry.contentRect.width
+      resizeToContent()
+    })
+    observer.observe(element.current)
+    return () => observer.disconnect()
+  }, [resizeToContent])
+
+  function handleInput(event) {
+    resizeToContent()
+    onInput?.(event)
+  }
+
+  return (
+    <textarea
+      {...props}
+      ref={setRefs}
+      value={value}
+      defaultValue={defaultValue}
+      data-slot="textarea"
+      className={twMerge(BASE_CLASSES, className)}
+      onInput={handleInput}
+    />
+  )
+})
+
+export default Textarea

--- a/docs/klean-ui/sources/textarea/Textarea.svelte
+++ b/docs/klean-ui/sources/textarea/Textarea.svelte
@@ -1,0 +1,58 @@
+<script>
+  import { onMount, tick } from "svelte";
+  import { twMerge } from "tailwind-merge";
+
+  const BASE_CLASSES = [
+    "block h-(--klean-textarea-height) min-h-28 w-full resize-none overflow-y-hidden rounded-md border border-gray-300 bg-white px-3 py-2 text-base text-gray-950 shadow-sm outline-none transition-colors duration-150",
+    "placeholder:text-gray-500 hover:border-gray-400",
+    "focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950",
+    "disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500",
+    "aria-invalid:border-red-600 aria-invalid:focus-visible:outline-red-600",
+    "dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-400 dark:hover:border-gray-600 dark:focus-visible:border-white dark:focus-visible:outline-white dark:disabled:bg-gray-900 dark:disabled:text-gray-500 dark:aria-invalid:border-red-500 dark:aria-invalid:focus-visible:outline-red-500",
+    "motion-reduce:transition-none",
+  ];
+
+  let { value = $bindable(), class: className, oninput, ...props } = $props();
+
+  let element;
+
+  function resizeToContent() {
+    if (!element) return;
+    element.style.removeProperty("--klean-textarea-height");
+    element.style.setProperty(
+      "--klean-textarea-height",
+      `${element.scrollHeight}px`,
+    );
+  }
+
+  function handleInput(event) {
+    resizeToContent();
+    oninput?.(event);
+  }
+
+  onMount(() => {
+    resizeToContent();
+    if (typeof ResizeObserver === "undefined") return;
+    let width = element.offsetWidth;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry.contentRect.width === width) return;
+      width = entry.contentRect.width;
+      resizeToContent();
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  });
+
+  $effect(() => {
+    value;
+    tick().then(resizeToContent);
+  });
+</script>
+
+<textarea
+  bind:this={element}
+  {...props}
+  bind:value
+  data-slot="textarea"
+  class={twMerge(BASE_CLASSES, className)}
+  oninput={handleInput}></textarea>


### PR DESCRIPTION
## What changed

- add one accessible, remembered Vue/React/Svelte framework selector for Klean UI documentation
- keep installation, usage, and complete copied source in sync across Button, Input, and Textarea
- add complete React and Svelte sources and framework-native usage recipes alongside Vue
- retain zero-configuration CLI installation while making manual installation equally complete

## Verification

- `npm run build`
- scoped Prettier check for all 18 changed files
- browser QA of Button, Input, and Textarea at `127.0.0.1:5173`
- verified click selection, ArrowLeft/ArrowRight/Home/End behavior, focus movement, cross-section synchronization, and preference persistence across component pages

The repository-wide lint command still reports six unrelated, pre-existing formatting failures outside this change.

Closes #249
