### PR TITLE
docs(klean-ui): make theming framework-native

### DIFF
--- a/docs/klean-ui/snippets/theming/local.jsx
+++ b/docs/klean-ui/snippets/theming/local.jsx
@@ -1,0 +1,9 @@
+import Button from '@/components/ui/button/Button.jsx'
+
+export default function ApproveInvoiceButton() {
+  return (
+    <Button className="bg-emerald-700 text-white hover:bg-emerald-800">
+      Approve invoice
+    </Button>
+  )
+}

--- a/docs/klean-ui/snippets/theming/local.svelte
+++ b/docs/klean-ui/snippets/theming/local.svelte
@@ -1,0 +1,7 @@
+<script>
+  import Button from '@/components/ui/button/Button.svelte'
+</script>
+
+<Button class="bg-emerald-700 text-white hover:bg-emerald-800">
+  Approve invoice
+</Button>

--- a/docs/klean-ui/snippets/theming/local.vue
+++ b/docs/klean-ui/snippets/theming/local.vue
@@ -1,0 +1,9 @@
+<script setup>
+import Button from '@/components/ui/button/Button.vue'
+</script>
+
+<template>
+  <Button class="bg-emerald-700 text-white hover:bg-emerald-800">
+    Approve invoice
+  </Button>
+</template>

--- a/docs/klean-ui/snippets/theming/product.jsx
+++ b/docs/klean-ui/snippets/theming/product.jsx
@@ -1,0 +1,10 @@
+// assets/js/components/DeployButton.jsx
+import { twMerge } from 'tailwind-merge'
+import Button from './ui/button/Button.jsx'
+
+const classes =
+  'min-h-11 bg-emerald-700 px-5 font-semibold text-white hover:bg-emerald-800'
+
+export default function DeployButton({ className, ...props }) {
+  return <Button {...props} className={twMerge(classes, className)} />
+}

--- a/docs/klean-ui/snippets/theming/product.svelte
+++ b/docs/klean-ui/snippets/theming/product.svelte
@@ -1,0 +1,14 @@
+<!-- assets/js/components/DeployButton.svelte -->
+<script>
+  import { twMerge } from 'tailwind-merge'
+  import Button from './ui/button/Button.svelte'
+
+  const classes =
+    'min-h-11 bg-emerald-700 px-5 font-semibold text-white hover:bg-emerald-800'
+
+  let { children, class: className, ...props } = $props()
+</script>
+
+<Button {...props} class={twMerge(classes, className)}>
+  {@render children?.()}
+</Button>

--- a/docs/klean-ui/snippets/theming/product.vue
+++ b/docs/klean-ui/snippets/theming/product.vue
@@ -1,0 +1,12 @@
+<!-- assets/js/components/DeployButton.vue -->
+<script setup>
+import Button from './ui/button/Button.vue'
+</script>
+
+<template>
+  <Button
+    class="min-h-11 bg-emerald-700 px-5 font-semibold text-white hover:bg-emerald-800"
+  >
+    <slot />
+  </Button>
+</template>

--- a/docs/klean-ui/theming.md
+++ b/docs/klean-ui/theming.md
@@ -5,6 +5,28 @@ description: Theme Klean UI with application-owned CSS and Tailwind instead of p
 outline: [2, 3]
 ---
 
+<script setup>
+import KleanFrameworkCode from '../.vitepress/theme/components/KleanFrameworkCode.vue'
+import localVue from './snippets/theming/local.vue?raw'
+import localReact from './snippets/theming/local.jsx?raw'
+import localSvelte from './snippets/theming/local.svelte?raw'
+import productVue from './snippets/theming/product.vue?raw'
+import productReact from './snippets/theming/product.jsx?raw'
+import productSvelte from './snippets/theming/product.svelte?raw'
+
+const localExamples = [
+  { id: 'vue', label: 'Vue', code: localVue, filename: 'ApproveInvoiceButton.vue' },
+  { id: 'react', label: 'React', code: localReact, filename: 'ApproveInvoiceButton.jsx' },
+  { id: 'svelte', label: 'Svelte', code: localSvelte, filename: 'ApproveInvoiceButton.svelte' }
+]
+
+const productExamples = [
+  { id: 'vue', label: 'Vue', code: productVue, filename: 'DeployButton.vue' },
+  { id: 'react', label: 'React', code: productReact, filename: 'DeployButton.jsx' },
+  { id: 'svelte', label: 'Svelte', code: productSvelte, filename: 'DeployButton.svelte' }
+]
+</script>
+
 # Theming
 
 The application's CSS is the theme. Klean has no `ThemeProvider`, theme object, preset code, named theme catalog, or theme section in a configuration file.
@@ -15,30 +37,21 @@ Neutral component defaults work without global Klean tokens. Products apply thei
 
 ### One local treatment: use classes
 
-```vue
-<Button class="bg-emerald-700 text-white hover:bg-emerald-800">
-  Approve invoice
-</Button>
-```
+<KleanFrameworkCode
+  id="theming-local-treatment"
+  :frameworks="localExamples"
+  label="Local Tailwind framework"
+/>
 
 ### One repeated product concept: create a component
 
-```vue
-<!-- assets/js/components/PrimaryButton.vue -->
-<script setup>
-import Button from './ui/button/Button.vue'
-</script>
+<KleanFrameworkCode
+  id="theming-product-component"
+  :frameworks="productExamples"
+  label="Application-owned component framework"
+/>
 
-<template>
-  <Button
-    class="min-h-11 bg-emerald-700 px-5 font-semibold text-white hover:bg-emerald-800"
-  >
-    <slot />
-  </Button>
-</template>
-```
-
-This is the normal replacement for `variant="primary"`. The product concept receives a product name and stays inside the product.
+This is the normal replacement for `variant="primary"`. The product concept receives a product name and stays inside the product. Caller classes still merge last when the product component needs a local adjustment.
 
 ### One shared value: use Tailwind's theme
 
@@ -59,9 +72,13 @@ This is the normal replacement for `variant="primary"`. The product concept rece
 
 The token creates Tailwind utilities. It does not create component variants.
 
+The Vue, React, and Svelte examples above all consume the same application CSS. Changing frameworks does not create a Klean theme layer.
+
 ## Optional semantic foundations
 
 Applications with coordinated modes or white-label branding can define a short set of application-owned roles such as `canvas`, `ink`, `surface`, `muted`, `line`, and `focus`. Product signals should have paired foregrounds such as `brand` / `on-brand`.
+
+These roles are optional application infrastructure. Klean does not generate them, prompt for them, or require them before a component works.
 
 Avoid component-specific tokens such as `--button-primary-hover-background`. They recreate a variant matrix in CSS and make the primitive harder to replace.
 
@@ -78,6 +95,12 @@ An application that follows the operating system can use Tailwind's ordinary `da
 ```
 
 If the stored preference is `system`, application-owned code resolves the media query and writes `light` or `dark` before paint. A server-readable cookie is the right convention when SSR must avoid a flash.
+
+The mode preference is a Durable UI concern because a person chose it. Store that preference in application-owned code, resolve it before paint, and leave component source unaware of the storage mechanism.
+
+## Proving applications, not themes
+
+Hagfish and Slipway intentionally keep different typography, spacing, color, density, shadow, and motion. They prove that Klean's semantic and behavioral source accepts radically different application-owned Tailwind. They are not named themes and do not appear in a theme selector.
 
 ## Accessibility invariants
 


### PR DESCRIPTION
## What changed

- replace Vue-only theming examples with synchronized Vue, React, and Svelte source
- show direct Tailwind styling and framework-native application-owned product components
- preserve the shared optional `@theme` and root `data-mode` conventions
- clarify that semantic roles are application infrastructure and mode preference is Durable UI state
- state explicitly that Hagfish and Slipway are proving applications, not themes

## Verification

- `npm run build`
- scoped Prettier checks for all changed Markdown, Vue, JSX, and Svelte files
- browser QA verifies synchronized click selection, ArrowRight keyboard selection, copy controls, and remembered framework preference

Closes #251
Related: sailscastshq/klean-ui#6
