### PR TITLE
docs(klean-ui): document resilience source bundle

### DIFF
--- a/docs/klean-ui/durable-ui.md
+++ b/docs/klean-ui/durable-ui.md
@@ -5,11 +5,34 @@ description: How Klean UI implements resilient state, focus, navigation, and asy
 outline: [2, 3]
 ---
 
+<script setup>
+import KleanFrameworkCode from '../.vitepress/theme/components/KleanFrameworkCode.vue'
+import formDraftVue from './snippets/durable-ui/form-draft.vue?raw'
+import formDraftReact from './snippets/durable-ui/form-draft.jsx?raw'
+import formDraftSvelte from './snippets/durable-ui/form-draft.svelte?raw'
+
+const formDraftExamples = [
+  { id: 'vue', label: 'Vue', code: formDraftVue, filename: 'NewInvoice.vue' },
+  { id: 'react', label: 'React', code: formDraftReact, filename: 'NewInvoice.jsx' },
+  { id: 'svelte', label: 'Svelte', code: formDraftSvelte, filename: 'NewInvoice.svelte' }
+]
+</script>
+
 # Durable UI
 
 Klean UI is the canonical source-owned implementation of Durable UI for The Boring JavaScript Stack. Components should not merely look correct in a screenshot; useful state, navigation context, focus, and in-progress work should survive the real conditions of an application.
 
 Vue, React, and Svelte preserve the same outcomes with framework-native source.
+
+## Installation
+
+Add the complete resilience layer from any conventional Boring Stack application:
+
+```bash
+npx klean-ui add durable-ui
+```
+
+Klean detects Vue, React, or Svelte and writes eight readable files to `assets/js/components/ui/durable-ui`: seven focused framework-native utilities and their small browser core. There is no Durable UI runtime dependency, provider, initializer, manifest, or setup questionnaire.
 
 ## Two kinds of resilience
 
@@ -44,6 +67,48 @@ Klean components, state utilities, and blocks cover:
 - accessible toast queues with deduplication, hover pause, manual dismissal, and Inertia flash integration;
 - debounced client or server search with URL synchronization and stale-request cancellation.
 
+## The APIs
+
+| Need                       | Vue / React            | Svelte                    | Durable default                                       |
+| -------------------------- | ---------------------- | ------------------------- | ----------------------------------------------------- |
+| Browser preference         | `useStoredState`       | `createStoredState`       | namespaced, versioned, SSR-safe, cross-tab            |
+| Shareable navigation state | `useQueryState`        | `createQueryState`        | inferred type, clean default, Back/Forward            |
+| Recoverable form           | `useFormDraft`         | `createFormDraft`         | explicit restore/discard, expiry, native unload guard |
+| Multi-step work            | `useWizardDraft`       | `createWizardDraft`       | step recovery, merged schema defaults, clear success  |
+| Return position            | `useScrollRestoration` | `createScrollRestoration` | session storage, window/container/hash restoration    |
+| Reversible async change    | `useOptimistic`        | `createOptimistic`        | inflight guard, server resync, rollback, error        |
+| Remote or local search     | `useSearch`            | `createSearch`            | debounce, minimum query, abort, stale-result guard    |
+
+The names follow each framework. The behavior does not drift. Install the bundle once, then import only the focused source a flow needs.
+
+### A recoverable form
+
+The draft key is the only required durability decision. The application still owns its fields, submission, messages, and server state.
+
+<KleanFrameworkCode
+  id="durable-form-draft"
+  :frameworks="formDraftExamples"
+  label="Recoverable form framework"
+/>
+
+The saved draft expires after 24 hours by default. It is offered for deliberate restore or discard, ignores empty work, and is cleared after the application confirms success. A dirty form uses the browser's native unsaved-change guard; `clear()` updates the clean baseline after a successful submission.
+
+### URL state and server visits
+
+`useQueryState('page', 1)` and `createQueryState('page', 1)` infer a number from the default, remove `page=1` from the URL, and follow Back and Forward navigation. Use `{ history: 'replace' }` for rapid filters or search and the default push history for meaningful view changes.
+
+For server-owned collections, compose URL state with the framework's Inertia router or use [Data Table](/klean-ui/components/data-table), whose query helper already preserves scroll, restores focus, cleans defaults, and makes partial visits. Klean does not hide a server visit inside every state value.
+
+### Optimistic work and search
+
+`useOptimistic` / `createOptimistic` updates visible state immediately only when a rejected operation can restore the previous value. It blocks accidental duplicate work, accepts the server's confirmed value, exposes the failure, and calls the application's error handler so a Toast or inline Alert can make rollback perceivable.
+
+`useSearch` / `createSearch` debounces by default, passes an `AbortSignal` to the application search function, and prevents an older result from replacing a newer query. Compose its query with URL state when the search should survive reload or be shareable. Keep transient picker searches out of the URL.
+
+### Scroll restoration
+
+Scroll state uses `sessionStorage`, not `localStorage`: returning within one browser tab is useful, while reopening an old tab days later should not jump to stale coordinates. Window and scroll-container targets are supported. Hash destinations take priority and are retried while asynchronously rendered content arrives.
+
 ## Durable does not mean global
 
 Zero configuration does not mean every pattern runs globally without being invoked. A toast queue still needs a host in the application layout. A controlled Dialog still needs open state. A draft needs an intentional key and lifecycle.
@@ -63,3 +128,10 @@ Durability is observable:
 - Navigation does not make a success or error message disappear before it can be perceived.
 
 Each Klean component page documents the durability behaviors that apply. Button has a small contract; Dialog, Toast, Combobox, forms, and state utilities will carry more.
+
+## Related components
+
+- [Dialog](/klean-ui/components/dialog), [Sheet](/klean-ui/components/sheet), [Popover](/klean-ui/components/popover), and [Menu](/klean-ui/components/menu) own dismissal, focus, and cleanup.
+- [Toast](/klean-ui/components/toast) owns perceivable queued feedback and survives page swaps through its provider-free controller.
+- [Data Table](/klean-ui/components/data-table), [Filter Bar](/klean-ui/components/filter-bar), [Pagination](/klean-ui/components/pagination), and [Tabs](/klean-ui/components/tabs) demonstrate durable URL navigation.
+- [Combobox](/klean-ui/components/combobox) and [Command](/klean-ui/components/command) demonstrate keyboard-safe search and focus recovery.

--- a/docs/klean-ui/installation.md
+++ b/docs/klean-ui/installation.md
@@ -32,6 +32,8 @@ The CLI is a delivery tool. The installed component does not import a Klean runt
 
 Registry items may include prerequisites and more than one source file. Button, Input, and Textarea are deliberately self-contained. Popover installs its focused geometry dependencies, and `npx klean-ui add menu`, `npx klean-ui add select`, or `npx klean-ui add combobox` resolves Popover first before writing the requested component. The full plan stays visible with `--dry-run`; prerequisite handling adds no configuration step.
 
+The registry also delivers focused nonvisual source. `npx klean-ui add durable-ui` writes the framework-native resilience utilities and their browser core beside the components. It follows the same detection, ownership, diff, and safe-update rules without installing a Durable UI runtime package.
+
 ## Conventional paths
 
 For a Boring Stack application, the framework determines the file—not a prompt:

--- a/docs/klean-ui/snippets/durable-ui/form-draft.jsx
+++ b/docs/klean-ui/snippets/durable-ui/form-draft.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { useFormDraft } from '@/components/ui/durable-ui/useFormDraft.js'
+
+export default function NewInvoice() {
+  const [data, setData] = useState({ customer: '', note: '' })
+  const [saved, setSaved] = useState(false)
+  const draft = useFormDraft('invoice:new', data, {
+    clearWhen: saved,
+    onRestore: setData
+  })
+
+  async function submit(event) {
+    event.preventDefault()
+    await saveInvoice(data)
+    setSaved(true)
+  }
+
+  return (
+    <>
+      {draft.hasDraft && (
+        <aside aria-label="Recovered draft">
+          <p>A saved invoice draft is available.</p>
+          <button type="button" onClick={draft.restore}>
+            Restore
+          </button>
+          <button type="button" onClick={draft.discard}>
+            Discard
+          </button>
+        </aside>
+      )}
+      <form onSubmit={submit}>{/* ordinary application fields */}</form>
+    </>
+  )
+}

--- a/docs/klean-ui/snippets/durable-ui/form-draft.svelte
+++ b/docs/klean-ui/snippets/durable-ui/form-draft.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { createFormDraft } from '@/components/ui/durable-ui/formDraft.svelte.js'
+
+  let form = $state({ customer: '', note: '' })
+  let saved = $state(false)
+
+  const draft = createFormDraft('invoice:new', () => form, {
+    clearWhen: () => saved,
+    restore(next) {
+      form = next
+    }
+  })
+
+  async function submit(event) {
+    event.preventDefault()
+    await saveInvoice(form)
+    saved = true
+  }
+</script>
+
+{#if draft.hasDraft}
+  <aside aria-label="Recovered draft">
+    <p>A saved invoice draft is available.</p>
+    <button type="button" onclick={draft.restore}>Restore</button>
+    <button type="button" onclick={draft.discard}>Discard</button>
+  </aside>
+{/if}
+
+<form onsubmit={submit}>
+  <!-- ordinary application fields -->
+</form>

--- a/docs/klean-ui/snippets/durable-ui/form-draft.vue
+++ b/docs/klean-ui/snippets/durable-ui/form-draft.vue
@@ -1,0 +1,28 @@
+<script setup>
+import { reactive, ref } from 'vue'
+import { useFormDraft } from '@/components/ui/durable-ui/useFormDraft.js'
+
+const form = reactive({ customer: '', note: '' })
+const saved = ref(false)
+
+const { hasDraft, restore, discard } = useFormDraft('invoice:new', form, {
+  clearWhen: () => saved.value
+})
+
+async function submit() {
+  await saveInvoice(form)
+  saved.value = true
+}
+</script>
+
+<template>
+  <aside v-if="hasDraft" aria-label="Recovered draft">
+    <p>A saved invoice draft is available.</p>
+    <button type="button" @click="restore">Restore</button>
+    <button type="button" @click="discard">Discard</button>
+  </aside>
+
+  <form @submit.prevent="submit">
+    <!-- ordinary application fields -->
+  </form>
+</template>

--- a/docs/klean-ui/theming.md
+++ b/docs/klean-ui/theming.md
@@ -96,7 +96,7 @@ An application that follows the operating system can use Tailwind's ordinary `da
 
 If the stored preference is `system`, application-owned code resolves the media query and writes `light` or `dark` before paint. A server-readable cookie is the right convention when SSR must avoid a flash.
 
-The mode preference is a Durable UI concern because a person chose it. Store that preference in application-owned code, resolve it before paint, and leave component source unaware of the storage mechanism.
+The mode preference is a Durable UI concern because a person chose it. Store that preference with the framework-native `useStoredState` or `createStoredState` source from the [Durable UI bundle](/klean-ui/durable-ui), resolve it before paint, and leave component source unaware of the storage mechanism.
 
 ## Proving applications, not themes
 


### PR DESCRIPTION
## Outcome

Document the shipped Klean UI resilience source as the canonical Durable UI implementation for Vue, React, and Svelte.

## What changed

- add the zero-configuration `npx klean-ui add durable-ui` installation path;
- document all seven framework-native utilities and their durable defaults;
- add synchronized, copyable Vue, React, and Svelte form-draft examples;
- explain URL/Inertia composition, optimistic rollback, stale-search cancellation, and session scroll restoration;
- connect persisted theming and related interaction-resilient components to the bundle;
- keep implementation provenance and duplicate runtime concepts out of the public docs.

## Verification

- `npx prettier --write docs/klean-ui/durable-ui.md docs/klean-ui/installation.md docs/klean-ui/theming.md docs/klean-ui/snippets/durable-ui`
- `npm run build`
- live VitePress keyboard and responsive review

Related to sailscastshq/klean-ui#7

Closes #253
