### PR TITLE
docs(klean-ui): publish the complete Klean Icons catalog

### DIFF
--- a/docs/.vitepress/theme/components/klean/icons/icons.js
+++ b/docs/.vitepress/theme/components/klean/icons/icons.js
@@ -1,5 +1,5 @@
-// Synced from the canonical Klean Icons proof set in sailscastshq/klean-ui#150.
-// The public docs derive previews and exact framework source from the same SVG.
+// Generated from the canonical Klean Icons catalog in sailscastshq/klean-ui#152.
+// The public docs derive previews and exact framework source from the reviewed SVG geometry.
 
 export const icons = [
   {
@@ -7,124 +7,686 @@ export const icons = [
     slug: 'trash',
     description: 'A waste bin for destructive removal actions.',
     keywords: ['delete', 'remove', 'discard'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M4.5 7.25h15" />
-  <path d="M9 7.25v-1.5c0-.83.67-1.5 1.5-1.5h3c.83 0 1.5.67 1.5 1.5v1.5" />
-  <path d="m6.5 7.25.75 12.5h9.5l.75-12.5" />
-  <path d="M10 11v5.25M14 11v5.25" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.5 7.25h15" />\n  <path d="M9 7.25v-1.5c0-.83.67-1.5 1.5-1.5h3c.83 0 1.5.67 1.5 1.5v1.5" />\n  <path d="m6.5 7.25.75 12.5h9.5l.75-12.5" />\n  <path d="M10 11v5.25M14 11v5.25" />\n</svg>'
   },
   {
     name: 'Search',
     slug: 'search',
     description: 'A magnifying glass for search and discovery.',
     keywords: ['find', 'filter', 'lookup'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="10.75" cy="10.75" r="6.25" />
-  <path d="m15.25 15.25 4.25 4.25" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="10.75" cy="10.75" r="6.25" />\n  <path d="m15.25 15.25 4.25 4.25" />\n</svg>'
   },
   {
     name: 'Calendar',
     slug: 'calendar',
     description: 'A calendar page for dates and schedules.',
     keywords: ['date', 'schedule', 'event'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="3.75" y="5.5" width="16.5" height="14.25" rx="2.25" />
-  <path d="M8 3.75v3.5M16 3.75v3.5M3.75 9.5h16.5" />
-  <path d="M8 13h.01M12 13h.01M16 13h.01M8 16.5h.01M12 16.5h.01" stroke-width="2.25" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="5.5" width="16.5" height="14.25" rx="2.25" />\n  <path d="M8 3.75v3.5M16 3.75v3.5M3.75 9.5h16.5" />\n  <path d="M8 13h.01M12 13h.01M16 13h.01M8 16.5h.01M12 16.5h.01" stroke-width="2.25" />\n</svg>'
   },
   {
     name: 'CheckCircle',
     slug: 'check-circle',
     description: 'A checked circle for successful or completed status.',
     keywords: ['success', 'complete', 'approved'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="12" cy="12" r="8.25" />
-  <path d="m8.25 12.25 2.5 2.5 5.25-5.5" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <path d="m8.25 12.25 2.5 2.5 5.25-5.5" />\n</svg>'
   },
   {
     name: 'X',
     slug: 'x',
     description: 'A crossing mark for close, clear, or cancel actions.',
     keywords: ['close', 'clear', 'cancel'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="m6.5 6.5 11 11M17.5 6.5l-11 11" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m6.5 6.5 11 11M17.5 6.5l-11 11" />\n</svg>'
   },
   {
     name: 'ChevronRight',
     slug: 'chevron-right',
     description: 'A right-facing chevron for forward navigation.',
     keywords: ['next', 'forward', 'disclosure'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="m8.75 6.25 6.5 5.75-6.5 5.75" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m8.75 6.25 6.5 5.75-6.5 5.75" />\n</svg>'
   },
   {
     name: 'Copy',
     slug: 'copy',
     description: 'Two overlapping sheets for copying content.',
     keywords: ['duplicate', 'clipboard', 'clone'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="7.75" y="7.75" width="11.75" height="11.75" rx="2.25" />
-  <path d="M16.25 7.75v-1c0-1.24-1.01-2.25-2.25-2.25H6.75C5.51 4.5 4.5 5.51 4.5 6.75V14c0 1.24 1.01 2.25 2.25 2.25h1" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="7.75" y="7.75" width="11.75" height="11.75" rx="2.25" />\n  <path d="M16.25 7.75v-1c0-1.24-1.01-2.25-2.25-2.25H6.75C5.51 4.5 4.5 5.51 4.5 6.75V14c0 1.24 1.01 2.25 2.25 2.25h1" />\n</svg>'
   },
   {
     name: 'User',
     slug: 'user',
     description: 'A person for accounts, profiles, and ownership.',
     keywords: ['person', 'profile', 'account'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="12" cy="8.25" r="3.5" />
-  <path d="M5.5 20c.42-4.1 2.72-6.15 6.5-6.15S18.08 15.9 18.5 20" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="8.25" r="3.5" />\n  <path d="M5.5 20c.42-4.1 2.72-6.15 6.5-6.15S18.08 15.9 18.5 20" />\n</svg>'
   },
   {
     name: 'Folder',
     slug: 'folder',
     description: 'A tabbed folder for projects and grouped files.',
     keywords: ['project', 'directory', 'files'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M3.5 7.5c0-1.24 1.01-2.25 2.25-2.25h3.1l2 2.25h7.9c.97 0 1.75.78 1.75 1.75v7.5c0 1.24-1.01 2.25-2.25 2.25H5.75A2.25 2.25 0 0 1 3.5 16.75z" />
-  <path d="M3.5 9.5h17" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M3.5 7.5c0-1.24 1.01-2.25 2.25-2.25h3.1l2 2.25h7.9c.97 0 1.75.78 1.75 1.75v7.5c0 1.24-1.01 2.25-2.25 2.25H5.75A2.25 2.25 0 0 1 3.5 16.75z" />\n  <path d="M3.5 9.5h17" />\n</svg>'
   },
   {
     name: 'Server',
     slug: 'server',
     description: 'A stacked server for infrastructure and deployments.',
     keywords: ['machine', 'host', 'infrastructure'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="3.75" y="3.75" width="16.5" height="6.75" rx="2.25" />
-  <rect x="3.75" y="13.5" width="16.5" height="6.75" rx="2.25" />
-  <path d="M7.25 7.15h.01M10 7.15h5.75M7.25 16.9h.01M10 16.9h5.75" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="3.75" width="16.5" height="6.75" rx="2.25" />\n  <rect x="3.75" y="13.5" width="16.5" height="6.75" rx="2.25" />\n  <path d="M7.25 7.15h.01M10 7.15h5.75M7.25 16.9h.01M10 16.9h5.75" />\n</svg>'
   },
   {
     name: 'Bell',
     slug: 'bell',
     description: 'A bell for notifications and updates.',
     keywords: ['notification', 'alert', 'updates'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M6.25 10.25c0-3.7 2.15-6 5.75-6s5.75 2.3 5.75 6c0 4.5 1.75 5.35 1.75 6.75h-15c0-1.4 1.75-2.25 1.75-6.75" />
-  <path d="M9.5 19.25c.55.67 1.37 1 2.5 1s1.95-.33 2.5-1" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M6.25 10.25c0-3.7 2.15-6 5.75-6s5.75 2.3 5.75 6c0 4.5 1.75 5.35 1.75 6.75h-15c0-1.4 1.75-2.25 1.75-6.75" />\n  <path d="M9.5 19.25c.55.67 1.37 1 2.5 1s1.95-.33 2.5-1" />\n</svg>'
   },
   {
     name: 'Rocket',
     slug: 'rocket',
-    description: "Klean's launch mark for deploy and release actions.",
+    description: "Klean's balanced launch mark for deploy and release actions.",
     keywords: ['deploy', 'launch', 'release'],
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M9 14.75 5.75 14.5 3.75 16.5l4.6 1.15" />
-  <path d="m14.75 9 .25-3.25-2-2-1.15 4.6" />
-  <path d="M8.35 17.65 6.5 20.5l3.7-1 9.15-9.15c1.12-1.12 1.17-4.3.9-6.6-2.3-.27-5.48-.22-6.6.9L4.5 13.8l-1 3.7 2.85-1.85" />
-  <circle cx="15.75" cy="8.25" r="1.75" />
-</svg>`
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 3.25c-2.7 2-4.15 5.05-3.9 8.4l.9 4.6h6l.9-4.6c.25-3.35-1.2-6.4-3.9-8.4Z" />\n  <circle cx="12" cy="9.25" r="1.5" />\n  <path d="m8.45 12.75-3.2 2.75v3l3.95-1.75M15.55 12.75l3.2 2.75v3l-3.95-1.75" />\n  <path d="M10 19c.4 1.05 1.05 1.7 2 2 .95-.3 1.6-.95 2-2" />\n</svg>'
+  },
+  {
+    name: 'ArrowRight',
+    slug: 'arrow-right',
+    description: 'A right-pointing arrow for forward movement and navigation.',
+    keywords: ['next', 'forward', 'continue'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.5 12h14" />\n  <path d="m13.25 6.75 5.25 5.25-5.25 5.25" />\n</svg>'
+  },
+  {
+    name: 'ChartBar',
+    slug: 'chart-bar',
+    description: 'Three measured bars for analytics and performance.',
+    keywords: ['analytics', 'metrics', 'report'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.25 20v-8.25h4V20M10 20V4.25h4V20M15.75 20v-11h4v11" />\n  <path d="M3.5 20h17" />\n</svg>'
+  },
+  {
+    name: 'Check',
+    slug: 'check',
+    description: 'A simple check mark for confirmation and selection.',
+    keywords: ['done', 'confirm', 'selected'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m5.25 12.5 4.25 4.25 9.25-9.5" />\n</svg>'
+  },
+  {
+    name: 'ChevronDown',
+    slug: 'chevron-down',
+    description: 'A downward chevron for disclosure and selection.',
+    keywords: ['expand', 'select', 'open'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m6.25 8.75 5.75 6.5 5.75-6.5" />\n</svg>'
+  },
+  {
+    name: 'ChevronLeft',
+    slug: 'chevron-left',
+    description: 'A left-facing chevron for previous navigation.',
+    keywords: ['previous', 'back', 'collapse'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m15.25 6.25-6.5 5.75 6.5 5.75" />\n</svg>'
+  },
+  {
+    name: 'Clock',
+    slug: 'clock',
+    description: 'A clock face for time, duration, and schedules.',
+    keywords: ['time', 'duration', 'schedule'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <path d="M12 7.5v4.9l3.25 2" />\n</svg>'
+  },
+  {
+    name: 'DocumentText',
+    slug: 'document-text',
+    description: 'A folded document with text lines.',
+    keywords: ['document', 'file', 'content'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M6 3.75h7l5 5v11.5H6z" />\n  <path d="M13 3.75v5h5M9 13h6M9 16.5h6" />\n</svg>'
+  },
+  {
+    name: 'Download',
+    slug: 'download',
+    description: 'A downward transfer arrow landing in a tray.',
+    keywords: ['download', 'save', 'receive'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 4.25v10.5m-4-4 4 4 4-4" />\n  <path d="M4.5 16.75v3h15v-3" />\n</svg>'
+  },
+  {
+    name: 'Edit',
+    slug: 'edit',
+    description: 'A precise pencil for editing content.',
+    keywords: ['edit', 'pencil', 'write'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m5 15.75-.75 4 4-.75L18.5 8.75l-3.25-3.25z" />\n  <path d="m13.75 7 3.25 3.25M5 15.75 8.25 19" />\n</svg>'
+  },
+  {
+    name: 'EllipsisHorizontal',
+    slug: 'ellipsis-horizontal',
+    description: 'Three horizontal dots for more actions.',
+    keywords: ['more', 'options', 'menu'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M6.25 12h.01M12 12h.01M17.75 12h.01" stroke-width="2.25" />\n</svg>'
+  },
+  {
+    name: 'EllipsisVertical',
+    slug: 'ellipsis-vertical',
+    description: 'Three vertical dots for more actions.',
+    keywords: ['more', 'options', 'menu'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 6.25h.01M12 12h.01M12 17.75h.01" stroke-width="2.25" />\n</svg>'
+  },
+  {
+    name: 'Envelope',
+    slug: 'envelope',
+    description: 'A closed envelope for email and messages.',
+    keywords: ['email', 'mail', 'message'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="5.5" width="16.5" height="13" rx="2.25" />\n  <path d="m4.5 7 7.5 6 7.5-6" />\n</svg>'
+  },
+  {
+    name: 'ExternalLink',
+    slug: 'external-link',
+    description: 'An arrow leaving a frame for external destinations.',
+    keywords: ['external', 'open', 'new window'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M10.25 5.25H6.5c-1.24 0-2.25 1.01-2.25 2.25v10c0 1.24 1.01 2.25 2.25 2.25h10c1.24 0 2.25-1.01 2.25-2.25v-3.75" />\n  <path d="M13 4.25h6.75V11M19.5 4.5l-8.75 8.75" />\n</svg>'
+  },
+  {
+    name: 'Eye',
+    slug: 'eye',
+    description: 'An open eye for visibility and preview.',
+    keywords: ['view', 'visible', 'preview'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M3.5 12s3-5.5 8.5-5.5 8.5 5.5 8.5 5.5-3 5.5-8.5 5.5S3.5 12 3.5 12" />\n  <circle cx="12" cy="12" r="2.5" />\n</svg>'
+  },
+  {
+    name: 'EyeOff',
+    slug: 'eye-off',
+    description: 'A crossed eye for hidden or private content.',
+    keywords: ['hidden', 'private', 'visibility off'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M8.25 7.15A9.8 9.8 0 0 1 12 6.5c5.5 0 8.5 5.5 8.5 5.5a13 13 0 0 1-2.35 3.1M14.5 17.15a9.8 9.8 0 0 1-2.5.35C6.5 17.5 3.5 12 3.5 12a13 13 0 0 1 2.1-2.85" />\n  <path d="M9.85 9.85a3 3 0 0 0 4.3 4.3M4.5 4.5l15 15" />\n</svg>'
+  },
+  {
+    name: 'Globe',
+    slug: 'globe',
+    description: 'A globe for public, international, and web contexts.',
+    keywords: ['world', 'public', 'web'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <path d="M3.75 12h16.5M12 3.75c2.25 2.25 3.25 5 3.25 8.25S14.25 18 12 20.25C9.75 18 8.75 15.25 8.75 12S9.75 6 12 3.75" />\n</svg>'
+  },
+  {
+    name: 'History',
+    slug: 'history',
+    description: 'A returning clock for history and recent activity.',
+    keywords: ['history', 'recent', 'restore'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.5 8V4.5H8" />\n  <path d="M5 6.25A8.25 8.25 0 1 1 4.15 15" />\n  <path d="M12 7.75v4.5l3 1.75" />\n</svg>'
+  },
+  {
+    name: 'Image',
+    slug: 'image',
+    description: 'A framed landscape for images and media.',
+    keywords: ['photo', 'picture', 'media'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="4.25" width="16.5" height="15.5" rx="2.25" />\n  <circle cx="8.25" cy="8.75" r="1.5" />\n  <path d="m4.5 17 4.5-4.25 3 2.5 3-3 4.5 4.75" />\n</svg>'
+  },
+  {
+    name: 'InfoCircle',
+    slug: 'info-circle',
+    description: 'An information mark inside a circle.',
+    keywords: ['info', 'help', 'details'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <path d="M12 10.75v5M12 7.75h.01" stroke-width="2" />\n</svg>'
+  },
+  {
+    name: 'Key',
+    slug: 'key',
+    description: 'A key for credentials and access.',
+    keywords: ['access', 'credential', 'secret'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="8.25" cy="11.75" r="3.75" />\n  <path d="m11.5 10 8-4.5M15.5 7.75l2 2M17.75 6.5l1.5 1.5" />\n</svg>'
+  },
+  {
+    name: 'Link',
+    slug: 'link',
+    description: 'Two joined links for URLs and relationships.',
+    keywords: ['url', 'chain', 'attach'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m9.75 14.25-1.5 1.5a3.54 3.54 0 0 1-5-5l3-3a3.54 3.54 0 0 1 5 0" />\n  <path d="m14.25 9.75 1.5-1.5a3.54 3.54 0 0 1 5 5l-3 3a3.54 3.54 0 0 1-5 0" />\n  <path d="m8.75 15.25 6.5-6.5" />\n</svg>'
+  },
+  {
+    name: 'Lock',
+    slug: 'lock',
+    description: 'A closed padlock for security and private state.',
+    keywords: ['secure', 'private', 'locked'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="5.25" y="10" width="13.5" height="10.25" rx="2.25" />\n  <path d="M8.25 10V7.75a3.75 3.75 0 0 1 7.5 0V10M12 14.25v2" />\n</svg>'
+  },
+  {
+    name: 'Menu',
+    slug: 'menu',
+    description: 'Three balanced lines for application navigation.',
+    keywords: ['navigation', 'hamburger', 'drawer'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.5 7h15M4.5 12h15M4.5 17h15" />\n</svg>'
+  },
+  {
+    name: 'Plus',
+    slug: 'plus',
+    description: 'A plus mark for adding and creating.',
+    keywords: ['add', 'create', 'new'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 5v14M5 12h14" />\n</svg>'
+  },
+  {
+    name: 'Refresh',
+    slug: 'refresh',
+    description: 'Two returning arcs for refresh and retry.',
+    keywords: ['reload', 'retry', 'sync'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M19.5 8.5V4.75h-3.75M4.5 15.5v3.75h3.75" />\n  <path d="M18.65 7A8 8 0 0 0 5.5 7.25M5.35 17A8 8 0 0 0 18.5 16.75" />\n</svg>'
+  },
+  {
+    name: 'Settings',
+    slug: 'settings',
+    description: 'A compact gear for settings and configuration.',
+    keywords: ['settings', 'configuration', 'preferences'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="3" />\n  <path d="M12 3.75v2M12 18.25v2M3.75 12h2M18.25 12h2M6.17 6.17l1.42 1.42M16.41 16.41l1.42 1.42M17.83 6.17l-1.42 1.42M7.59 16.41l-1.42 1.42" />\n  <circle cx="12" cy="12" r="6.25" />\n</svg>'
+  },
+  {
+    name: 'Share',
+    slug: 'share',
+    description: 'Three connected nodes for sharing content.',
+    keywords: ['share', 'send', 'distribute'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="6" cy="12" r="2.25" />\n  <circle cx="17.75" cy="6" r="2.25" />\n  <circle cx="17.75" cy="18" r="2.25" />\n  <path d="m8 10.9 7.75-3.8M8 13.1l7.75 3.8" />\n</svg>'
+  },
+  {
+    name: 'ShieldCheck',
+    slug: 'shield-check',
+    description: 'A checked shield for verified protection.',
+    keywords: ['secure', 'verified', 'protected'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 3.5c2.25 1.55 4.8 2.25 7.25 2.25v5.75c0 4.3-2.4 7.25-7.25 9-4.85-1.75-7.25-4.7-7.25-9V5.75c2.45 0 5-.7 7.25-2.25" />\n  <path d="m8.5 12 2.25 2.25 4.75-5" />\n</svg>'
+  },
+  {
+    name: 'SignOut',
+    slug: 'sign-out',
+    description: 'An exit arrow leaving a doorway.',
+    keywords: ['logout', 'exit', 'sign out'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M10.25 5H6.5c-1.24 0-2.25 1.01-2.25 2.25v9.5C4.25 17.99 5.26 19 6.5 19h3.75" />\n  <path d="M9 12h10.5m-4-4 4 4-4 4" />\n</svg>'
+  },
+  {
+    name: 'Users',
+    slug: 'users',
+    description: 'Two people for teams and shared ownership.',
+    keywords: ['team', 'people', 'group'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="9.25" cy="8.5" r="3.25" />\n  <path d="M3.75 19.5c.35-3.65 2.18-5.5 5.5-5.5s5.15 1.85 5.5 5.5M14 6.25a3 3 0 0 1 0 5.75M15.5 14c2.85.3 4.35 2.15 4.75 5.5" />\n</svg>'
+  },
+  {
+    name: 'WarningTriangle',
+    slug: 'warning-triangle',
+    description: 'A warning mark inside a balanced triangle.',
+    keywords: ['warning', 'caution', 'alert'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M10.25 4.75a2 2 0 0 1 3.5 0l7 12.5a2 2 0 0 1-1.75 3H5a2 2 0 0 1-1.75-3z" />\n  <path d="M12 9v4.75M12 17h.01" stroke-width="2" />\n</svg>'
+  },
+  {
+    name: 'ArrowLeft',
+    slug: 'arrow-left',
+    description: 'A left-pointing arrow for return and backward movement.',
+    keywords: ['back', 'previous', 'return'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M19.5 12h-14" />\n  <path d="m10.75 6.75-5.25 5.25 5.25 5.25" />\n</svg>'
+  },
+  {
+    name: 'Ban',
+    slug: 'ban',
+    description: 'A barred circle for prohibited and unavailable actions.',
+    keywords: ['blocked', 'prohibited', 'forbidden'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <path d="m6.25 6.25 11.5 11.5" />\n</svg>'
+  },
+  {
+    name: 'Calculator',
+    slug: 'calculator',
+    description: 'A calculator for totals, pricing, and arithmetic.',
+    keywords: ['calculate', 'math', 'total'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="5" y="3.75" width="14" height="16.5" rx="2.25" />\n  <path d="M8.25 7h7.5v3h-7.5zM8.5 13.5h.01M12 13.5h.01M15.5 13.5h.01M8.5 17h.01M12 17h.01M15.5 17h.01" />\n</svg>'
+  },
+  {
+    name: 'CalendarX',
+    slug: 'calendar-x',
+    description: 'A calendar page marked unavailable.',
+    keywords: ['cancel date', 'unavailable', 'remove schedule'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="5.5" width="16.5" height="14.25" rx="2.25" />\n  <path d="M8 3.75v3.5M16 3.75v3.5M3.75 9.5h16.5M9.25 13l5.5 5M14.75 13l-5.5 5" />\n</svg>'
+  },
+  {
+    name: 'Camera',
+    slug: 'camera',
+    description: 'A camera for capturing and attaching photographs.',
+    keywords: ['photo', 'capture', 'picture'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4 8.25c0-1.1.9-2 2-2h2l1.25-2h5.5l1.25 2h2c1.1 0 2 .9 2 2v8.5c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2z" />\n  <circle cx="12" cy="12.5" r="3.25" />\n</svg>'
+  },
+  {
+    name: 'Cash',
+    slug: 'cash',
+    description: 'A banknote for cash and monetary amounts.',
+    keywords: ['money', 'payment', 'banknote'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.5" y="6" width="17" height="12" rx="2" />\n  <circle cx="12" cy="12" r="3" />\n  <path d="M6.5 9.25h.01M17.5 14.75h.01" stroke-width="2" />\n</svg>'
+  },
+  {
+    name: 'Chat',
+    slug: 'chat',
+    description: 'A rounded conversation bubble for chat.',
+    keywords: ['chat', 'message', 'conversation'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4 11.25c0-4.15 3.25-7 8-7s8 2.85 8 7-3.25 7-8 7c-1.15 0-2.25-.18-3.2-.5L4.5 20l1.15-4A6.45 6.45 0 0 1 4 11.25" />\n  <path d="M8.5 11.25h.01M12 11.25h.01M15.5 11.25h.01" stroke-width="2" />\n</svg>'
+  },
+  {
+    name: 'Comment',
+    slug: 'comment',
+    description: 'A compact comment card with text lines.',
+    keywords: ['comment', 'note', 'feedback'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.25 5.25h15.5v11.5H10l-4.75 3v-3H4.25z" />\n  <path d="M8 9.25h8M8 12.75h5.5" />\n</svg>'
+  },
+  {
+    name: 'CreditCard',
+    slug: 'credit-card',
+    description: 'A payment card for billing and checkout.',
+    keywords: ['card', 'payment', 'billing'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.5" y="5.25" width="17" height="13.5" rx="2.25" />\n  <path d="M3.5 9.25h17M7 14.75h4.5" />\n</svg>'
+  },
+  {
+    name: 'CurrencyDollar',
+    slug: 'currency-dollar',
+    description: 'A dollar mark in a circle for currency values.',
+    keywords: ['dollar', 'currency', 'price'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <path d="M15 8.5c-.65-.75-1.65-1.1-3-1.1-1.75 0-3 .9-3 2.25 0 3.6 6 1.25 6 4.7 0 1.35-1.25 2.25-3 2.25-1.35 0-2.35-.35-3-1.1M12 5.75v12.5" />\n</svg>'
+  },
+  {
+    name: 'Document',
+    slug: 'document',
+    description: 'A simple folded document for files and records.',
+    keywords: ['file', 'page', 'record'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M6 3.75h7l5 5v11.5H6z" />\n  <path d="M13 3.75v5h5" />\n</svg>'
+  },
+  {
+    name: 'EnvelopeOpen',
+    slug: 'envelope-open',
+    description: 'An open envelope for received and read messages.',
+    keywords: ['email', 'open mail', 'read'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m4.25 10.5 7.75-6 7.75 6v9.25H4.25z" />\n  <path d="M7 10.25V6.75h10v3.5M4.5 10.75l7.5 5.5 7.5-5.5M4.75 19.25 10 14.8M19.25 19.25 14 14.8" />\n</svg>'
+  },
+  {
+    name: 'Expand',
+    slug: 'expand',
+    description: 'Four outward corners for expanding a view.',
+    keywords: ['fullscreen', 'expand', 'maximize'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M9.25 4.5H4.5v4.75M14.75 4.5h4.75v4.75M9.25 19.5H4.5v-4.75M14.75 19.5h4.75v-4.75" />\n  <path d="m4.75 9 4.5-4.5M19.25 9l-4.5-4.5M4.75 15l4.5 4.5M19.25 15l-4.5 4.5" />\n</svg>'
+  },
+  {
+    name: 'FilePdf',
+    slug: 'file-pdf',
+    description: 'A folded document with an archival PDF mark.',
+    keywords: ['pdf', 'document', 'export'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M6 3.75h7l5 5v11.5H6zM13 3.75v5h5" />\n  <path d="M8.5 16.5v-4h1.25c1.1 0 1.75.6 1.75 1.5s-.65 1.5-1.75 1.5H8.5M13.25 16.5v-4h1c1.25 0 2 .75 2 2s-.75 2-2 2z" />\n</svg>'
+  },
+  {
+    name: 'Fingerprint',
+    slug: 'fingerprint',
+    description: 'Layered fingerprint ridges for identity verification.',
+    keywords: ['identity', 'biometric', 'security'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M5 11.5a7 7 0 0 1 14 0c0 2.75-.4 5.2-1.25 7.25M7.5 11.5a4.5 4.5 0 0 1 9 0c0 3.9-.85 6.65-2.5 8.25M10 11.5a2 2 0 0 1 4 0c0 3.25-.65 5.5-2 7.25M5.25 15.25c.2 1.65.7 3.15 1.5 4.5M8 16.5c.3 1.4.75 2.55 1.4 3.5" />\n</svg>'
+  },
+  {
+    name: 'MapPin',
+    slug: 'map-pin',
+    description: 'A location pin for places and addresses.',
+    keywords: ['location', 'place', 'address'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 21c4-4.4 6-7.75 6-10.5a6 6 0 0 0-12 0C6 13.25 8 16.6 12 21" />\n  <circle cx="12" cy="10.5" r="2.25" />\n</svg>'
+  },
+  {
+    name: 'Newspaper',
+    slug: 'newspaper',
+    description: 'A newspaper layout for editorial content and updates.',
+    keywords: ['news', 'article', 'publication'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M5 5h14v14.5H5c-1.1 0-2-.9-2-2V8h2" />\n  <path d="M8 8h8v3H8zM8 14h3M8 17h3M13.5 14H16M13.5 17H16" />\n</svg>'
+  },
+  {
+    name: 'Recurring',
+    slug: 'recurring',
+    description: 'Two circular arrows for recurring activity.',
+    keywords: ['repeat', 'recurring', 'cycle'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M17.75 7.5H9a4.5 4.5 0 0 0-4.5 4.5v.5M15.25 5l2.5 2.5-2.5 2.5" />\n  <path d="M6.25 16.5H15a4.5 4.5 0 0 0 4.5-4.5v-.5M8.75 14l-2.5 2.5 2.5 2.5" />\n</svg>'
+  },
+  {
+    name: 'Send',
+    slug: 'send',
+    description: 'A folded paper plane for sending content.',
+    keywords: ['send', 'submit', 'paper airplane'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m3.75 5 16.5-1.25-7 16.5-2.25-7z" />\n  <path d="m11 13.25 9.25-9.5M11 13.25l-.5 5" />\n</svg>'
+  },
+  {
+    name: 'StopCircle',
+    slug: 'stop-circle',
+    description: 'A stop square inside a circle for terminating activity.',
+    keywords: ['stop', 'cancel', 'terminate'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <rect x="9" y="9" width="6" height="6" rx="1" />\n</svg>'
+  },
+  {
+    name: 'Swap',
+    slug: 'swap',
+    description: 'Opposing horizontal arrows for exchanging values.',
+    keywords: ['swap', 'exchange', 'switch'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.5 8.25h13m-3.5-3.5 3.5 3.5-3.5 3.5M19.5 15.75h-13m3.5 3.5-3.5-3.5 3.5-3.5" />\n</svg>'
+  },
+  {
+    name: 'Ticket',
+    slug: 'ticket',
+    description: 'A perforated ticket for credits and admissions.',
+    keywords: ['ticket', 'credit', 'coupon'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4 6.25h16v3a2.75 2.75 0 0 0 0 5.5v3H4v-3a2.75 2.75 0 0 0 0-5.5z" />\n  <path d="M9 7.75v1M9 11.5v1M9 15.25v1" />\n</svg>'
+  },
+  {
+    name: 'UserPlus',
+    slug: 'user-plus',
+    description: 'A person with a plus mark for invitations.',
+    keywords: ['invite', 'add user', 'new person'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="9" cy="8.25" r="3.25" />\n  <path d="M3.75 19.75c.35-3.9 2.1-5.75 5.25-5.75 2.2 0 3.7.9 4.55 2.75M17.5 9v6M14.5 12h6" />\n</svg>'
+  },
+  {
+    name: 'Wallet',
+    slug: 'wallet',
+    description: 'A wallet for balances and stored payment methods.',
+    keywords: ['wallet', 'balance', 'money'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="5.25" width="16.5" height="13.5" rx="2.25" />\n  <path d="M3.75 8.5h14.5M14.75 10h5.5v4.75h-5.5a2.38 2.38 0 0 1 0-4.75Z" />\n  <path d="M16.5 12.38h.01" stroke-width="2" />\n</svg>'
+  },
+  {
+    name: 'XCircle',
+    slug: 'x-circle',
+    description: 'A crossing mark inside a circle for failure and removal.',
+    keywords: ['error', 'failed', 'remove'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="8.25" />\n  <path d="m9 9 6 6M15 9l-6 6" />\n</svg>'
+  },
+  {
+    name: 'ArrowDown',
+    slug: 'arrow-down',
+    description: 'A downward arrow for movement and descending actions.',
+    keywords: ['down', 'move down', 'descending'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 4.5v14" />\n  <path d="m6.75 13.25 5.25 5.25 5.25-5.25" />\n</svg>'
+  },
+  {
+    name: 'ArrowUp',
+    slug: 'arrow-up',
+    description: 'An upward arrow for movement and ascending actions.',
+    keywords: ['up', 'move up', 'ascending'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 19.5v-14" />\n  <path d="m6.75 10.75 5.25-5.25 5.25 5.25" />\n</svg>'
+  },
+  {
+    name: 'Bolt',
+    slug: 'bolt',
+    description: 'A sharp energy bolt for fast and powered actions.',
+    keywords: ['energy', 'fast', 'power'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m13.5 3.5-8 10.25h6.25l-1.25 6.75 8-10.25h-6.25z" />\n</svg>'
+  },
+  {
+    name: 'BookOpen',
+    slug: 'book-open',
+    description: 'An open book for documentation and guides.',
+    keywords: ['docs', 'guide', 'book'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M3.75 5.25h5.5A2.75 2.75 0 0 1 12 8v11a3.75 3.75 0 0 0-3.25-1.75h-5z" />\n  <path d="M20.25 5.25h-5.5A2.75 2.75 0 0 0 12 8v11a3.75 3.75 0 0 1 3.25-1.75h5z" />\n</svg>'
+  },
+  {
+    name: 'Bookmark',
+    slug: 'bookmark',
+    description: 'A bookmark ribbon for saved items.',
+    keywords: ['save', 'favorite', 'bookmark'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M7 4.25h10v16l-5-3.5-5 3.5z" />\n</svg>'
+  },
+  {
+    name: 'Building',
+    slug: 'building',
+    description: 'A compact office building for organizations.',
+    keywords: ['organization', 'company', 'office'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M5 20.25V4.5h11v15.75M16 9h3v11.25M3.75 20.25h16.5" />\n  <path d="M8.5 8h.01M12.5 8h.01M8.5 11.5h.01M12.5 11.5h.01M8.5 15h.01M12.5 15h.01M9.5 20.25v-2h2v2" stroke-width="2" />\n</svg>'
+  },
+  {
+    name: 'ChevronUp',
+    slug: 'chevron-up',
+    description: 'An upward chevron for collapse and ascending selection.',
+    keywords: ['collapse', 'up', 'close'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m6.25 15.25 5.75-6.5 5.75 6.5" />\n</svg>'
+  },
+  {
+    name: 'CloudUpload',
+    slug: 'cloud-upload',
+    description: 'A cloud receiving an upload arrow.',
+    keywords: ['cloud', 'upload', 'deploy'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M7.25 18.5H6.5a3.75 3.75 0 0 1-.25-7.5A6.25 6.25 0 0 1 18 9.5a4.5 4.5 0 0 1-.5 9h-.75" />\n  <path d="M12 20.25V12m-3 3 3-3 3 3" />\n</svg>'
+  },
+  {
+    name: 'Code',
+    slug: 'code',
+    description: 'Angle brackets for code and source.',
+    keywords: ['code', 'source', 'developer'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m8.5 7-4.75 5 4.75 5M15.5 7l4.75 5-4.75 5M13.5 4.75l-3 14.5" />\n</svg>'
+  },
+  {
+    name: 'Cube',
+    slug: 'cube',
+    description: 'An isometric cube for packages and services.',
+    keywords: ['package', 'service', 'container'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="m12 3.75 7.25 4.1v8.3L12 20.25l-7.25-4.1v-8.3z" />\n  <path d="m4.75 7.85 7.25 4.1 7.25-4.1M12 11.95v8.3" />\n</svg>'
+  },
+  {
+    name: 'Database',
+    slug: 'database',
+    description: 'A stacked database cylinder for persistent data.',
+    keywords: ['database', 'storage', 'data'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <ellipse cx="12" cy="6.25" rx="7.5" ry="2.75" />\n  <path d="M4.5 6.25v5.75c0 1.5 3.35 2.75 7.5 2.75s7.5-1.25 7.5-2.75V6.25M4.5 12v5.75c0 1.5 3.35 2.75 7.5 2.75s7.5-1.25 7.5-2.75V12" />\n</svg>'
+  },
+  {
+    name: 'DocumentAdd',
+    slug: 'document-add',
+    description: 'A folded document with a plus mark.',
+    keywords: ['new file', 'add document', 'create'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M6 3.75h7l5 5v11.5H6zM13 3.75v5h5" />\n  <path d="M12 12v5M9.5 14.5h5" />\n</svg>'
+  },
+  {
+    name: 'Filter',
+    slug: 'filter',
+    description: 'A narrowing funnel for filtering data.',
+    keywords: ['filter', 'funnel', 'refine'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M3.75 5h16.5l-6.5 7.25v6.25l-3.5 1.75v-8z" />\n</svg>'
+  },
+  {
+    name: 'Heart',
+    slug: 'heart',
+    description: 'A heart for favorites and care.',
+    keywords: ['favorite', 'love', 'support'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 20c-5.25-3.2-8-6.15-8-10a4.5 4.5 0 0 1 8-2.8A4.5 4.5 0 0 1 20 10c0 3.85-2.75 6.8-8 10" />\n</svg>'
+  },
+  {
+    name: 'LayoutDashboard',
+    slug: 'layout-dashboard',
+    description: 'An asymmetric panel grid for dashboards.',
+    keywords: ['dashboard', 'layout', 'overview'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="3.75" width="6.5" height="9.5" rx="1.5" />\n  <rect x="13.75" y="3.75" width="6.5" height="5.5" rx="1.5" />\n  <rect x="3.75" y="16.75" width="6.5" height="3.5" rx="1.5" />\n  <rect x="13.75" y="12.75" width="6.5" height="7.5" rx="1.5" />\n</svg>'
+  },
+  {
+    name: 'ListTree',
+    slug: 'list-tree',
+    description: 'A branching list for hierarchy and nested resources.',
+    keywords: ['tree', 'hierarchy', 'nested'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="6" cy="5.75" r="1.5" />\n  <circle cx="11" cy="12" r="1.25" />\n  <circle cx="11" cy="18.25" r="1.25" />\n  <path d="M6 7.25v11h3.75M6 12h3.75M13.25 12h6M13.25 18.25h6" />\n</svg>'
+  },
+  {
+    name: 'Pause',
+    slug: 'pause',
+    description: 'Two vertical bars for pausing activity.',
+    keywords: ['pause', 'hold', 'suspend'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="7" y="5" width="3.25" height="14" rx="1" />\n  <rect x="13.75" y="5" width="3.25" height="14" rx="1" />\n</svg>'
+  },
+  {
+    name: 'Pin',
+    slug: 'pin',
+    description: 'A pushpin for keeping important resources in reach.',
+    keywords: ['pin', 'pinned', 'location'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M8 4.25h8l-1 5 2.75 2.75v1.5H6.25V12L9 9.25z" />\n  <path d="M12 13.5v7.25" />\n</svg>'
+  },
+  {
+    name: 'Play',
+    slug: 'play',
+    description: 'A right-pointing play triangle for starting activity.',
+    keywords: ['play', 'start', 'run'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M8 5.25v13.5L18.5 12z" />\n</svg>'
+  },
+  {
+    name: 'SidebarClose',
+    slug: 'sidebar-close',
+    description: 'A sidebar frame with an inward closing cue.',
+    keywords: ['sidebar', 'close panel', 'collapse'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="4.25" width="16.5" height="15.5" rx="2" />\n  <path d="M9 4.25v15.5M16.5 9l-3 3 3 3" />\n</svg>'
+  },
+  {
+    name: 'SidebarOpen',
+    slug: 'sidebar-open',
+    description: 'A sidebar frame with an outward opening cue.',
+    keywords: ['sidebar', 'open panel', 'expand'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="4.25" width="16.5" height="15.5" rx="2" />\n  <path d="M9 4.25v15.5M13.5 9l3 3-3 3" />\n</svg>'
+  },
+  {
+    name: 'Sort',
+    slug: 'sort',
+    description: 'Opposing vertical arrows for sorting order.',
+    keywords: ['sort', 'order', 'reorder'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M8 19V5m-3 3 3-3 3 3M16 5v14m-3-3 3 3 3-3" />\n</svg>'
+  },
+  {
+    name: 'StatusOnline',
+    slug: 'status-online',
+    description: 'Concentric signal rings for online status.',
+    keywords: ['online', 'status', 'connected'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <circle cx="12" cy="12" r="1.75" />\n  <path d="M8.5 8.5a5 5 0 0 0 0 7M15.5 8.5a5 5 0 0 1 0 7M5.5 5.5a9.2 9.2 0 0 0 0 13M18.5 5.5a9.2 9.2 0 0 1 0 13" />\n</svg>'
+  },
+  {
+    name: 'Stop',
+    slug: 'stop',
+    description: 'A compact stop square for terminating activity.',
+    keywords: ['stop', 'terminate', 'cancel'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="6" y="6" width="12" height="12" rx="2" />\n</svg>'
+  },
+  {
+    name: 'TableCells',
+    slug: 'table-cells',
+    description: 'A structured grid of table cells.',
+    keywords: ['table', 'grid', 'data'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="4.25" width="16.5" height="15.5" rx="2" />\n  <path d="M3.75 9.5h16.5M3.75 14.75h16.5M9.25 4.25v15.5M14.75 4.25v15.5" />\n</svg>'
+  },
+  {
+    name: 'Tag',
+    slug: 'tag',
+    description: 'A price tag for labels and metadata.',
+    keywords: ['tag', 'label', 'metadata'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.25 4.25h7l8.5 8.5-7 7-8.5-8.5z" />\n  <circle cx="8.25" cy="8.25" r="1.25" />\n</svg>'
+  },
+  {
+    name: 'Terminal',
+    slug: 'terminal',
+    description: 'A command prompt inside a terminal frame.',
+    keywords: ['terminal', 'shell', 'command line'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <rect x="3.75" y="4.5" width="16.5" height="15" rx="2.25" />\n  <path d="m7.25 9 3 3-3 3M12.75 15H17" />\n</svg>'
+  },
+  {
+    name: 'Upload',
+    slug: 'upload',
+    description: 'An upward transfer arrow leaving a tray.',
+    keywords: ['upload', 'send file', 'transfer'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M12 15.25V4.75m-4 4 4-4 4 4" />\n  <path d="M4.5 16.75v3h15v-3" />\n</svg>'
+  },
+  {
+    name: 'WrapText',
+    slug: 'wrap-text',
+    description: 'Text lines with a returning wrap arrow.',
+    keywords: ['wrap', 'text', 'line break'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M4.25 6.5h15.5M4.25 11.5h11a3.25 3.25 0 0 1 0 6.5H11" />\n  <path d="m13.75 15.25-2.75 2.75 2.75 2.75M4.25 18h3" />\n</svg>'
+  },
+  {
+    name: 'Wrench',
+    slug: 'wrench',
+    description: 'An angled wrench for tools and maintenance.',
+    keywords: ['tool', 'maintenance', 'repair'],
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\n  <path d="M14.25 5.25a4.5 4.5 0 0 0-5.5 5.5l-4.5 4.5a2.65 2.65 0 0 0 3.75 3.75l4.5-4.5a4.5 4.5 0 0 0 5.5-5.5l-2.75 2.75-3-3z" />\n  <path d="M6.25 17h.01" stroke-width="2" />\n</svg>'
   }
 ]
 

--- a/docs/klean-ui/components/icons.md
+++ b/docs/klean-ui/components/icons.md
@@ -67,7 +67,7 @@ const usageFrameworks = [
 
 # Icons
 
-Klean Icons is a small, original SVG family drawn from the actions and objects that repeat across Slipway and Hagfish. Every mark uses the same 24px canvas, calm 1.5px stroke, rounded joins, and optical rhythm.
+Klean Icons is a focused family of 98 original SVGs drawn from the actions and objects that repeat across Slipway and Hagfish. Every mark uses the same 24px canvas, calm 1.5px stroke, rounded joins, and optical rhythm.
 
 There is no icon font, runtime package, provider, icon registry in the browser, size prop, color prop, or variant API. Install only the source you use. Then style ordinary SVG with Tailwind or native attributes.
 


### PR DESCRIPTION
## Summary

- expand the public gallery from the 12-icon proof set to all 98 reviewed Klean Icons
- synchronize names, intent keywords, descriptions, and SVG geometry with klean-ui#152
- publish the redesigned Rocket and keep SVG, Vue, React, Svelte, and CLI copy actions exact
- state the shipped catalog size on the component page

## Verification

- canonical catalog parity: 98/98
- focused Prettier check: pass
- VitePress production build: pass
- full-repository Prettier still reports six unrelated pre-existing files

Closes #259