### PR TITLE
docs(slipway): align custom domains with the environment CLI

### DIFF
--- a/docs/slipway/custom-domain.md
+++ b/docs/slipway/custom-domain.md
@@ -17,344 +17,87 @@ editLink: true
 
 # Custom Domain & SSL
 
-Give your applications professional, branded URLs with automatic HTTPS.
+Slipway supports one custom hostname per **environment**. Routed apps in that
+environment share the hostname and use their configured paths. Saving a new
+hostname replaces the previous custom hostname. A generated hostname, when
+configured, remains available as a fallback.
 
-## How It Works
+## Set an environment domain
 
-Slipway uses **Caddy** as its reverse proxy, which provides:
-
-- **Automatic HTTPS** via Let's Encrypt
-- **Automatic certificate renewal**
-- **HTTP/2 and HTTP/3 support**
-- **WebSocket proxying** (critical for Sails real-time features)
-
-These certificate steps describe the default public VPS mode. In optional
-Cloudflare Tunnel mode, Cloudflare terminates browser TLS and Caddy serves
-plain HTTP on the loopback origin. See
-[Ingress and Firewall](/slipway/ingress-and-firewall).
-
-When you add a domain, Caddy automatically:
-
-1. Obtains an SSL certificate from Let's Encrypt
-2. Configures HTTPS redirection
-3. Sets up the reverse proxy to your app
-
-## Adding a Domain
-
-### Via CLI
+Run these commands from the project directory linked to Slipway:
 
 ```bash
-slipway domain:add myapp example.com
+slipway link my-project
+slipway environment:update production --domain app.example.com
 ```
 
-### Via Dashboard
+In the dashboard, open the app's domain menu and choose **Custom domain**.
+The hostname applies to its environment, not just that app.
 
-1. Go to your project and select an environment
-2. Click the app name from the Apps list to go to the app detail page
-3. Click the ellipsis dropdown menu and select **Custom domain**
-4. Enter your domain name
-5. Click **Add**
+Use a hostname only, without a scheme, port, or path. Deploy a routed app before
+assigning its custom domain. Multiple custom hostnames, wildcard custom domains,
+primary-domain selection, domain redirects, and certificate inspection commands
+are not currently supported.
 
-## DNS Configuration
+## Configure DNS and HTTPS
 
-Before adding a domain in Slipway, configure your DNS:
+Create an A record pointing your hostname to the server's public IPv4 address.
+Use an AAAA record only when the server is reachable over IPv6. For a subdomain,
+a CNAME can instead point to a hostname that resolves to the same server.
 
-### A Record (Recommended)
+Allow inbound TCP ports 80 and 443 for standard public Caddy ingress. Configure
+the certificate email under **Settings → Instance**. Caddy requests and renews
+certificates automatically when DNS and ingress permit it.
 
-Point your domain directly to your Slipway server's IP:
+Saving verifies the proxy route; it does not prove public DNS propagation or
+certificate issuance. Treat DNS and TLS as unverified until you check the public
+hostname. Open its HTTPS URL and inspect the browser's certificate information.
+If the connection fails, check DNS records, ingress/firewall rules, and certificate
+issuance errors on your server before retrying. Do not assume a saved domain
+means its certificate is ready.
 
-| Type | Name | Value        | TTL |
-| ---- | ---- | ------------ | --- |
-| A    | @    | 203.0.113.50 | 300 |
-| A    | www  | 203.0.113.50 | 300 |
+For Cloudflare Tunnel or deliberate raw-port access, follow
+[Ingress and Firewall](/slipway/ingress-and-firewall). Edge TLS and direct HTTP
+access have different readiness requirements from standard Caddy ingress.
 
-### CNAME Record
+## Change or remove a domain
 
-If your DNS provider doesn't support A records at the apex, use a CNAME:
-
-| Type  | Name | Value                  | TTL |
-| ----- | ---- | ---------------------- | --- |
-| CNAME | www  | slipway.yourdomain.com | 300 |
-
-::: warning Root Domain CNAME
-Most DNS providers don't allow CNAME records on the root domain (e.g., `example.com`). Use an A record for the root, or check if your provider supports CNAME flattening (Cloudflare calls this "CNAME at apex").
-:::
-
-## SSL Certificates
-
-### Automatic Provisioning
-
-SSL certificates are provisioned automatically when you add a domain. This typically takes 30-60 seconds.
+Replace the custom hostname with the same command:
 
 ```bash
-$ slipway domain:add myapp example.com
-
-Adding domain example.com to myapp...
-✓ Domain added
-✓ SSL certificate provisioned
-✓ HTTPS enabled
-
-Your app is now available at:
-  https://example.com
+slipway environment:update production --domain new.example.com
 ```
 
-### Certificate Status
-
-Check certificate status:
+Remove it by passing an empty string:
 
 ```bash
-slipway domain:info myapp example.com
+slipway environment:update production --domain ""
 ```
 
-Output:
-
-```
-Domain: example.com
-App: myapp
-SSL: ✓ Valid
-  Issuer: Let's Encrypt
-  Expires: 2024-04-20
-  Auto-renew: Enabled
-```
-
-### Certificate Renewal
-
-Certificates are renewed automatically 30 days before expiration. No action required.
-
-### Troubleshooting SSL
-
-If SSL provisioning fails:
-
-1. **Verify DNS is correct**:
-
-   ```bash
-   dig example.com +short
-   # Should return your server's IP
-   ```
-
-2. **Check port 80 is accessible**:
-   Let's Encrypt validates via HTTP. Ensure port 80 is open.
-
-3. **Wait for DNS propagation**:
-   DNS changes can take up to 48 hours. Use [DNS Checker](https://dnschecker.org) to verify.
-
-4. **Check rate limits**:
-   Let's Encrypt has [rate limits](https://letsencrypt.org/docs/rate-limits/). If you've requested too many certificates, wait and try again.
-
-## Multiple Domains
-
-You can add multiple domains to a single app:
-
-```bash
-slipway domain:add myapp example.com
-slipway domain:add myapp www.example.com
-slipway domain:add myapp app.example.com
-```
-
-All domains will point to the same application.
-
-### Primary Domain
-
-The first domain added becomes the primary domain. To change it:
-
-```bash
-slipway domain:set-primary myapp www.example.com
-```
-
-## Subdomains
-
-### Wildcard Subdomains
-
-For apps that need dynamic subdomains (e.g., `tenant1.example.com`, `tenant2.example.com`):
-
-```bash
-slipway domain:add myapp "*.example.com"
-```
-
-::: warning DNS Wildcard Required
-You'll need a wildcard DNS record:
-
-| Type | Name | Value        |
-| ---- | ---- | ------------ |
-| A    | \*   | 203.0.113.50 |
-
-:::
-
-### Specific Subdomains
-
-```bash
-slipway domain:add myapp api.example.com
-slipway domain:add myapp admin.example.com
-```
-
-## Removing Domains
-
-```bash
-slipway domain:remove myapp example.com
-```
-
-This removes the domain from routing but doesn't affect your DNS records. Update DNS separately.
-
-## Domain Verification
-
-For security, Slipway verifies domain ownership before provisioning SSL:
-
-1. **DNS Verification** (automatic): Slipway checks if the domain points to your server
-2. **HTTP Verification** (automatic): Let's Encrypt verifies via HTTP challenge
-
-## Redirects
-
-### WWW to Non-WWW
-
-Redirect `www.example.com` to `example.com`:
-
-```bash
-slipway domain:redirect www.example.com example.com
-```
-
-### Non-WWW to WWW
-
-Redirect `example.com` to `www.example.com`:
-
-```bash
-slipway domain:redirect example.com www.example.com
-```
-
-### Custom Redirects
-
-For other redirects, use environment variables in your Sails app or configure in `config/routes.js`.
-
-## Using Cloudflare
-
-If you're using Cloudflare as a DNS proxy:
-
-### Recommended Settings
-
-1. **SSL/TLS Mode**: Set to **Full (Strict)**
-   - Cloudflare → HTTPS → Your Server → HTTPS → App
-
-2. **Disable Cloudflare Proxy Initially**:
-   - Set DNS to "DNS only" (gray cloud) first
-   - Once SSL is working, enable proxy (orange cloud)
-
-3. **Page Rules**:
-   - Create a rule to always use HTTPS
-
-### Cloudflare + Slipway SSL
-
-With Cloudflare proxy enabled, you get:
-
-- Cloudflare's edge SSL (browser → Cloudflare)
-- Slipway's origin SSL (Cloudflare → your server)
-
-This is the most secure configuration.
-
-## Slipway Dashboard Domain
-
-To add a custom domain for the Slipway dashboard itself:
-
-### 1. Add DNS Record
-
-Point your domain to your Slipway server:
-
-| Type | Name    | Value        |
-| ---- | ------- | ------------ |
-| A    | slipway | 203.0.113.50 |
-
-### 2. Update Slipway Configuration
-
-SSH into your server and update the Slipway container:
-
-```bash
-docker stop slipway
-
-docker run -d \
-  --name slipway \
-  --network slipway \
-  --restart unless-stopped \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v slipway-data:/app/data \
-  -e NODE_ENV=production \
-  -e PORT=1337 \
-  -e SLIPWAY_URL="https://slipway.yourdomain.com" \
-  -e SLIPWAY_SECRET=$SLIPWAY_SECRET \
-  -l "caddy=slipway.yourdomain.com" \
-  -l "caddy.reverse_proxy={{upstreams 1337}}" \
-  ghcr.io/sailscastshq/slipway:latest
-```
-
-The Caddy labels tell the proxy to route `slipway.yourdomain.com` to the Slipway container.
-
-### 3. Access via HTTPS
-
-Your Slipway dashboard is now available at:
-
-```
-https://slipway.yourdomain.com
-```
-
-## Best Practices
-
-### 1. Always Use HTTPS
-
-Slipway enforces HTTPS by default. HTTP requests are automatically redirected.
-
-### 2. Use Separate Domains for Environments
-
-```
-myapp.com           → production
-staging.myapp.com   → staging
-dev.myapp.com       → development
-```
-
-### 3. Set Up Both WWW and Non-WWW
-
-Add both domains and set up a redirect:
-
-```bash
-slipway domain:add myapp example.com
-slipway domain:add myapp www.example.com
-slipway domain:redirect www.example.com example.com
-```
-
-### 4. Monitor Certificate Expiration
-
-While auto-renewal should work, monitor your certificates:
-
-```bash
-slipway domain:list myapp
-```
+The dashboard supports removal by clearing the hostname field and saving.
+The environment then uses its generated hostname when configured. If no hostname
+is configured, check the app's access link; raw-port access requires its explicit
+ingress configuration and is not automatically public.
+
+If the proxy cannot apply a domain change, the operation fails and attempts to
+restore the previous route and domain. Follow the returned recovery instructions
+before retrying if restoration also fails.
+
+## Dashboard domain
+
+The Slipway dashboard's own hostname is separate from an environment hostname.
+Configure it in **Settings → Instance**, point DNS at the server, and verify its
+HTTPS connection after saving.
 
 ## Troubleshooting
 
-### "Domain Not Resolving"
+- **DNS does not resolve:** check the authoritative records and allow caches to expire.
+- **TLS is not ready:** check DNS, ports 80/443, certificate email, and server issuance errors.
+- **The hostname opens but the app fails:** check the app's deployment status and logs.
 
-1. Check DNS propagation: https://dnschecker.org
-2. Verify A record points to correct IP
-3. Wait up to 48 hours for propagation
+```bash
+slipway deployments --env production
+slipway logs --env production --follow
+```
 
-### "SSL Certificate Error"
-
-1. Ensure port 80 is open (Let's Encrypt needs it)
-2. Check rate limits if you've made many requests
-3. Verify domain ownership
-
-### "502 Bad Gateway"
-
-1. Ensure your app is running: `slipway app:status myapp`
-2. Check app logs: `slipway logs myapp`
-3. Verify the app is listening on the correct port
-
-### "Mixed Content Warnings"
-
-If your browser shows mixed content warnings:
-
-1. Ensure all assets use HTTPS URLs
-2. Update hardcoded HTTP URLs in your code
-3. Use protocol-relative URLs: `//example.com/asset.js`
-
-## What's Next?
-
-- Configure [Environment Variables](/slipway/environment-variables) for your domains
-- Set up [Auto-Deploy](/slipway/auto-deploy) for continuous deployment
-- Learn about [Database Services](/slipway/database-services) for your app
+See [CLI Commands](/slipway/cli-commands) for supported commands.

--- a/docs/slipway/first-deploy.md
+++ b/docs/slipway/first-deploy.md
@@ -140,12 +140,12 @@ Most Sails apps need environment variables. Set them before or after deploying:
 
 ```bash
 # Set individual variables
-slipway env:set myapp DATABASE_URL=postgres://...
-slipway env:set myapp SESSION_SECRET=your-secret-key
-slipway env:set myapp NODE_ENV=production
+slipway env:set DATABASE_URL=postgres://...
+slipway env:set SESSION_SECRET=your-secret-key
+slipway env:set NODE_ENV=production
 
 # Or set multiple at once
-slipway env:set myapp \
+slipway env:set \
   DATABASE_URL=postgres://... \
   SESSION_SECRET=your-secret-key \
   NODE_ENV=production
@@ -162,13 +162,13 @@ slipway slide
 
 ## Add a Custom Domain
 
-Give your app a proper domain:
+Assign one custom hostname to the production environment from your linked project directory:
 
 ```bash
-slipway domain:add myapp myapp.example.com
+slipway environment:update production --domain myapp.example.com
 ```
 
-Then point your DNS to your Slipway server's IP address. SSL will be provisioned automatically via Caddy.
+Point DNS to your Slipway server's public IP and allow ports 80 and 443. Saving verifies the proxy route, not DNS propagation or certificate issuance. Open the HTTPS URL to verify it. See [Custom Domain & SSL](/slipway/custom-domain) for removal, fallback access, and troubleshooting.
 
 ## View Logs
 
@@ -176,19 +176,17 @@ Check your application logs:
 
 ```bash
 # View recent logs
-slipway logs myapp
+slipway logs --env production
 
 # Tail logs in real-time
-slipway logs myapp -t
+slipway logs --env production --follow
 ```
 
 ## Open the Helm (REPL)
 
 Need to debug or query your production data? Open the Helm:
 
-```bash
-slipway helm myapp
-```
+Open the deployed app in the dashboard and choose **Helm** from its tools menu.
 
 ```javascript
 Slipway Helm (myapp production)


### PR DESCRIPTION
The domain guide advertised commands and a multiple-domain model that the CLI does not support. It now documents one custom hostname per environment, the existing `environment:update --domain` command, removal/fallback access, and the separate DNS/TLS checks required after saving.

First Deploy uses the same command and corrects obsolete CLI examples encountered by the new command-registry consistency check.

Validation: documentation production build passed; all command examples in Custom Domain, First Deploy, and CLI Commands pass Slipway's registry consistency check.

Closes #263.
Related implementation: sailscastshq/slipway#374.
