### PR TITLE
docs(klean-ui): add the Klean Icons catalog

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -118,6 +118,7 @@ function kleanUiGuide() {
         { text: 'Avatar', link: '/klean-ui/components/avatar' },
         { text: 'Badge', link: '/klean-ui/components/badge' },
         { text: 'Button', link: '/klean-ui/components/button' },
+        { text: 'Icons', link: '/klean-ui/components/icons' },
         { text: 'Card', link: '/klean-ui/components/card' },
         { text: 'Input', link: '/klean-ui/components/input' },
         { text: 'Tags Input', link: '/klean-ui/components/tags-input' },

--- a/docs/.vitepress/theme/components/KleanInstallation.vue
+++ b/docs/.vitepress/theme/components/KleanInstallation.vue
@@ -305,7 +305,7 @@ function chooseFramework(framework, focusTab = false) {
         class="klean-installation__framework-panel"
       >
         <ol class="klean-installation__steps">
-          <li>
+          <li v-if="dependencies.length">
             <h3>Install direct dependencies</h3>
             <CopyCode :code="dependencyCommand" label="Terminal" />
           </li>

--- a/docs/.vitepress/theme/components/klean/icons/IconGallery.vue
+++ b/docs/.vitepress/theme/components/klean/icons/IconGallery.vue
@@ -1,0 +1,525 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useKleanFramework } from '../../../composables/useKleanFramework.js'
+import { iconSource, icons } from './icons.js'
+
+const frameworks = [
+  { id: 'vue', label: 'Vue' },
+  { id: 'react', label: 'React' },
+  { id: 'svelte', label: 'Svelte' }
+]
+
+const query = ref('')
+const size = ref(32)
+const color = ref('#111827')
+const copiedKey = ref('')
+const copyStatus = ref('')
+const frameworkRefs = ref([])
+const urlReady = ref(false)
+const { activeFramework, selectFramework } = useKleanFramework(frameworks)
+
+let copyResetTimer
+
+const activeFrameworkLabel = computed(
+  () =>
+    frameworks.find(({ id }) => id === activeFramework.value)?.label ?? 'Vue'
+)
+
+const filteredIcons = computed(() => {
+  const term = query.value.trim().toLowerCase()
+  if (!term) return icons
+
+  return icons.filter((icon) =>
+    [icon.name, icon.description, ...icon.keywords]
+      .join(' ')
+      .toLowerCase()
+      .includes(term)
+  )
+})
+
+const resultSummary = computed(() => {
+  const count = filteredIcons.value.length
+  return `${count} ${count === 1 ? 'icon' : 'icons'}`
+})
+
+function syncQueryFromUrl() {
+  query.value = new URL(window.location.href).searchParams.get('icons') ?? ''
+}
+
+function syncQueryToUrl(value) {
+  const url = new URL(window.location.href)
+  if (value.trim()) url.searchParams.set('icons', value.trim())
+  else url.searchParams.delete('icons')
+  window.history.replaceState(window.history.state, '', url)
+}
+
+onMounted(() => {
+  syncQueryFromUrl()
+  urlReady.value = true
+  window.addEventListener('popstate', syncQueryFromUrl)
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(copyResetTimer)
+  window.removeEventListener('popstate', syncQueryFromUrl)
+})
+
+watch(query, (value) => {
+  if (urlReady.value) syncQueryToUrl(value)
+})
+
+async function chooseFramework(framework, focusButton = false) {
+  selectFramework(framework)
+  if (!focusButton) return
+
+  await nextTick()
+  frameworkRefs.value[
+    frameworks.findIndex(({ id }) => id === framework)
+  ]?.focus()
+}
+
+function handleFrameworkKeydown(event, index) {
+  let nextIndex
+
+  if (event.key === 'ArrowRight') nextIndex = (index + 1) % frameworks.length
+  else if (event.key === 'ArrowLeft')
+    nextIndex = (index - 1 + frameworks.length) % frameworks.length
+  else if (event.key === 'Home') nextIndex = 0
+  else if (event.key === 'End') nextIndex = frameworks.length - 1
+  else return
+
+  event.preventDefault()
+  chooseFramework(frameworks[nextIndex].id, true)
+}
+
+async function copy(text, key, message) {
+  copiedKey.value = ''
+  copyStatus.value = ''
+
+  try {
+    await navigator.clipboard.writeText(text)
+    copiedKey.value = key
+    copyStatus.value = message
+    clearTimeout(copyResetTimer)
+    copyResetTimer = setTimeout(() => {
+      copiedKey.value = ''
+    }, 2000)
+  } catch {
+    copyStatus.value =
+      'Could not copy. Select the source and copy it manually instead.'
+  }
+}
+
+function copySvg(icon) {
+  copy(icon.svg, `${icon.slug}-svg`, `${icon.name} SVG copied.`)
+}
+
+function copyComponent(icon) {
+  copy(
+    iconSource(icon, activeFramework.value),
+    `${icon.slug}-${activeFramework.value}`,
+    `${icon.name} ${activeFrameworkLabel.value} component copied.`
+  )
+}
+
+function copyCommand(icon) {
+  copy(
+    `npx klean-ui add icon ${icon.slug}`,
+    `${icon.slug}-command`,
+    `${icon.name} installation command copied.`
+  )
+}
+</script>
+
+<template>
+  <section class="icon-gallery" aria-labelledby="icon-gallery-title">
+    <header class="icon-gallery__header">
+      <div>
+        <h2 id="icon-gallery-title">Icon catalog</h2>
+        <p>
+          Search by name or intent, then copy exactly the source your app needs.
+        </p>
+      </div>
+
+      <div
+        class="icon-gallery__frameworks"
+        role="toolbar"
+        aria-label="Component framework"
+      >
+        <button
+          v-for="(framework, index) in frameworks"
+          :key="framework.id"
+          :ref="(element) => (frameworkRefs[index] = element)"
+          type="button"
+          :aria-pressed="activeFramework === framework.id"
+          :tabindex="activeFramework === framework.id ? 0 : -1"
+          @click="chooseFramework(framework.id)"
+          @keydown="handleFrameworkKeydown($event, index)"
+        >
+          {{ framework.label }}
+        </button>
+      </div>
+    </header>
+
+    <form class="icon-gallery__controls" role="search" @submit.prevent>
+      <label class="icon-gallery__search">
+        <span>Search icons</span>
+        <input
+          v-model="query"
+          type="search"
+          name="icons"
+          placeholder="Try calendar, delete, or deploy"
+          autocomplete="off"
+        />
+      </label>
+
+      <label class="icon-gallery__size">
+        <span
+          >Size <output for="icon-size">{{ size }}px</output></span
+        >
+        <input
+          id="icon-size"
+          v-model="size"
+          type="range"
+          min="16"
+          max="48"
+          step="1"
+        />
+      </label>
+
+      <label class="icon-gallery__color">
+        <span>Color</span>
+        <input v-model="color" type="color" aria-label="Preview color" />
+      </label>
+    </form>
+
+    <p class="icon-gallery__count" aria-live="polite">{{ resultSummary }}</p>
+
+    <ul v-if="filteredIcons.length" class="icon-gallery__grid">
+      <li v-for="icon in filteredIcons" :key="icon.slug">
+        <article class="icon-gallery__card">
+          <div class="icon-gallery__preview">
+            <span
+              class="icon-gallery__mark"
+              aria-hidden="true"
+              :style="{ color, fontSize: `${size}px` }"
+              v-html="icon.svg"
+            ></span>
+          </div>
+
+          <div class="icon-gallery__identity">
+            <h3>{{ icon.name }}</h3>
+            <p>{{ icon.description }}</p>
+          </div>
+
+          <div class="icon-gallery__actions">
+            <button type="button" @click="copySvg(icon)">
+              {{ copiedKey === `${icon.slug}-svg` ? 'Copied' : 'Copy SVG' }}
+            </button>
+            <button type="button" @click="copyComponent(icon)">
+              {{
+                copiedKey === `${icon.slug}-${activeFramework}`
+                  ? 'Copied'
+                  : `Copy ${activeFrameworkLabel}`
+              }}
+            </button>
+            <button type="button" @click="copyCommand(icon)">
+              {{
+                copiedKey === `${icon.slug}-command` ? 'Copied' : 'Copy command'
+              }}
+            </button>
+          </div>
+        </article>
+      </li>
+    </ul>
+
+    <div v-else class="icon-gallery__empty">
+      <h3>No matching icons</h3>
+      <p>Try a name such as “Bell” or an intent such as “notification”.</p>
+      <button type="button" @click="query = ''">Show all icons</button>
+    </div>
+
+    <p class="icon-gallery__status" role="status" aria-live="polite">
+      {{ copyStatus }}
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.icon-gallery {
+  margin: 1.5rem 0 3rem;
+}
+
+.icon-gallery__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.icon-gallery__header h2 {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 1.4rem;
+}
+
+.icon-gallery__header p {
+  max-width: 38rem;
+  margin: 0.4rem 0 0;
+  color: var(--vp-c-text-2);
+}
+
+.icon-gallery__frameworks {
+  display: flex;
+  flex: none;
+  gap: 0.25rem;
+  border-radius: 0.7rem;
+  background: var(--vp-c-bg-soft);
+  padding: 0.25rem;
+}
+
+.icon-gallery__frameworks button,
+.icon-gallery__actions button,
+.icon-gallery__empty button {
+  min-height: 2.75rem;
+  border: 0;
+  border-radius: 0.5rem;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.icon-gallery__frameworks button {
+  background: transparent;
+  padding: 0 0.8rem;
+  color: var(--vp-c-text-2);
+}
+
+.icon-gallery__frameworks button[aria-pressed='true'] {
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+}
+
+.icon-gallery__controls {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1fr) minmax(10rem, 0.45fr) auto;
+  gap: 1rem;
+  align-items: end;
+  margin-top: 1.5rem;
+  border-radius: 0.9rem;
+  background: var(--vp-c-bg-soft);
+  padding: 1rem;
+}
+
+.icon-gallery__controls label {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.icon-gallery__search input {
+  width: 100%;
+  min-height: 2.75rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.6rem;
+  background: var(--vp-c-bg);
+  padding: 0 0.85rem;
+  color: var(--vp-c-text-1);
+  font: inherit;
+  font-size: 0.875rem;
+}
+
+.icon-gallery__size span {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.icon-gallery__size output {
+  color: var(--vp-c-text-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.icon-gallery__size input {
+  min-height: 2.75rem;
+  accent-color: var(--vp-c-text-1);
+  cursor: pointer;
+}
+
+.icon-gallery__color input {
+  width: 3rem;
+  height: 2.75rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.6rem;
+  background: var(--vp-c-bg);
+  padding: 0.25rem;
+  cursor: pointer;
+}
+
+.icon-gallery__count {
+  margin: 1rem 0 0.75rem;
+  color: var(--vp-c-text-3);
+  font-size: 0.8rem;
+}
+
+.icon-gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.icon-gallery__card {
+  display: grid;
+  height: 100%;
+  grid-template-rows: auto 1fr auto;
+  gap: 1rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.9rem;
+  background: var(--vp-c-bg);
+  padding: 0.75rem;
+}
+
+.icon-gallery__preview {
+  display: grid;
+  min-height: 8.5rem;
+  place-items: center;
+  border-radius: 0.65rem;
+  background: #fff;
+}
+
+.icon-gallery__mark {
+  display: grid;
+  place-items: center;
+  line-height: 1;
+}
+
+.icon-gallery__mark :deep(svg) {
+  width: 1em;
+  height: 1em;
+}
+
+.icon-gallery__identity {
+  text-align: center;
+}
+
+.icon-gallery__identity h3 {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  font-size: 0.95rem;
+}
+
+.icon-gallery__identity p {
+  margin: 0.35rem auto 0;
+  color: var(--vp-c-text-2);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.icon-gallery__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.icon-gallery__actions button {
+  background: var(--vp-c-bg-soft);
+  padding: 0 0.55rem;
+  color: var(--vp-c-text-1);
+}
+
+.icon-gallery__actions button:last-child {
+  grid-column: 1 / -1;
+}
+
+.icon-gallery__frameworks button:hover,
+.icon-gallery__actions button:hover,
+.icon-gallery__empty button:hover {
+  background: var(--vp-c-bg-mute);
+  color: var(--vp-c-text-1);
+}
+
+.icon-gallery button:focus-visible,
+.icon-gallery input:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
+}
+
+.icon-gallery__empty {
+  display: grid;
+  min-height: 14rem;
+  place-items: center;
+  align-content: center;
+  gap: 0.5rem;
+  border-radius: 0.9rem;
+  background: var(--vp-c-bg-soft);
+  padding: 2rem;
+  text-align: center;
+}
+
+.icon-gallery__empty h3,
+.icon-gallery__empty p {
+  margin: 0;
+}
+
+.icon-gallery__empty p {
+  color: var(--vp-c-text-2);
+}
+
+.icon-gallery__empty button {
+  margin-top: 0.5rem;
+  background: var(--vp-c-bg-mute);
+  padding: 0 0.85rem;
+  color: var(--vp-c-text-1);
+}
+
+.icon-gallery__status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .icon-gallery__header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .icon-gallery__frameworks {
+    width: fit-content;
+  }
+
+  .icon-gallery__controls {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .icon-gallery__search {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 420px) {
+  .icon-gallery__controls {
+    grid-template-columns: 1fr;
+  }
+
+  .icon-gallery__search {
+    grid-column: auto;
+  }
+
+  .icon-gallery__color input {
+    width: 100%;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/klean/icons/icons.js
+++ b/docs/.vitepress/theme/components/klean/icons/icons.js
@@ -1,0 +1,258 @@
+// Synced from the canonical Klean Icons proof set in sailscastshq/klean-ui#150.
+// The public docs derive previews and exact framework source from the same SVG.
+
+export const icons = [
+  {
+    name: 'Trash',
+    slug: 'trash',
+    description: 'A waste bin for destructive removal actions.',
+    keywords: ['delete', 'remove', 'discard'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 7.25h15" />
+  <path d="M9 7.25v-1.5c0-.83.67-1.5 1.5-1.5h3c.83 0 1.5.67 1.5 1.5v1.5" />
+  <path d="m6.5 7.25.75 12.5h9.5l.75-12.5" />
+  <path d="M10 11v5.25M14 11v5.25" />
+</svg>`
+  },
+  {
+    name: 'Search',
+    slug: 'search',
+    description: 'A magnifying glass for search and discovery.',
+    keywords: ['find', 'filter', 'lookup'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="10.75" cy="10.75" r="6.25" />
+  <path d="m15.25 15.25 4.25 4.25" />
+</svg>`
+  },
+  {
+    name: 'Calendar',
+    slug: 'calendar',
+    description: 'A calendar page for dates and schedules.',
+    keywords: ['date', 'schedule', 'event'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3.75" y="5.5" width="16.5" height="14.25" rx="2.25" />
+  <path d="M8 3.75v3.5M16 3.75v3.5M3.75 9.5h16.5" />
+  <path d="M8 13h.01M12 13h.01M16 13h.01M8 16.5h.01M12 16.5h.01" stroke-width="2.25" />
+</svg>`
+  },
+  {
+    name: 'CheckCircle',
+    slug: 'check-circle',
+    description: 'A checked circle for successful or completed status.',
+    keywords: ['success', 'complete', 'approved'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="8.25" />
+  <path d="m8.25 12.25 2.5 2.5 5.25-5.5" />
+</svg>`
+  },
+  {
+    name: 'X',
+    slug: 'x',
+    description: 'A crossing mark for close, clear, or cancel actions.',
+    keywords: ['close', 'clear', 'cancel'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m6.5 6.5 11 11M17.5 6.5l-11 11" />
+</svg>`
+  },
+  {
+    name: 'ChevronRight',
+    slug: 'chevron-right',
+    description: 'A right-facing chevron for forward navigation.',
+    keywords: ['next', 'forward', 'disclosure'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m8.75 6.25 6.5 5.75-6.5 5.75" />
+</svg>`
+  },
+  {
+    name: 'Copy',
+    slug: 'copy',
+    description: 'Two overlapping sheets for copying content.',
+    keywords: ['duplicate', 'clipboard', 'clone'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="7.75" y="7.75" width="11.75" height="11.75" rx="2.25" />
+  <path d="M16.25 7.75v-1c0-1.24-1.01-2.25-2.25-2.25H6.75C5.51 4.5 4.5 5.51 4.5 6.75V14c0 1.24 1.01 2.25 2.25 2.25h1" />
+</svg>`
+  },
+  {
+    name: 'User',
+    slug: 'user',
+    description: 'A person for accounts, profiles, and ownership.',
+    keywords: ['person', 'profile', 'account'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="8.25" r="3.5" />
+  <path d="M5.5 20c.42-4.1 2.72-6.15 6.5-6.15S18.08 15.9 18.5 20" />
+</svg>`
+  },
+  {
+    name: 'Folder',
+    slug: 'folder',
+    description: 'A tabbed folder for projects and grouped files.',
+    keywords: ['project', 'directory', 'files'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3.5 7.5c0-1.24 1.01-2.25 2.25-2.25h3.1l2 2.25h7.9c.97 0 1.75.78 1.75 1.75v7.5c0 1.24-1.01 2.25-2.25 2.25H5.75A2.25 2.25 0 0 1 3.5 16.75z" />
+  <path d="M3.5 9.5h17" />
+</svg>`
+  },
+  {
+    name: 'Server',
+    slug: 'server',
+    description: 'A stacked server for infrastructure and deployments.',
+    keywords: ['machine', 'host', 'infrastructure'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3.75" y="3.75" width="16.5" height="6.75" rx="2.25" />
+  <rect x="3.75" y="13.5" width="16.5" height="6.75" rx="2.25" />
+  <path d="M7.25 7.15h.01M10 7.15h5.75M7.25 16.9h.01M10 16.9h5.75" />
+</svg>`
+  },
+  {
+    name: 'Bell',
+    slug: 'bell',
+    description: 'A bell for notifications and updates.',
+    keywords: ['notification', 'alert', 'updates'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6.25 10.25c0-3.7 2.15-6 5.75-6s5.75 2.3 5.75 6c0 4.5 1.75 5.35 1.75 6.75h-15c0-1.4 1.75-2.25 1.75-6.75" />
+  <path d="M9.5 19.25c.55.67 1.37 1 2.5 1s1.95-.33 2.5-1" />
+</svg>`
+  },
+  {
+    name: 'Rocket',
+    slug: 'rocket',
+    description: "Klean's launch mark for deploy and release actions.",
+    keywords: ['deploy', 'launch', 'release'],
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 14.75 5.75 14.5 3.75 16.5l4.6 1.15" />
+  <path d="m14.75 9 .25-3.25-2-2-1.15 4.6" />
+  <path d="M8.35 17.65 6.5 20.5l3.7-1 9.15-9.15c1.12-1.12 1.17-4.3.9-6.6-2.3-.27-5.48-.22-6.6.9L4.5 13.8l-1 3.7 2.85-1.85" />
+  <circle cx="15.75" cy="8.25" r="1.75" />
+</svg>`
+  }
+]
+
+function geometry(icon) {
+  return icon.svg
+    .match(/^<svg\b[^>]*>\s*([\s\S]*?)\s*<\/svg>$/)[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function indent(lines, spaces) {
+  const prefix = ' '.repeat(spaces)
+  return lines.map((line) => `${prefix}${line}`).join('\n')
+}
+
+function jsxGeometry(lines) {
+  return lines.map((line) =>
+    line
+      .replaceAll('stroke-width=', 'strokeWidth=')
+      .replaceAll('stroke-linecap=', 'strokeLinecap=')
+      .replaceAll('stroke-linejoin=', 'strokeLinejoin=')
+      .replaceAll('fill-rule=', 'fillRule=')
+      .replaceAll('clip-rule=', 'clipRule=')
+  )
+}
+
+function wrapGeometry(lines, wrapSingleAttribute = true) {
+  return lines.flatMap((line) => {
+    if (line.length <= 76) return line
+
+    const match = line.match(/^<(\w+)\s+(.+)\s\/>$/)
+    if (!match) return line
+
+    const attributes = [...match[2].matchAll(/([\w:-]+)="([^"]*)"/g)].map(
+      ([, name, value]) => `${name}="${value}"`
+    )
+
+    if (!wrapSingleAttribute && attributes.length === 1) return line
+
+    return [
+      `<${match[1]}`,
+      ...attributes.map((attribute) => `  ${attribute}`),
+      '/>'
+    ]
+  })
+}
+
+export function iconSource(icon, framework) {
+  const lines = geometry(icon)
+
+  if (framework === 'react') {
+    return `import { forwardRef } from "react";
+
+const ${icon.name} = forwardRef(function ${icon.name}(props, ref) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      data-slot="icon"
+      {...props}
+      ref={ref}
+    >
+${indent(wrapGeometry(jsxGeometry(lines), false), 6)}
+    </svg>
+  );
+});
+
+export default ${icon.name};
+`
+  }
+
+  if (framework === 'svelte') {
+    return `<script>
+  let { ...props } = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  width="1em"
+  height="1em"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+  focusable="false"
+  data-slot="icon"
+  {...props}
+>
+${indent(wrapGeometry(lines), 2)}
+</svg>
+`
+  }
+
+  return `<script setup>
+defineOptions({ inheritAttrs: false });
+</script>
+
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
+    data-slot="icon"
+    v-bind="$attrs"
+  >
+${indent(wrapGeometry(lines), 4)}
+  </svg>
+</template>
+`
+}

--- a/docs/klean-ui/components/icons.md
+++ b/docs/klean-ui/components/icons.md
@@ -1,0 +1,199 @@
+---
+title: Icons
+titleTemplate: Klean UI
+description: Original source-owned SVG icons with one quiet visual voice, exact Vue, React, and Svelte components, and caller-owned styling.
+outline: [2, 3]
+---
+
+<script setup>
+import CopyCode from '../../.vitepress/theme/components/CopyCode.vue'
+import KleanFrameworkCode from '../../.vitepress/theme/components/KleanFrameworkCode.vue'
+import KleanInstallation from '../../.vitepress/theme/components/KleanInstallation.vue'
+import IconGallery from '../../.vitepress/theme/components/klean/icons/IconGallery.vue'
+import { iconSource, icons } from '../../.vitepress/theme/components/klean/icons/icons.js'
+import vueUsage from '../snippets/icons/usage.vue?raw'
+import reactUsage from '../snippets/icons/usage.jsx?raw'
+import svelteUsage from '../snippets/icons/usage.svelte?raw'
+
+const trash = icons.find(({ slug }) => slug === 'trash')
+const frameworkSources = [
+  {
+    id: 'vue',
+    label: 'Vue',
+    filename: 'Trash.vue',
+    destination: 'assets/js/components/ui/icons/Trash.vue',
+    source: iconSource(trash, 'vue')
+  },
+  {
+    id: 'react',
+    label: 'React',
+    filename: 'Trash.jsx',
+    destination: 'assets/js/components/ui/icons/Trash.jsx',
+    source: iconSource(trash, 'react')
+  },
+  {
+    id: 'svelte',
+    label: 'Svelte',
+    filename: 'Trash.svelte',
+    destination: 'assets/js/components/ui/icons/Trash.svelte',
+    source: iconSource(trash, 'svelte')
+  }
+]
+
+const usageFrameworks = [
+  {
+    id: 'vue',
+    label: 'Vue',
+    filename: 'DeleteInvoice.vue',
+    language: 'vue',
+    code: vueUsage
+  },
+  {
+    id: 'react',
+    label: 'React',
+    filename: 'DeleteInvoice.jsx',
+    language: 'jsx',
+    code: reactUsage
+  },
+  {
+    id: 'svelte',
+    label: 'Svelte',
+    filename: 'DeleteInvoice.svelte',
+    language: 'svelte',
+    code: svelteUsage
+  }
+]
+</script>
+
+# Icons
+
+Klean Icons is a small, original SVG family drawn from the actions and objects that repeat across Slipway and Hagfish. Every mark uses the same 24px canvas, calm 1.5px stroke, rounded joins, and optical rhythm.
+
+There is no icon font, runtime package, provider, icon registry in the browser, size prop, color prop, or variant API. Install only the source you use. Then style ordinary SVG with Tailwind or native attributes.
+
+<IconGallery />
+
+Search is reflected in the page URL, so a filtered catalog can be reloaded, bookmarked, and shared. Framework choice is remembered across the Klean docs.
+
+## Installation
+
+Install one icon by its lowercase name. The CLI detects Vue, React, or Svelte and writes the matching source into the conventional <code>icons</code> directory:
+
+<KleanInstallation
+  id="icon-installation"
+  component="icon trash"
+  :frameworks="frameworkSources"
+  :dependencies="[]"
+/>
+
+Install several icons in one command when a screen needs a set:
+
+<CopyCode code="npx klean-ui add icon trash search calendar" label="Terminal" />
+
+Re-running <code>add</code> preserves changed local source. Use <code>klean-ui check icon trash</code>, <code>diff icon trash</code>, or <code>update icon trash</code> when you deliberately review upstream changes.
+
+## Usage
+
+The component is decorative by default. Put its meaning in visible button or link text, or in the accessible name of the semantic parent control.
+
+<KleanFrameworkCode
+  id="icon-usage"
+  :frameworks="usageFrameworks"
+  label="Icon usage framework"
+/>
+
+## Styling
+
+Icons use <code>1em</code> for width and height and <code>currentColor</code> for stroke. Text size and color utilities therefore work without a Klean-specific API:
+
+```vue
+<Search class="size-5 text-blue-600" />
+<Bell class="size-4 text-gray-500" stroke-width="1.75" />
+<Rocket class="size-8 text-orange-500" />
+```
+
+Use `size-*`, `text-*`, opacity, responsive, state, and dark-mode utilities directly. Native SVG attributes such as <code>stroke-width</code>, <code>aria-label</code>, and <code>role</code> are forwarded by every framework component.
+
+Do not make every icon louder to create hierarchy. Start with one color and one stroke weight. Let placement, visible text, and the parent control carry most of the meaning.
+
+## API
+
+| Input                                                | Default          | Purpose                                                                                  |
+| ---------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------- |
+| <code>class</code> / <code>className</code>          | —                | Ordinary Tailwind sizing, color, opacity, state, responsive, and dark-mode utilities.    |
+| <code>stroke-width</code> / <code>strokeWidth</code> | <code>1.5</code> | Native SVG stroke override for a deliberate product treatment.                           |
+| other SVG attributes                                 | native           | IDs, data hooks, event handlers, roles, labels, and other framework-native SVG inputs.   |
+| element reference                                    | —                | Framework-native access to the SVG element when genuinely needed.                        |
+| accessible presentation                              | decorative       | Hidden from assistive technology by default; override only for a truly informative mark. |
+
+There is no <code>size</code>, <code>color</code>, <code>tone</code>, <code>variant</code>, <code>label</code>, <code>title</code>, <code>spin</code>, <code>filled</code>, or <code>as</code> prop. CSS and SVG already provide those capabilities without another naming layer.
+
+## Accessibility
+
+Prefer visible text. In a button that says “Delete”, Trash is decorative and should stay hidden from assistive technology. For an icon-only control, name the button—not the SVG:
+
+```vue
+<button type="button" aria-label="Delete invoice">
+  <Trash class="size-5" />
+</button>
+```
+
+Only make the SVG itself informative when it stands alone and no semantic parent can own its name:
+
+```vue
+<CheckCircle
+  class="size-5 text-emerald-600"
+  role="img"
+  aria-hidden="false"
+  aria-label="Payment complete"
+/>
+```
+
+- Never rely on the icon alone when a destructive, irreversible, unfamiliar, or status-changing action needs text.
+- Keep touch and pointer targets on the parent Button or link at least 44px; enlarging the SVG does not enlarge the target.
+- Do not encode status with color alone. Pair the mark with useful text.
+- Avoid redundant names such as a labeled button containing a separately labeled icon.
+- Icons are not focusable. Keyboard focus belongs to the control that owns the action.
+
+## Why source-owned icons
+
+An icon is interface source, not an opaque service. Installing the exact Vue, React, or Svelte component means an application can inspect it, change geometry when its product genuinely needs to, and keep rendering without a Klean runtime.
+
+The shared 24px geometry keeps Slipway and Hagfish recognizable as part of the same ecosystem. <code>currentColor</code>, native attributes, and caller-owned classes let each product retain its own density, palette, contrast, and motion without forking an icon library API.
+
+Updates are deliberate. Klean never silently replaces local geometry. The CLI shows whether an installed icon differs, and the application chooses when to inspect and accept a new source version.
+
+## Naming
+
+Use the concrete object or action: <code>Trash</code>, <code>Search</code>, <code>Calendar</code>, <code>Copy</code>. Do not encode placement, product, color, or size into the exported name. The same <code>Bell</code> can appear in a header, notification preference, or activity feed without becoming three components.
+
+The CLI uses lowercase kebab-case names while framework exports use PascalCase:
+
+```sh
+npx klean-ui add icon check-circle chevron-right
+```
+
+```js
+import CheckCircle from '@/components/ui/icons/CheckCircle.vue'
+import ChevronRight from '@/components/ui/icons/ChevronRight.vue'
+```
+
+## When to use
+
+Use Klean Icons for repeated application actions, navigation, statuses, dates, identity, infrastructure, notifications, and deployment language. Use the shared source when consistency is more valuable than a product-specific illustration.
+
+## When not to use
+
+- Use text without an icon when the mark adds no recognition or scanning value.
+- Use a logo or product mark for brand identity; do not force a general interface icon to become one.
+- Use an illustration for editorial, empty-state, onboarding, or marketing storytelling.
+- Use [Spinner](/klean-ui/components/spinner) for indeterminate progress and [Avatar](/klean-ui/components/avatar) for resilient identity images.
+- Keep highly specialized domain glyphs in the application until repeated use proves that they belong in the shared family.
+
+## Related components
+
+- [Button](/klean-ui/components/button) — owns action semantics, target size, pending state, and accessible naming around an icon.
+- [Menu](/klean-ui/components/menu), [Command](/klean-ui/components/command), and [Tabs](/klean-ui/components/tabs) — compose icons with truthful actions, destinations, and navigation.
+- [Tooltip](/klean-ui/components/tooltip) — adds brief supplementary text to a real icon-only control; it does not replace the control's accessible name.
+- [Badge](/klean-ui/components/badge), [Alert](/klean-ui/components/alert), and [Toast](/klean-ui/components/toast) — pair status marks with visible language and truthful announcement behavior.
+- [Avatar](/klean-ui/components/avatar), [Spinner](/klean-ui/components/spinner), and [Empty State](/klean-ui/components/empty-state) — cover nearby visual roles that should not be folded into the icon contract.

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -29,6 +29,10 @@ One static inline metadata span for visible labels, counts, and compact statuses
 
 A native-first action primitive that can render a truthful button, anchor, or Boring Stack Link. It handles safe type defaults, disabled semantics, attribute forwarding, and caller-owned Tailwind classes.
 
+### [Icons](/klean-ui/components/icons)
+
+Original source-owned SVG marks on one calm 24px grid, with exact Vue, React, and Svelte components, native attribute forwarding, and caller-owned Tailwind styling.
+
 ### [Card](/klean-ui/components/card)
 
 One shallow semantic surface with native application content, truthful whole-card links or actions, explicit multiple-action composition, and caller-owned Tailwind styling.

--- a/docs/klean-ui/snippets/icons/usage.jsx
+++ b/docs/klean-ui/snippets/icons/usage.jsx
@@ -1,0 +1,14 @@
+import Trash from '@/components/ui/icons/Trash.jsx'
+
+export default function DeleteInvoice() {
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white"
+      aria-label="Delete invoice"
+    >
+      <Trash className="size-4" />
+      Delete
+    </button>
+  )
+}

--- a/docs/klean-ui/snippets/icons/usage.svelte
+++ b/docs/klean-ui/snippets/icons/usage.svelte
@@ -1,0 +1,12 @@
+<script>
+  import Trash from '$lib/components/ui/icons/Trash.svelte'
+</script>
+
+<button
+  type="button"
+  class="inline-flex items-center gap-2 rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white"
+  aria-label="Delete invoice"
+>
+  <Trash class="size-4" />
+  Delete
+</button>

--- a/docs/klean-ui/snippets/icons/usage.vue
+++ b/docs/klean-ui/snippets/icons/usage.vue
@@ -1,0 +1,14 @@
+<script setup>
+import Trash from '@/components/ui/icons/Trash.vue'
+</script>
+
+<template>
+  <button
+    type="button"
+    class="inline-flex items-center gap-2 rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white"
+    aria-label="Delete invoice"
+  >
+    <Trash class="size-4" />
+    Delete
+  </button>
+</template>


### PR DESCRIPTION
## Summary

- add a searchable Klean Icons catalog with centered, responsive previews
- persist icon search in the URL and remember the active Vue, React, or Svelte framework
- add one-click raw SVG, exact framework component, and CLI command copy actions
- document single and multi-icon installation, native SVG/Tailwind customization, naming, accessibility, update behavior, and related components
- expose Icons in the Klean UI sidebar and component catalog
- let zero-dependency sources use the existing manual installation flow cleanly

## Verification

- all 36 copied framework sources match the Klean registry byte-for-byte
- targeted Prettier checks pass
- `git diff --check` passes
- VitePress production build passes
- desktop and mobile browser checks pass
- URL-backed search, framework keyboard selection, SVG copy, component copy, and command copy pass
- no browser console errors

Coordinates with sailscastshq/klean-ui#151.

Resolves #257
