### PR TITLE
docs(schedule-picker): document historical datetimes and compact time controls

### DIFF
--- a/docs/.vitepress/theme/components/klean/popover/Popover.vue
+++ b/docs/.vitepress/theme/components/klean/popover/Popover.vue
@@ -4,7 +4,8 @@ import {
   computePosition,
   flip,
   offset as floatingOffset,
-  shift
+  shift,
+  size
 } from '@floating-ui/dom'
 import {
   computed,
@@ -27,6 +28,8 @@ const props = defineProps({
   open: { type: Boolean, default: undefined },
   /** Initial state when `open` is not controlled. */
   defaultOpen: { type: Boolean, default: false },
+  /** Element or element id used only for floating-surface positioning. */
+  anchor: { type: [String, Object], default: undefined },
   /** Preferred logical placement. Collision handling may flip it. */
   placement: {
     type: String,
@@ -59,7 +62,12 @@ const activeInvoker = ref()
 const internalOpen = ref(props.defaultOpen)
 const nativePopover = ref(false)
 const resolvedPlacement = ref(props.placement)
-const positionStyle = ref({ position: 'fixed', left: '0px', top: '0px' })
+const positionStyle = ref({
+  position: 'fixed',
+  inset: 'auto',
+  left: '0px',
+  top: '0px'
+})
 let cleanupPosition = () => {}
 
 const isControlled = computed(() => props.open !== undefined)
@@ -114,6 +122,21 @@ function resolveInvoker(candidate) {
   }
 
   return activeInvoker.value
+}
+
+function resolveAnchor() {
+  if (typeof props.anchor === 'string') {
+    const root = content.value?.getRootNode?.() ?? document
+    const element =
+      root.getElementById?.(props.anchor) ??
+      document.getElementById(props.anchor)
+
+    if (element?.isConnected) return element
+  } else if (props.anchor?.isConnected) {
+    return props.anchor
+  }
+
+  return resolveInvoker()
 }
 
 function syncInvokerAria() {
@@ -217,12 +240,13 @@ function handleFallbackInvokerClick(event) {
 
 function handleOutsidePointer(event) {
   const path = eventPath(event)
-  const reference = resolveInvoker()
+  const invoker = resolveInvoker()
+  const anchor = resolveAnchor()
 
   if (
     path.includes(content.value) ||
-    (reference &&
-      (path.includes(reference) || reference.contains?.(event.target))) ||
+    (invoker && (path.includes(invoker) || invoker.contains?.(event.target))) ||
+    (anchor && (path.includes(anchor) || anchor.contains?.(event.target))) ||
     invokers().some(
       (invoker) => path.includes(invoker) || invoker.contains(event.target)
     )
@@ -234,10 +258,22 @@ function handleOutsidePointer(event) {
 }
 
 function handleEscape(event) {
-  if (event.key !== 'Escape') return
+  if (event.key !== 'Escape' || event.defaultPrevented) return
 
   if (nativePopover.value) {
-    const openPopovers = [...document.querySelectorAll(':popover-open')]
+    const root = content.value?.getRootNode?.() ?? document
+    const path = eventPath(event)
+    const rootIndex = path.indexOf(root)
+    const innerPath = rootIndex < 0 ? path : path.slice(0, rootIndex)
+    // An open nested surface in a shadow tree owns Escape before its parent.
+    if (
+      innerPath.some(
+        (node) =>
+          node !== root && node?.host && node.querySelector?.(':popover-open')
+      )
+    )
+      return
+    const openPopovers = [...root.querySelectorAll(':popover-open')]
     if (openPopovers.at(-1) !== content.value) return
   }
 
@@ -246,20 +282,39 @@ function handleEscape(event) {
 }
 
 async function updatePosition() {
-  const invoker = resolveInvoker()
-  if (!isOpen.value || !invoker || !content.value) return
+  const anchor = resolveAnchor()
+  const element = content.value
+  if (!isOpen.value || !anchor || !element) return
 
-  const { x, y, placement } = await computePosition(invoker, content.value, {
+  const { x, y, placement } = await computePosition(anchor, element, {
     placement: props.placement,
     strategy: 'fixed',
-    middleware: [floatingOffset(props.offset), flip(), shift({ padding: 8 })]
+    middleware: [
+      floatingOffset(props.offset),
+      flip({ padding: 8 }),
+      size({
+        padding: 8,
+        apply({ availableHeight, elements }) {
+          elements.floating.style.setProperty(
+            '--klean-popover-available-height',
+            `${Math.max(0, availableHeight)}px`
+          )
+        }
+      }),
+      shift({ padding: 8, crossAxis: true })
+    ]
   })
 
+  if (content.value !== element || !isOpen.value) return
   resolvedPlacement.value = placement
   positionStyle.value = {
     position: 'fixed',
+    inset: 'auto',
     left: `${x}px`,
-    top: `${y}px`
+    top: `${y}px`,
+    '--klean-popover-available-height': element.style.getPropertyValue(
+      '--klean-popover-available-height'
+    )
   }
 }
 
@@ -276,17 +331,23 @@ async function syncOpenEffects() {
   syncInvokerAria()
   syncNativePopover()
 
-  const invoker = resolveInvoker()
-  if (!isOpen.value || !invoker || !content.value) return
+  const anchor = resolveAnchor()
+  if (!isOpen.value || !anchor || !content.value) return
 
-  cleanupPosition = autoUpdate(invoker, content.value, updatePosition)
+  cleanupPosition = autoUpdate(anchor, content.value, updatePosition)
 
   document.addEventListener('keydown', handleEscape)
   document.addEventListener('pointerdown', handleOutsidePointer, true)
 }
 
 watch(
-  () => [isOpen.value, props.placement, props.offset, activeInvoker.value],
+  () => [
+    isOpen.value,
+    props.anchor,
+    props.placement,
+    props.offset,
+    activeInvoker.value
+  ],
   syncOpenEffects,
   { flush: 'post' }
 )

--- a/docs/.vitepress/theme/components/klean/schedule-picker/SchedulePicker.vue
+++ b/docs/.vitepress/theme/components/klean/schedule-picker/SchedulePicker.vue
@@ -2,17 +2,18 @@
 import { computed, nextTick, ref, useAttrs, useId, watch } from 'vue'
 import { twMerge } from 'tailwind-merge'
 import Calendar from '../calendar/Calendar.vue'
-import { todayIso } from '../calendar/date.js'
 import Input from '../input/Input.vue'
 import Popover from '../popover/Popover.vue'
 import {
   formatSchedule,
-  formatTimeLabel,
+  initialScheduleWallClock,
   instantToWallClock,
   interpretSchedule,
   resolveTimeZone,
-  roundedFutureWallClock,
-  timeOptions,
+  scheduleCalendarBounds,
+  scheduleConstraint,
+  timeFields,
+  updateTimeField,
   wallClockToIso
 } from './schedule.js'
 
@@ -31,7 +32,11 @@ const props = defineProps({
   dir: { type: String, default: undefined },
   /** Earliest allowed ISO instant. Scheduling remains future-only by default. */
   min: { type: String, default: undefined },
-  /** Minutes between default time choices. Natural input may be more precise. */
+  /** Latest allowed ISO instant, inclusive. */
+  max: { type: String, default: undefined },
+  /** Allow historical records as well as future dates. */
+  allowPast: { type: Boolean, default: false },
+  /** Round the initial suggested time to this interval. Edits may use any minute. */
   minuteStep: { type: Number, default: 15 },
   open: { type: Boolean, default: undefined },
   defaultOpen: { type: Boolean, default: false },
@@ -57,9 +62,13 @@ const internalValue = ref(validDefault)
 const value = computed(() =>
   props.modelValue === undefined ? internalValue.value : props.modelValue
 )
-const initialWallClock =
-  instantToWallClock(value.value, zone.value) ||
-  roundedFutureWallClock(new Date(), zone.value, props.minuteStep)
+const initialWallClock = initialScheduleWallClock(value.value, {
+  allowPast: props.allowPast,
+  min: props.min,
+  max: props.max,
+  timeZone: zone.value,
+  minuteStep: props.minuteStep
+})
 const selectedDate = ref(initialWallClock.date)
 const selectedTime = ref(initialWallClock.time)
 const draft = ref(
@@ -81,27 +90,32 @@ const popover = ref()
 const panel = ref()
 const root = ref()
 const touched = ref(false)
-const minimumTimestamp = computed(() => {
-  const configured = new Date(props.min).getTime()
-  return Math.max(Date.now(), Number.isNaN(configured) ? -Infinity : configured)
-})
-const calendarMin = computed(() => {
-  const instant = new Date(minimumTimestamp.value + 1000).toISOString()
-  return instantToWallClock(instant, zone.value)?.date ?? todayIso(zone.value)
-})
-const choices = computed(() => timeOptions(props.minuteStep))
-const proposalIsPast = computed(
-  () =>
-    interpretation.value.state === 'proposal' &&
-    new Date(interpretation.value.iso).getTime() <= minimumTimestamp.value
+const validationClock = ref(Date.now())
+const constraints = computed(() => ({
+  allowPast: props.allowPast,
+  min: props.min,
+  max: props.max,
+  reference: new Date(validationClock.value)
+}))
+const calendarBounds = computed(() =>
+  scheduleCalendarBounds({ ...constraints.value, timeZone: zone.value })
+)
+const fields = computed(() => timeFields(selectedTime.value, props.locale))
+const minutes = Array.from({ length: 60 }, (_, minute) =>
+  String(minute).padStart(2, '0')
+)
+const constraintError = computed(() =>
+  interpretation.value.iso
+    ? scheduleConstraint(interpretation.value.iso, constraints.value)
+    : ''
 )
 const committable = computed(
-  () => interpretation.value.state === 'proposal' && !proposalIsPast.value
+  () => interpretation.value.state === 'proposal' && !constraintError.value
 )
 const invalid = computed(
   () =>
     interpretation.value.state === 'invalid' ||
-    proposalIsPast.value ||
+    Boolean(constraintError.value) ||
     (touched.value && interpretation.value.state === 'incomplete')
 )
 const statusText = computed(() => {
@@ -114,11 +128,15 @@ const statusText = computed(() => {
   if (interpretation.value.state === 'incomplete') {
     return interpretation.value.message
   }
-  if (proposalIsPast.value) return 'Choose a time in the future.'
+  if (constraintError.value === 'past') return 'Choose a time in the future.'
+  if (constraintError.value === 'min')
+    return `Choose ${formatSchedule(props.min, props.locale, zone.value)} or later.`
+  if (constraintError.value === 'max')
+    return `Choose ${formatSchedule(props.max, props.locale, zone.value)} or earlier.`
   if (interpretation.value.state === 'proposal') {
-    return `Will schedule for ${interpretation.value.label} in ${zone.value}. Press Enter or leave the picker to use it.`
+    return `${props.allowPast ? 'Use' : 'Will schedule for'} ${interpretation.value.label} in ${zone.value}. Press Enter or leave the picker to use it.`
   }
-  return `Scheduled for ${interpretation.value.label} in ${zone.value}.`
+  return `${props.allowPast ? 'Selected' : 'Scheduled for'} ${interpretation.value.label} in ${zone.value}.`
 })
 const inputAttrs = computed(() => {
   const {
@@ -151,6 +169,7 @@ function clear() {
 }
 
 function readDraft(nextDraft) {
+  validationClock.value = Date.now()
   draft.value = nextDraft
   if (!nextDraft.trim()) {
     clear()
@@ -160,7 +179,8 @@ function readDraft(nextDraft) {
   const next = interpretSchedule(nextDraft, {
     reference: new Date(),
     locale: props.locale,
-    timeZone: zone.value
+    timeZone: zone.value,
+    allowPast: props.allowPast
   })
   interpretation.value = next
   if (next.date) selectedDate.value = next.date
@@ -173,13 +193,20 @@ function handleInput(event) {
 }
 
 function stage(date = selectedDate.value, time = selectedTime.value) {
-  const iso = wallClockToIso({ date, time, timeZone: zone.value })
+  if (props.disabled || props.readonly) return
+  validationClock.value = Date.now()
+  // Opening or reselecting an unchanged instant must not discard its seconds.
+  const previous = interpretation.value
+  const iso =
+    previous.iso && previous.date === date && previous.time === time
+      ? previous.iso
+      : wallClockToIso({ date, time, timeZone: zone.value })
+  selectedDate.value = date
+  selectedTime.value = time
   if (!iso) {
     interpretation.value = { state: 'invalid' }
     return
   }
-  selectedDate.value = date
-  selectedTime.value = time
   const label = formatSchedule(iso, props.locale, zone.value)
   interpretation.value = {
     state: 'proposal',
@@ -193,6 +220,7 @@ function stage(date = selectedDate.value, time = selectedTime.value) {
 }
 
 function commitProposal({ restoreFocus = true } = {}) {
+  validationClock.value = Date.now()
   if (!committable.value || props.disabled || props.readonly) return
   const next = interpretation.value
   setInternalValue(next.iso)
@@ -207,12 +235,28 @@ function handleFocusOut(event) {
   commitProposal({ restoreFocus: false })
 }
 
+function finish() {
+  if (props.disabled || props.readonly) return
+  validationClock.value = Date.now()
+  if (interpretation.value.state === 'committed' && !constraintError.value) {
+    popover.value?.close()
+  } else {
+    commitProposal()
+  }
+}
+
 function handleInputKeydown(event) {
   if (event.key === 'ArrowDown' && !props.disabled && !props.readonly) {
     event.preventDefault()
     popover.value?.open()
-  } else if (event.key === 'Enter' && committable.value) {
+  } else if (
+    event.key === 'Enter' &&
+    (interpretation.value.state === 'proposal' ||
+      interpretation.value.state === 'incomplete' ||
+      invalid.value)
+  ) {
     event.preventDefault()
+    touched.value = true
     commitProposal({ restoreFocus: false })
   }
 }
@@ -220,10 +264,21 @@ function handleInputKeydown(event) {
 async function handleOpenUpdate(nextOpen) {
   emit('update:open', nextOpen)
   if (!nextOpen) return
+  validationClock.value = Date.now()
+  if (interpretation.value.state === 'empty') {
+    const initial = initialScheduleWallClock('', {
+      ...constraints.value,
+      timeZone: zone.value,
+      minuteStep: props.minuteStep
+    })
+    selectedDate.value = initial.date
+    selectedTime.value = initial.time
+  }
   await nextTick()
-  panel.value
-    ?.querySelector(`[data-time="${selectedTime.value}"]`)
-    ?.scrollIntoView?.({ block: 'center' })
+  requestAnimationFrame(() => {
+    if (!panel.value?.getClientRects().length) return
+    panel.value.parentElement.scrollTop = 0
+  })
 }
 
 function chooseDate(nextDate) {
@@ -234,45 +289,11 @@ function chooseTime(nextTime) {
   stage(selectedDate.value, nextTime)
 }
 
-function timeIsUnavailable(time) {
-  const iso = wallClockToIso({
-    date: selectedDate.value,
-    time,
-    timeZone: zone.value
-  })
-  return !iso || new Date(iso).getTime() <= minimumTimestamp.value
+function chooseTimeField(part, nextValue) {
+  chooseTime(updateTimeField(selectedTime.value, part, nextValue, props.locale))
 }
 
-async function focusTime(nextTime) {
-  selectedTime.value = nextTime
-  await nextTick()
-  panel.value
-    ?.querySelector(`[data-time="${nextTime}"]`)
-    ?.focus({ preventScroll: true })
-}
-
-function handleTimeKeydown(event, index) {
-  let nextIndex
-  if (event.key === 'ArrowDown')
-    nextIndex = Math.min(index + 1, choices.value.length - 1)
-  else if (event.key === 'ArrowUp') nextIndex = Math.max(index - 1, 0)
-  else if (event.key === 'Home') nextIndex = 0
-  else if (event.key === 'End') nextIndex = choices.value.length - 1
-  else return
-  event.preventDefault()
-
-  const direction = nextIndex >= index ? 1 : -1
-  while (
-    nextIndex >= 0 &&
-    nextIndex < choices.value.length &&
-    timeIsUnavailable(choices.value[nextIndex])
-  ) {
-    nextIndex += direction
-  }
-  if (choices.value[nextIndex]) focusTime(choices.value[nextIndex])
-}
-
-watch(value, (nextValue) => {
+watch([value, zone, () => props.locale], ([nextValue]) => {
   const wallClock = instantToWallClock(nextValue, zone.value)
   if (!wallClock) {
     if (!nextValue) {
@@ -306,8 +327,8 @@ watch(
     const element = input.value?.element
     if (!element) return
     if (props.required && !value.value) {
-      element.setCustomValidity('Choose a schedule.')
-    } else if (invalid.value) {
+      element.setCustomValidity('Choose a date and time.')
+    } else if (invalid.value || interpretation.value.state === 'incomplete') {
       element.setCustomValidity(statusText.value)
     } else {
       element.setCustomValidity('')
@@ -346,7 +367,6 @@ defineExpose({
         :readonly="readonly"
         :aria-invalid="invalid || undefined"
         :aria-describedby="describedBy"
-        data-slot="schedule-picker-input"
         @input="handleInput"
         @click="!disabled && !readonly && popover?.open()"
         @keydown="handleInputKeydown"
@@ -373,7 +393,13 @@ defineExpose({
       </button>
     </div>
 
-    <input v-if="name" type="hidden" :name="name" :value="value" />
+    <input
+      v-if="name"
+      type="hidden"
+      :name="name"
+      :value="value"
+      :disabled="disabled"
+    />
     <p
       :id="statusId"
       data-slot="schedule-picker-status"
@@ -387,18 +413,20 @@ defineExpose({
     <Popover
       ref="popover"
       :id="popoverId"
+      :anchor="inputId"
       :open="open"
       :default-open="defaultOpen"
       placement="bottom-start"
       data-slot="schedule-picker-popover"
-      class="w-[min(42rem,calc(100vw-1rem))] p-0"
+      class="max-h-[min(var(--klean-popover-available-height,100dvh),calc(100dvh-1rem))] w-[min(24rem,calc(100vw-1rem))] overflow-y-auto overscroll-contain rounded-xl p-0"
       @update:open="handleOpenUpdate"
     >
       <div ref="panel" data-slot="schedule-picker-panel">
-        <div class="grid sm:grid-cols-[minmax(0,1fr)_10rem]">
+        <div class="grid">
           <Calendar
             :model-value="selectedDate"
-            :min="calendarMin"
+            :min="calendarBounds.min"
+            :max="calendarBounds.max"
             :locale="locale"
             :dir="dir"
             :disabled="disabled"
@@ -409,54 +437,117 @@ defineExpose({
 
           <section
             data-slot="schedule-picker-times"
-            class="border-t border-gray-200 p-3 sm:border-s sm:border-t-0 dark:border-gray-700"
+            class="sticky bottom-0 grid min-w-0 gap-2 border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-950"
             :aria-labelledby="timeHeadingId"
           >
-            <h2 :id="timeHeadingId" class="px-2 pb-2 text-sm font-semibold">
-              Time
-            </h2>
-            <div
-              role="listbox"
-              aria-label="Choose a time"
-              class="max-h-64 overflow-y-auto overscroll-contain"
-            >
-              <button
-                v-for="(time, index) in choices"
-                :key="time"
-                type="button"
-                role="option"
-                data-slot="schedule-picker-time"
-                :data-time="time"
-                :aria-selected="time === selectedTime"
-                :disabled="timeIsUnavailable(time)"
-                :tabindex="time === selectedTime ? 0 : -1"
-                class="block min-h-11 w-full rounded-md px-3 text-start text-sm tabular-nums hover:bg-gray-100 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:text-gray-300 aria-selected:bg-gray-950 aria-selected:font-semibold aria-selected:text-white dark:hover:bg-gray-800 dark:focus-visible:outline-white dark:disabled:text-gray-700 dark:aria-selected:bg-white dark:aria-selected:text-gray-950"
-                @click="chooseTime(time)"
-                @keydown="handleTimeKeydown($event, index)"
+            <div class="flex min-w-0 items-baseline justify-between gap-3">
+              <h2 :id="timeHeadingId" class="text-sm font-medium">Time</h2>
+              <p
+                :id="`${inputId}-time-zone`"
+                data-slot="schedule-picker-time-zone"
+                class="min-w-0 text-end text-xs wrap-anywhere text-gray-500 dark:text-gray-400"
               >
-                {{ formatTimeLabel(time, locale) }}
-              </button>
+                {{ zone }}
+              </p>
             </div>
+            <div class="flex flex-wrap items-center justify-between gap-2">
+              <div
+                data-slot="schedule-picker-time-fields"
+                role="group"
+                :aria-labelledby="timeHeadingId"
+                :aria-describedby="`${inputId}-time-zone`"
+                dir="ltr"
+                class="inline-flex shrink-0 items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 text-sm font-medium tabular-nums shadow-xs dark:border-gray-700 dark:bg-gray-900"
+              >
+                <select
+                  data-slot="schedule-picker-hour"
+                  aria-label="Hour"
+                  class="h-11 w-11 cursor-pointer appearance-none rounded-md bg-transparent text-center text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                  :value="fields.hour"
+                  :disabled="disabled || readonly"
+                  @change="chooseTimeField('hour', $event.target.value)"
+                >
+                  <option
+                    v-for="hour in fields.hours"
+                    :key="hour.value"
+                    :value="hour.value"
+                  >
+                    {{ hour.label }}
+                  </option>
+                </select>
+                <span aria-hidden="true" class="text-gray-400">:</span>
+                <select
+                  data-slot="schedule-picker-minute"
+                  aria-label="Minute"
+                  class="h-11 w-11 cursor-pointer appearance-none rounded-md bg-transparent text-center text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                  :value="fields.minute"
+                  :disabled="disabled || readonly"
+                  @change="chooseTimeField('minute', $event.target.value)"
+                >
+                  <option
+                    v-for="minute in minutes"
+                    :key="minute"
+                    :value="minute"
+                  >
+                    {{ minute }}
+                  </option>
+                </select>
+                <div
+                  v-if="fields.hour12"
+                  class="relative ms-1 border-s border-gray-200 ps-1 dark:border-gray-700"
+                >
+                  <select
+                    data-slot="schedule-picker-period"
+                    aria-label="Period"
+                    class="h-11 min-w-16 cursor-pointer appearance-none rounded-md bg-transparent ps-2 pe-6 text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                    :value="fields.period"
+                    :disabled="disabled || readonly"
+                    @change="chooseTimeField('period', $event.target.value)"
+                  >
+                    <option
+                      v-for="period in fields.periods"
+                      :key="period.value"
+                      :value="period.value"
+                    >
+                      {{ period.label }}
+                    </option>
+                  </select>
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="pointer-events-none absolute inset-e-2 top-1/2 size-3 -translate-y-1/2 text-gray-500 dark:text-gray-400"
+                  >
+                    <path d="m7 10 5 5 5-5" />
+                  </svg>
+                </div>
+              </div>
+              <div data-slot="schedule-picker-footer">
+                <button
+                  type="button"
+                  data-slot="schedule-picker-confirm"
+                  class="min-h-11 cursor-pointer rounded-lg bg-gray-950 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
+                  :disabled="
+                    (!committable && interpretation.state !== 'committed') ||
+                    invalid ||
+                    disabled ||
+                    readonly
+                  "
+                  @click="finish()"
+                >
+                  Done
+                </button>
+              </div>
+            </div>
+            <p v-if="invalid" class="text-sm text-red-700 dark:text-red-400">
+              {{ statusText }}
+            </p>
           </section>
         </div>
-
-        <footer
-          data-slot="schedule-picker-footer"
-          class="flex flex-col gap-3 border-t border-gray-200 p-4 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700"
-        >
-          <p class="text-sm text-gray-600 dark:text-gray-400">
-            {{ statusText }}
-          </p>
-          <button
-            type="button"
-            data-slot="schedule-picker-confirm"
-            class="min-h-11 shrink-0 rounded-md bg-gray-950 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
-            :disabled="!committable || disabled || readonly"
-            @click="commitProposal()"
-          >
-            Use this time
-          </button>
-        </footer>
       </div>
     </Popover>
   </div>

--- a/docs/.vitepress/theme/components/klean/schedule-picker/schedule.js
+++ b/docs/.vitepress/theme/components/klean/schedule-picker/schedule.js
@@ -58,7 +58,7 @@ export function wallClockToIso({
   }
 
   try {
-    return toZoned(
+    const zoned = toZoned(
       new CalendarDateTime(
         parsedDate.year,
         parsedDate.month,
@@ -71,8 +71,20 @@ export function wallClockToIso({
       resolveTimeZone(timeZone),
       'compatible'
     )
-      .toDate()
-      .toISOString()
+    // A gap must not silently move an entered time forward. During an overlap,
+    // compatible disambiguation keeps the earlier occurrence.
+    if (
+      zoned.year !== parsedDate.year ||
+      zoned.month !== parsedDate.month ||
+      zoned.day !== parsedDate.day ||
+      zoned.hour !== parsedTime.hour ||
+      zoned.minute !== parsedTime.minute ||
+      zoned.second !== second ||
+      zoned.millisecond !== millisecond
+    ) {
+      return undefined
+    }
+    return zoned.toDate().toISOString()
   } catch {
     return undefined
   }
@@ -111,8 +123,128 @@ export function formatTimeLabel(value, locale) {
   }).format(new Date(Date.UTC(2020, 0, 1, time.hour, time.minute)))
 }
 
+function timestamp(value) {
+  if (value === undefined || value === null || value === '') return NaN
+  return new Date(value).getTime()
+}
+
+function referenceTimestamp(reference) {
+  const value = timestamp(reference)
+  return Number.isFinite(value) ? value : Date.now()
+}
+
+export function scheduleConstraint(
+  value,
+  { allowPast = false, min, max, reference = new Date() } = {}
+) {
+  const instant = timestamp(value)
+  if (!Number.isFinite(instant)) return 'invalid'
+  if (!allowPast && instant <= referenceTimestamp(reference)) return 'past'
+  if (instant < timestamp(min)) return 'min'
+  if (instant > timestamp(max)) return 'max'
+  return ''
+}
+
+export function scheduleCalendarBounds({
+  allowPast = false,
+  min,
+  max,
+  timeZone,
+  reference = new Date()
+} = {}) {
+  const configuredMin = timestamp(min)
+  const lower = Math.max(
+    allowPast ? -Infinity : referenceTimestamp(reference) + 1,
+    Number.isFinite(configuredMin) ? configuredMin : -Infinity
+  )
+  const upper = timestamp(max)
+  return {
+    min: Number.isFinite(lower)
+      ? instantToWallClock(lower, timeZone)?.date
+      : undefined,
+    max: Number.isFinite(upper)
+      ? instantToWallClock(upper, timeZone)?.date
+      : undefined
+  }
+}
+
+export function timeFields(value, locale) {
+  const time = parseTime(value) ?? { hour: 0, minute: 0 }
+  const resolvedLocale = resolveLocale(locale)
+  const hour12 = new Intl.DateTimeFormat(resolvedLocale, {
+    hour: 'numeric'
+  }).resolvedOptions().hour12
+  const hoursFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+    timeZone: 'UTC',
+    hour: '2-digit',
+    hourCycle: hour12 ? 'h12' : 'h23'
+  })
+  const periodsFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+    timeZone: 'UTC',
+    hour: 'numeric',
+    hourCycle: 'h12'
+  })
+  const part = (formatter, hour, type) =>
+    formatter
+      .formatToParts(new Date(Date.UTC(2020, 0, 1, hour)))
+      .find((item) => item.type === type)?.value
+
+  return {
+    hour: String(hour12 ? time.hour % 12 || 12 : time.hour),
+    minute: String(time.minute).padStart(2, '0'),
+    period: time.hour < 12 ? 'am' : 'pm',
+    hour12,
+    periods: [
+      { value: 'am', label: part(periodsFormatter, 6, 'dayPeriod') ?? 'AM' },
+      { value: 'pm', label: part(periodsFormatter, 18, 'dayPeriod') ?? 'PM' }
+    ],
+    hours: Array.from({ length: hour12 ? 12 : 24 }, (_, index) => {
+      const hour = hour12 ? index + 1 : index
+      return {
+        value: String(hour),
+        label: part(hoursFormatter, hour, 'hour') ?? String(hour)
+      }
+    })
+  }
+}
+
+export function updateTimeField(time, part, value, locale) {
+  const current = parseTime(time)
+  if (!current) return time
+  const fields = timeFields(time, locale)
+  if (part === 'period') {
+    if (!fields.hour12 || !['am', 'pm'].includes(value)) return time
+    current.hour = (current.hour % 12) + (value === 'pm' ? 12 : 0)
+  } else {
+    if (!/^\d{1,2}$/.test(String(value))) return time
+    const number = Number(value)
+    if (part === 'minute') {
+      if (number > 59) return time
+      current.minute = number
+    } else if (part === 'hour') {
+      if (fields.hour12) {
+        if (number < 1 || number > 12) return time
+        current.hour = (number % 12) + (fields.period === 'pm' ? 12 : 0)
+      } else {
+        if (number > 23) return time
+        current.hour = number
+      }
+    } else {
+      return time
+    }
+  }
+  return formatTime(current)
+}
+
+function normalizeMinuteStep(step) {
+  const value = Number(step)
+  return Number.isFinite(value)
+    ? Math.min(60, Math.max(1, Math.round(value)))
+    : 15
+}
+
 export function timeOptions(step = 15) {
-  const safeStep = Math.min(60, Math.max(1, Math.round(step)))
+  const safeStep = normalizeMinuteStep(step)
   const values = []
   for (let minute = 0; minute < 24 * 60; minute += safeStep) {
     values.push(
@@ -122,20 +254,54 @@ export function timeOptions(step = 15) {
   return values
 }
 
-export function roundedFutureWallClock(reference, timeZone, step = 15) {
-  const amount = Math.min(60, Math.max(1, Math.round(step)))
-  const rounded = new Date(reference)
+function roundedFutureTimestamp(reference, step) {
+  const amount = normalizeMinuteStep(step)
+  const rounded = new Date(referenceTimestamp(reference))
   rounded.setSeconds(0, 0)
   const remainder = rounded.getMinutes() % amount
   rounded.setMinutes(
     rounded.getMinutes() + (remainder ? amount - remainder : amount)
   )
-  return instantToWallClock(rounded.toISOString(), timeZone)
+  return rounded.getTime()
+}
+
+export function roundedFutureWallClock(reference, timeZone, step = 15) {
+  return instantToWallClock(roundedFutureTimestamp(reference, step), timeZone)
+}
+
+export function initialScheduleWallClock(
+  value,
+  {
+    allowPast = false,
+    min,
+    max,
+    timeZone,
+    minuteStep = 15,
+    reference = new Date()
+  } = {}
+) {
+  const current = timestamp(value)
+  if (Number.isFinite(current)) return instantToWallClock(current, timeZone)
+
+  const now = referenceTimestamp(reference)
+  const initial = roundedFutureTimestamp(now, minuteStep)
+  const configuredMin = timestamp(min)
+  const configuredMax = timestamp(max)
+  const lower = Math.max(
+    allowPast ? -Infinity : now + 1,
+    Number.isFinite(configuredMin) ? configuredMin : -Infinity
+  )
+  const upper = Number.isFinite(configuredMax) ? configuredMax : Infinity
+  // Bounds still disable every choice when the allowed interval is empty.
+  // Initializing a view must not imply that a forbidden instant is valid.
+  const candidate =
+    lower <= upper ? Math.min(upper, Math.max(lower, initial)) : initial
+  return instantToWallClock(candidate, timeZone)
 }
 
 export function interpretSchedule(
   text,
-  { reference = new Date(), locale, timeZone } = {}
+  { reference = new Date(), locale, timeZone, allowPast = false } = {}
 ) {
   const source = text?.trim()
   if (!source) return { state: 'empty' }
@@ -153,7 +319,7 @@ export function interpretSchedule(
       instant: referenceInstant,
       timezone: zonedReference.offset / 60_000
     },
-    { forwardDate: true }
+    { forwardDate: !allowPast }
   )[0]
 
   if (!result) return { state: 'invalid' }
@@ -187,8 +353,7 @@ export function interpretSchedule(
 
   return {
     state: 'proposal',
-    date,
-    time,
+    ...instantToWallClock(iso, zone),
     iso,
     label: formatSchedule(iso, locale, zone),
     timeZone: zone

--- a/docs/klean-ui/components/calendar.md
+++ b/docs/klean-ui/components/calendar.md
@@ -144,7 +144,7 @@ Choose Schedule Picker when time and timezone must resolve to an exact ISO insta
 
 - [Date Picker](/klean-ui/components/date-picker) — one editable date-only `YYYY-MM-DD` field with an optional calendar.
 - [Date Range Picker](/klean-ui/components/date-range-picker) — two ordered date-only `YYYY-MM-DD` boundaries.
-- [Schedule Picker](/klean-ui/components/schedule-picker) — date, time, and IANA timezone stored as an exact ISO instant.
+- [Schedule Picker](/klean-ui/components/schedule-picker) — date and time as an exact ISO instant; future scheduling by default, historical editing with `allowPast`.
 - [Popover](/klean-ui/components/popover) — the floating surface used by compact date components.
 
 ## Complete framework source

--- a/docs/klean-ui/components/date-picker.md
+++ b/docs/klean-ui/components/date-picker.md
@@ -211,7 +211,7 @@ Choose Schedule Picker when time and timezone must resolve to an exact ISO insta
 
 - [Calendar](/klean-ui/components/calendar) — an always-visible date-only `YYYY-MM-DD` surface.
 - [Date Range Picker](/klean-ui/components/date-range-picker) — ordered date-only `YYYY-MM-DD` start and end values.
-- [Schedule Picker](/klean-ui/components/schedule-picker) — date, time, and IANA timezone stored as an exact ISO instant.
+- [Schedule Picker](/klean-ui/components/schedule-picker) — date and time as an exact ISO instant; future scheduling by default, historical editing with `allowPast`.
 - [Input](/klean-ui/components/input) — a plain field when a calendar adds no value.
 
 ## Complete framework source

--- a/docs/klean-ui/components/date-range-picker.md
+++ b/docs/klean-ui/components/date-range-picker.md
@@ -186,7 +186,7 @@ Choose Schedule Picker when time and timezone must resolve to an exact ISO insta
 
 - [Calendar](/klean-ui/components/calendar) — one always-visible date-only `YYYY-MM-DD` surface.
 - [Date Picker](/klean-ui/components/date-picker) — independent date-only `YYYY-MM-DD` values and asymmetric rules.
-- [Schedule Picker](/klean-ui/components/schedule-picker) — date, time, and IANA timezone stored as an exact ISO instant.
+- [Schedule Picker](/klean-ui/components/schedule-picker) — date and time as an exact ISO instant; future scheduling by default, historical editing with `allowPast`.
 - [Popover](/klean-ui/components/popover) — the floating surface used by the compact range.
 
 ## Complete framework source

--- a/docs/klean-ui/components/index.md
+++ b/docs/klean-ui/components/index.md
@@ -171,7 +171,7 @@ One related start-and-end decision with inclusive date boundaries, native form n
 
 ### [Schedule Picker](/klean-ui/components/schedule-picker)
 
-Natural-language future scheduling with Calendar, time choices, IANA timezone safety, exact relative durations, and predictable Enter or composite-blur commit.
+Choose a date and time together, with natural input, a visible timezone, and localized hour and minute controls. Schedule future work by default, or allow past dates for record editing.
 
 ### [Toast](/klean-ui/components/toast)
 

--- a/docs/klean-ui/components/schedule-picker.md
+++ b/docs/klean-ui/components/schedule-picker.md
@@ -1,7 +1,7 @@
 ---
 title: Schedule Picker
 titleTemplate: Klean UI
-description: Natural-language future scheduling with Calendar, time choices, timezone safety, and automatic Enter or blur commit.
+description: Pick a date and time together, schedule future work, or edit historical timestamps with natural input and a visible timezone.
 outline: [2, 3]
 ---
 
@@ -24,8 +24,14 @@ import svelteHelperSource from '../sources/schedule-picker/schedule.svelte.js?ra
 import vueUsage from '../snippets/schedule-picker/usage.vue?raw'
 import reactUsage from '../snippets/schedule-picker/usage.jsx?raw'
 import svelteUsage from '../snippets/schedule-picker/usage.svelte?raw'
+import vueHistorical from '../snippets/schedule-picker/historical.vue?raw'
+import reactHistorical from '../snippets/schedule-picker/historical.jsx?raw'
+import svelteHistorical from '../snippets/schedule-picker/historical.svelte?raw'
+import vueWindow from '../snippets/schedule-picker/window.vue?raw'
 
 const publishAt = ref('')
+const recordedAt = ref('2020-02-29T13:35:00.000Z')
+const reviewAt = ref('2020-02-29T13:35:00.000Z')
 const vueFiles = [
   {
     filename: 'Input.vue',
@@ -62,10 +68,11 @@ const vueFiles = [
 
 # Schedule Picker
 
-Schedule Picker turns a future wall-clock intention into an exact ISO instant.
-Natural language, Calendar, and time choices share one field, while a visible
-interpretation keeps the exact instant honest before Enter or composite blur
-commits it.
+Choose a date and time in one field. Type naturally or use the calendar and time
+controls, with the timezone always visible. The value is an exact ISO instant.
+
+Schedule Picker accepts future times by default. Add `allowPast` when editing
+historical records or choosing a time on either side of today.
 
 <KleanPreview id="schedule-picker-source" :source="scheduleSource" filename="SchedulePicker.vue">
   <template #preview>
@@ -101,9 +108,6 @@ commits it.
 
 ## Installation
 
-The registry resolves Input, Popover, and Calendar, then installs the
-framework-native Schedule Picker and its focused scheduling helper:
-
 <KleanInstallation
   id="schedule-picker-installation"
   component="schedule-picker"
@@ -114,20 +118,21 @@ framework-native Schedule Picker and its focused scheduling helper:
   :dependencies="['@floating-ui/dom', '@internationalized/date', 'chrono-node', 'tailwind-merge']"
 />
 
-There is no provider, locale configuration, timezone database setup, or
-natural-language mode to enable.
-
 ## When to use
 
-Use Schedule Picker for publishing, sending, deploying, appointments, and jobs
-that must happen at a future moment.
+Use Schedule Picker whenever both the day and time matter:
+
+- Schedule publishing, sending, appointments, or jobs with the future-only default.
+- Edit a record's timestamp, log an event, or search historical records with `allowPast`.
+- Restrict a datetime to a permitted window with `min` and `max`.
 
 ## When not to use
 
 Use [Date Picker](/klean-ui/components/date-picker) when only the day matters,
 [Date Range Picker](/klean-ui/components/date-range-picker) for a date-only
 period, and [Calendar](/klean-ui/components/calendar) when the calendar itself
-is the workspace.
+is the workspace. An invoice due date or birthday should stay a date-only value;
+do not add a midnight time or timezone to make it fit Schedule Picker.
 
 ## Usage
 
@@ -143,6 +148,105 @@ is the workspace.
 
 <CopyCode :code="svelteUsage" label="PublishSchedule.svelte" />
 
+## Historical dates and times
+
+Add `allowPast` to accept both past and future instants. The same field, calendar,
+time controls, and natural input work for editing records—there is no separate
+datetime component to learn.
+
+<KleanPreview id="schedule-picker-historical" :source="vueHistorical" filename="RecordedAt.vue">
+  <template #preview>
+    <div class="grid w-full max-w-xl gap-3">
+      <label for="docs-recorded-at" class="text-sm font-medium">Recorded at</label>
+      <KleanSchedulePicker
+        id="docs-recorded-at"
+        v-model="recordedAt"
+        name="recordedAt"
+        allow-past
+        time-zone="Africa/Lagos"
+        locale="en-US"
+        placeholder="February 29, 2020 at 2:35pm"
+        class="**:data-[slot=input]:border-dashed **:data-[slot=input]:shadow-none"
+      />
+      <output class="break-all font-mono text-sm text-gray-600 dark:text-gray-300">
+        {{ recordedAt || 'No instant selected' }}
+      </output>
+      <button
+        type="button"
+        class="min-h-11 justify-self-start rounded-md border border-gray-300 px-4 py-2 text-sm font-medium hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 dark:border-gray-700 dark:hover:bg-gray-900 dark:focus-visible:outline-white"
+      >
+        Continue
+      </button>
+    </div>
+  </template>
+  <template #caption>
+    Edit February 29, 2020, or type “yesterday at 2:35pm”. Enter or leaving the picker applies a valid choice.
+  </template>
+</KleanPreview>
+
+### Vue
+
+<CopyCode :code="vueHistorical" label="RecordedAt.vue" />
+
+### React
+
+<CopyCode :code="reactHistorical" label="RecordedAt.jsx" />
+
+### Svelte
+
+<CopyCode :code="svelteHistorical" label="RecordedAt.svelte" />
+
+## Allowed date and time window
+
+`min` and `max` are inclusive ISO instants, not date-only strings. They constrain
+both the calendar and time selection, including typed input. A value exactly at
+either boundary is allowed, provided it also satisfies the future-only default.
+
+An earlier `min` does not enable historical dates on its own. Use `allowPast` for
+a window that includes the past.
+
+<KleanPreview id="schedule-picker-window" :source="vueWindow" filename="ReviewTime.vue">
+  <template #preview>
+    <div class="grid w-full max-w-xl gap-2">
+      <label for="docs-review-at" class="text-sm font-medium">Review time</label>
+      <p id="docs-review-window" class="text-sm text-gray-600 dark:text-gray-300">
+        February 29, 2020, from 9am through 5pm in Africa/Lagos.
+      </p>
+      <KleanSchedulePicker
+        id="docs-review-at"
+        v-model="reviewAt"
+        name="reviewAt"
+        allow-past
+        min="2020-02-29T08:00:00.000Z"
+        max="2020-02-29T16:00:00.000Z"
+        time-zone="Africa/Lagos"
+        locale="en-US"
+        aria-describedby="docs-review-window"
+      />
+      <output class="break-all font-mono text-sm text-gray-600 dark:text-gray-300">
+        {{ reviewAt || 'No instant selected' }}
+      </output>
+    </div>
+  </template>
+</KleanPreview>
+
+<CopyCode :code="vueWindow" label="ReviewTime.vue" />
+
+In Vue use `allow-past`; in React and Svelte use `allowPast`. The `min` and `max`
+names are identical in all three frameworks. Continue validating the permitted
+window on the server when saving the value.
+
+## Choosing the time
+
+Choose the hour and minute in the compact time control beneath the calendar.
+A 12-hour locale such as `en-US` includes AM/PM; a 24-hour locale such as `en-GB`
+uses hours 00–23. The timezone stays beside the time, and the locale controls
+presentation, not the stored instant.
+
+Every minute is selectable. `minuteStep` defaults to 15 and only rounds the
+starting time for an empty picker; existing selections and typed values are not
+rounded.
+
 ## Natural input and commit
 
 The following all create a proposal:
@@ -153,11 +257,14 @@ The following all create a proposal:
 - `in one hour`
 
 The interpreted date, time, and IANA timezone remain visible. Press Enter,
-leave the complete picker, or choose **Use this time** to commit. Moving focus
-between the text field, Calendar, time list, and footer action does not commit
-prematurely. Until a valid commit point, the named hidden form value retains
-the last valid ISO instant. An incomplete phrase, parser mistake, or abandoned
-invalid edit cannot silently reschedule server work.
+leave the complete picker, or choose **Done** to commit. Moving focus
+between the text field, calendar, time controls, and footer action does not commit
+prematurely. Until a valid choice is committed, the field retains the last valid
+ISO instant. An incomplete phrase or invalid edit cannot silently replace it.
+Choosing **Done** without changing an existing value simply closes the picker.
+
+With `allowPast`, phrases such as `yesterday at 2:35pm`, `2 hours ago`, and
+`February 29, 2020 at 2:35pm` are also accepted. The allowed window still applies.
 
 Relative durations retain exact seconds. If the reference instant is 13:07:30
 in Lagos, `in 5 minutes` proposes 13:12:30 and stores the matching UTC instant.
@@ -170,9 +277,16 @@ the browser timezone is the useful zero-configuration default. Display remains
 localized through `Intl`; the committed value remains an ISO instant suitable
 for storage and server scheduling.
 
-The component handles timezone offset changes for the selected date, including
-daylight-saving transitions. Invalid timezone input falls back to the browser
-timezone rather than breaking the field.
+Pass an ISO timestamp with `Z` or an explicit offset as the value. Do not pass a
+timezone-less form string such as `2020-02-29T14:35`: it does not identify an exact
+instant. Keep date-only values as `YYYY-MM-DD` with Date Picker. An existing form
+that stores local date and time strings needs an explicit conversion at its
+boundary; do not append `Z` unless those values really are UTC.
+
+The component handles timezone offset changes for the selected date. Local times
+skipped by daylight saving are rejected. When a clock time occurs twice, the
+earlier occurrence is used unless the input includes an explicit UTC offset.
+Invalid timezone input falls back to the browser timezone.
 
 ## API
 
@@ -183,24 +297,37 @@ timezone rather than breaking the field.
 | Native form name        | `name`                             | `name`                             | `name`                             |
 | Interpretation timezone | `time-zone`                        | `timeZone`                         | `timeZone`                         |
 | Locale                  | `locale`, `dir`                    | `locale`, `dir`                    | `locale`, `dir`                    |
+| Accept past instants    | `allow-past`                       | `allowPast`                        | `allowPast`                        |
 | Earliest instant        | `min`                              | `min`                              | `min`                              |
-| Time-list spacing       | `minute-step`                      | `minuteStep`                       | `minuteStep`                       |
+| Latest instant          | `max`                              | `max`                              | `max`                              |
+| Initial time rounding   | `minute-step`                      | `minuteStep`                       | `minuteStep`                       |
 | Open state              | `v-model:open`                     | `open`, `onOpenChange`             | `bind:open`                        |
 | Native states           | `required`, `disabled`, `readonly` | `required`, `disabled`, `readOnly` | `required`, `disabled`, `readonly` |
 
-Scheduling is future-only by default. `min` may move the earliest acceptable
-instant later. `minuteStep` changes the conventional time list; natural input
-may remain more precise.
+`allowPast` defaults to `false`. `min` and `max` are optional, inclusive limits;
+neither disables the future-only default. `minuteStep` sets the suggested
+starting time, not the precision of the value.
+
+## Styling
+
+Use ordinary classes on the component. Target a part through its `data-slot` when
+you want to change only that part. The historical example above gives the input
+a dashed border without changing the text, calendar, or time controls:
+
+```html
+class="**:data-[slot=input]:border-dashed **:data-[slot=input]:shadow-none"
+```
+
+Use `className` in React. Classes and ordinary attributes remain application-owned.
 
 ## Durable behavior
 
-- Draft text and the last committed instant are separate truths until Enter or
-  a true composite blur.
+- Editing text does not replace the committed value until Enter or leaving the picker.
 - Enter commits without moving focus from the field.
 - Internal focus movement does not commit; leaving the complete picker does.
-- Calendar and time-list choices are keyboard navigable.
-- Opening the time list brings the selected time into view.
-- Past proposals are invalid and cannot be committed.
+- Calendar, hour, minute, and AM/PM choices are keyboard navigable.
+- Past proposals are rejected unless `allowPast` is enabled.
+- Bounds are checked at commit, so an expired scheduling choice cannot slip through.
 - Escape dismisses only ephemeral open state and returns focus predictably.
 - Klean never writes the draft, open state, or selected instant to storage or the URL.
 

--- a/docs/klean-ui/snippets/schedule-picker/historical.jsx
+++ b/docs/klean-ui/snippets/schedule-picker/historical.jsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import SchedulePicker from '@/components/ui/schedule-picker/SchedulePicker.jsx'
+
+export default function RecordedAt() {
+  const [recordedAt, setRecordedAt] = useState('2020-02-29T13:35:00.000Z')
+
+  return (
+    <>
+      <label htmlFor="recorded-at">Recorded at</label>
+      <SchedulePicker
+        id="recorded-at"
+        value={recordedAt}
+        onValueChange={setRecordedAt}
+        name="recordedAt"
+        allowPast
+        timeZone="Africa/Lagos"
+        locale="en-US"
+        placeholder="February 29, 2020 at 2:35pm"
+        className="**:data-[slot=input]:border-dashed **:data-[slot=input]:shadow-none"
+      />
+    </>
+  )
+}

--- a/docs/klean-ui/snippets/schedule-picker/historical.svelte
+++ b/docs/klean-ui/snippets/schedule-picker/historical.svelte
@@ -1,0 +1,17 @@
+<script>
+  import SchedulePicker from '~/components/ui/schedule-picker/SchedulePicker.svelte'
+
+  let recordedAt = $state('2020-02-29T13:35:00.000Z')
+</script>
+
+<label for="recorded-at">Recorded at</label>
+<SchedulePicker
+  id="recorded-at"
+  bind:value={recordedAt}
+  name="recordedAt"
+  allowPast
+  timeZone="Africa/Lagos"
+  locale="en-US"
+  placeholder="February 29, 2020 at 2:35pm"
+  class="**:data-[slot=input]:border-dashed **:data-[slot=input]:shadow-none"
+/>

--- a/docs/klean-ui/snippets/schedule-picker/historical.vue
+++ b/docs/klean-ui/snippets/schedule-picker/historical.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref } from 'vue'
+import SchedulePicker from '~/components/ui/schedule-picker/SchedulePicker.vue'
+
+const recordedAt = ref('2020-02-29T13:35:00.000Z')
+</script>
+
+<template>
+  <label for="recorded-at">Recorded at</label>
+  <SchedulePicker
+    id="recorded-at"
+    v-model="recordedAt"
+    name="recordedAt"
+    allow-past
+    time-zone="Africa/Lagos"
+    locale="en-US"
+    placeholder="February 29, 2020 at 2:35pm"
+    class="**:data-[slot=input]:border-dashed **:data-[slot=input]:shadow-none"
+  />
+</template>

--- a/docs/klean-ui/snippets/schedule-picker/window.vue
+++ b/docs/klean-ui/snippets/schedule-picker/window.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref } from 'vue'
+import SchedulePicker from '~/components/ui/schedule-picker/SchedulePicker.vue'
+
+const reviewAt = ref('2020-02-29T13:35:00.000Z')
+</script>
+
+<template>
+  <label for="review-at">Review time</label>
+  <SchedulePicker
+    id="review-at"
+    v-model="reviewAt"
+    name="reviewAt"
+    allow-past
+    min="2020-02-29T08:00:00.000Z"
+    max="2020-02-29T16:00:00.000Z"
+    time-zone="Africa/Lagos"
+    locale="en-US"
+  />
+</template>

--- a/docs/klean-ui/sources/popover/Popover.jsx
+++ b/docs/klean-ui/sources/popover/Popover.jsx
@@ -3,7 +3,8 @@ import {
   computePosition,
   flip,
   offset as floatingOffset,
-  shift
+  shift,
+  size
 } from '@floating-ui/dom'
 import {
   forwardRef,
@@ -26,6 +27,7 @@ const Popover = forwardRef(function Popover(
     id,
     open: controlledOpen,
     defaultOpen = false,
+    anchor,
     onOpenChange,
     placement = 'bottom-start',
     offset = 8,
@@ -47,6 +49,7 @@ const Popover = forwardRef(function Popover(
   const [resolvedPlacement, setResolvedPlacement] = useState(placement)
   const [positionStyle, setPositionStyle] = useState({
     position: 'fixed',
+    inset: 'auto',
     left: 0,
     top: 0
   })
@@ -86,6 +89,20 @@ const Popover = forwardRef(function Popover(
     },
     [contentId, invokers]
   )
+
+  const resolveAnchor = useCallback(() => {
+    if (typeof anchor === 'string') {
+      const root = contentRef.current?.getRootNode?.() ?? document
+      const element =
+        root.getElementById?.(anchor) ?? document.getElementById(anchor)
+
+      if (element?.isConnected) return element
+    } else if (anchor?.isConnected) {
+      return anchor
+    }
+
+    return resolveInvoker()
+  }, [anchor, resolveInvoker])
 
   const syncInvokerAria = useCallback(() => {
     for (const invoker of invokers()) {
@@ -192,26 +209,55 @@ const Popover = forwardRef(function Popover(
     syncInvokerAria()
     syncNativePopover()
 
-    const invoker = resolveInvoker()
-    if (!isOpen || !invoker || !contentRef.current) return
+    const anchorElement = resolveAnchor()
+    if (!isOpen || !anchorElement || !contentRef.current) return
+    const element = contentRef.current
+    let active = true
 
     const updatePosition = async () => {
-      const result = await computePosition(invoker, contentRef.current, {
+      const result = await computePosition(anchorElement, element, {
         placement,
         strategy: 'fixed',
-        middleware: [floatingOffset(offset), flip(), shift({ padding: 8 })]
+        middleware: [
+          floatingOffset(offset),
+          flip({ padding: 8 }),
+          size({
+            padding: 8,
+            apply({ availableHeight, elements }) {
+              elements.floating.style.setProperty(
+                '--klean-popover-available-height',
+                `${Math.max(0, availableHeight)}px`
+              )
+            }
+          }),
+          shift({ padding: 8, crossAxis: true })
+        ]
       })
 
+      if (!active || contentRef.current !== element) return
       setResolvedPlacement(result.placement)
-      setPositionStyle({ position: 'fixed', left: result.x, top: result.y })
+      setPositionStyle({
+        position: 'fixed',
+        inset: 'auto',
+        left: result.x,
+        top: result.y,
+        '--klean-popover-available-height': element.style.getPropertyValue(
+          '--klean-popover-available-height'
+        )
+      })
     }
 
-    return autoUpdate(invoker, contentRef.current, updatePosition)
+    const cleanup = autoUpdate(anchorElement, element, updatePosition)
+    return () => {
+      active = false
+      cleanup()
+    }
   }, [
     isOpen,
     offset,
     placement,
     referenceVersion,
+    resolveAnchor,
     resolveInvoker,
     syncInvokerAria,
     syncNativePopover
@@ -222,12 +268,16 @@ const Popover = forwardRef(function Popover(
 
     function handleOutsidePointer(event) {
       const path = eventPath(event)
-      const reference = resolveInvoker()
+      const invoker = resolveInvoker()
+      const anchorElement = resolveAnchor()
 
       if (
         path.includes(contentRef.current) ||
-        (reference &&
-          (path.includes(reference) || reference.contains?.(event.target))) ||
+        (invoker &&
+          (path.includes(invoker) || invoker.contains?.(event.target))) ||
+        (anchorElement &&
+          (path.includes(anchorElement) ||
+            anchorElement.contains?.(event.target))) ||
         invokers().some(
           (invoker) => path.includes(invoker) || invoker.contains(event.target)
         )
@@ -239,10 +289,24 @@ const Popover = forwardRef(function Popover(
     }
 
     function handleEscape(event) {
-      if (event.key !== 'Escape') return
+      if (event.key !== 'Escape' || event.defaultPrevented) return
 
       if (supportsNative) {
-        const openPopovers = [...document.querySelectorAll(':popover-open')]
+        const root = contentRef.current?.getRootNode?.() ?? document
+        const path = eventPath(event)
+        const rootIndex = path.indexOf(root)
+        const innerPath = rootIndex < 0 ? path : path.slice(0, rootIndex)
+        // An open nested surface in a shadow tree owns Escape before its parent.
+        if (
+          innerPath.some(
+            (node) =>
+              node !== root &&
+              node?.host &&
+              node.querySelector?.(':popover-open')
+          )
+        )
+          return
+        const openPopovers = [...root.querySelectorAll(':popover-open')]
         if (openPopovers.at(-1) !== contentRef.current) return
       }
 
@@ -257,7 +321,14 @@ const Popover = forwardRef(function Popover(
       document.removeEventListener('pointerdown', handleOutsidePointer, true)
       document.removeEventListener('keydown', handleEscape)
     }
-  }, [isOpen, invokers, requestOpen, supportsNative])
+  }, [
+    isOpen,
+    invokers,
+    requestOpen,
+    resolveAnchor,
+    resolveInvoker,
+    supportsNative
+  ])
 
   function handleNativeToggle(event) {
     const nativeEvent = event.nativeEvent

--- a/docs/klean-ui/sources/popover/Popover.svelte
+++ b/docs/klean-ui/sources/popover/Popover.svelte
@@ -5,6 +5,7 @@
     flip,
     offset as floatingOffset,
     shift,
+    size,
   } from "@floating-ui/dom";
   import { onMount, untrack } from "svelte";
   import { twMerge } from "tailwind-merge";
@@ -18,6 +19,7 @@
     id,
     open = $bindable(),
     defaultOpen = false,
+    anchor,
     onOpenChange,
     placement = "bottom-start",
     offset = 8,
@@ -34,7 +36,12 @@
   let activeInvoker = $state();
   let supportsNative = $state(false);
   let resolvedPlacement = $state(untrack(() => placement));
-  let positionStyle = $state({ position: "fixed", left: "0px", top: "0px" });
+  let positionStyle = $state({
+    position: "fixed",
+    inset: "auto",
+    left: "0px",
+    top: "0px",
+  });
   let isOpen = $derived(open ?? internalOpen);
   let contentId = $derived(id ?? generatedId);
   let mergedStyle = $derived(
@@ -75,6 +82,20 @@
 
     if (!activeInvoker?.isConnected) activeInvoker = invokers()[0];
     return activeInvoker;
+  }
+
+  function resolveAnchor() {
+    if (typeof anchor === "string") {
+      const root = contentElement?.getRootNode?.() ?? document;
+      const element =
+        root.getElementById?.(anchor) ?? document.getElementById(anchor);
+
+      if (element?.isConnected) return element;
+    } else if (anchor?.isConnected) {
+      return anchor;
+    }
+
+    return resolveInvoker();
   }
 
   function syncInvokerAria() {
@@ -193,25 +214,49 @@
     syncInvokerAria();
     syncNativePopover();
 
-    const invoker = resolveInvoker();
-    if (!isOpen || !invoker || !contentElement) return;
+    const anchorElement = resolveAnchor();
+    if (!isOpen || !anchorElement || !contentElement) return;
+    const element = contentElement;
+    let active = true;
 
     const updatePosition = async () => {
-      const result = await computePosition(invoker, contentElement, {
+      const result = await computePosition(anchorElement, element, {
         placement,
         strategy: "fixed",
-        middleware: [floatingOffset(offset), flip(), shift({ padding: 8 })],
+        middleware: [
+          floatingOffset(offset),
+          flip({ padding: 8 }),
+          size({
+            padding: 8,
+            apply({ availableHeight, elements }) {
+              elements.floating.style.setProperty(
+                "--klean-popover-available-height",
+                `${Math.max(0, availableHeight)}px`,
+              );
+            },
+          }),
+          shift({ padding: 8, crossAxis: true }),
+        ],
       });
 
+      if (!active || contentElement !== element) return;
       resolvedPlacement = result.placement;
       positionStyle = {
         position: "fixed",
+        inset: "auto",
         left: `${result.x}px`,
         top: `${result.y}px`,
+        "--klean-popover-available-height": element.style.getPropertyValue(
+          "--klean-popover-available-height",
+        ),
       };
     };
 
-    return autoUpdate(invoker, contentElement, updatePosition);
+    const cleanup = autoUpdate(anchorElement, element, updatePosition);
+    return () => {
+      active = false;
+      cleanup();
+    };
   });
 
   $effect(() => {
@@ -219,12 +264,16 @@
 
     function handleOutsidePointer(event) {
       const path = eventPath(event);
-      const reference = resolveInvoker();
+      const invoker = resolveInvoker();
+      const anchorElement = resolveAnchor();
 
       if (
         path.includes(contentElement) ||
-        (reference &&
-          (path.includes(reference) || reference.contains?.(event.target))) ||
+        (invoker &&
+          (path.includes(invoker) || invoker.contains?.(event.target))) ||
+        (anchorElement &&
+          (path.includes(anchorElement) ||
+            anchorElement.contains?.(event.target))) ||
         invokers().some(
           (invoker) => path.includes(invoker) || invoker.contains(event.target),
         )
@@ -236,10 +285,24 @@
     }
 
     function handleEscape(event) {
-      if (event.key !== "Escape") return;
+      if (event.key !== "Escape" || event.defaultPrevented) return;
 
       if (supportsNative) {
-        const openPopovers = [...document.querySelectorAll(":popover-open")];
+        const root = contentElement?.getRootNode?.() ?? document;
+        const path = eventPath(event);
+        const rootIndex = path.indexOf(root);
+        const innerPath = rootIndex < 0 ? path : path.slice(0, rootIndex);
+        // An open nested surface in a shadow tree owns Escape before its parent.
+        if (
+          innerPath.some(
+            (node) =>
+              node !== root &&
+              node?.host &&
+              node.querySelector?.(":popover-open"),
+          )
+        )
+          return;
+        const openPopovers = [...root.querySelectorAll(":popover-open")];
         if (openPopovers.at(-1) !== contentElement) return;
       }
 

--- a/docs/klean-ui/sources/schedule-picker/SchedulePicker.jsx
+++ b/docs/klean-ui/sources/schedule-picker/SchedulePicker.jsx
@@ -3,7 +3,6 @@ import {
   useEffect,
   useId,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState
 } from 'react'
@@ -13,12 +12,14 @@ import Input from '../input/Input.jsx'
 import Popover from '../popover/Popover.jsx'
 import {
   formatSchedule,
-  formatTimeLabel,
   instantToWallClock,
+  initialScheduleWallClock,
   interpretSchedule,
   resolveTimeZone,
-  roundedFutureWallClock,
-  timeOptions,
+  scheduleCalendarBounds,
+  scheduleConstraint,
+  timeFields,
+  updateTimeField,
   wallClockToIso
 } from './schedule.js'
 
@@ -34,7 +35,9 @@ const SchedulePicker = forwardRef(function SchedulePicker(
     timeZone,
     locale,
     dir,
+    allowPast = false,
     min,
+    max,
     minuteStep = 15,
     open,
     defaultOpen = false,
@@ -59,9 +62,13 @@ const SchedulePicker = forwardRef(function SchedulePicker(
     : defaultValue
   const [internalValue, setInternalValue] = useState(validDefault)
   const committedValue = value === undefined ? internalValue : value
-  const initialWall =
-    instantToWallClock(committedValue, zone) ||
-    roundedFutureWallClock(new Date(), zone, minuteStep)
+  const initialWall = initialScheduleWallClock(committedValue, {
+    allowPast,
+    min,
+    max,
+    timeZone: zone,
+    minuteStep
+  })
   const [selectedDate, setSelectedDate] = useState(initialWall.date)
   const [selectedTime, setSelectedTime] = useState(initialWall.time)
   const [draft, setDraft] = useState(
@@ -78,27 +85,32 @@ const SchedulePicker = forwardRef(function SchedulePicker(
       : { state: 'empty' }
   )
   const [touched, setTouched] = useState(false)
+  const [validationClock, setValidationClock] = useState(Date.now)
   const inputRef = useRef(null)
   const popoverRef = useRef(null)
   const panelRef = useRef(null)
   const rootRef = useRef(null)
-  const configuredMinimum = new Date(min).getTime()
-  const minimumTimestamp = Math.max(
-    Date.now(),
-    Number.isNaN(configuredMinimum) ? -Infinity : configuredMinimum
+  const constraints = {
+    allowPast,
+    min,
+    max,
+    reference: new Date(validationClock)
+  }
+  const calendarBounds = scheduleCalendarBounds({
+    ...constraints,
+    timeZone: zone
+  })
+  const fields = timeFields(selectedTime, locale)
+  const minutes = Array.from({ length: 60 }, (_, minute) =>
+    String(minute).padStart(2, '0')
   )
-  const calendarMin = instantToWallClock(
-    new Date(minimumTimestamp + 1000).toISOString(),
-    zone
-  ).date
-  const choices = useMemo(() => timeOptions(minuteStep), [minuteStep])
-  const proposalIsPast =
-    interpretation.state === 'proposal' &&
-    new Date(interpretation.iso).getTime() <= minimumTimestamp
-  const committable = interpretation.state === 'proposal' && !proposalIsPast
+  const constraintError = interpretation.iso
+    ? scheduleConstraint(interpretation.iso, constraints)
+    : ''
+  const committable = interpretation.state === 'proposal' && !constraintError
   const invalid =
     interpretation.state === 'invalid' ||
-    proposalIsPast ||
+    Boolean(constraintError) ||
     (touched && interpretation.state === 'incomplete')
   let statusText
   if (interpretation.state === 'empty')
@@ -107,10 +119,16 @@ const SchedulePicker = forwardRef(function SchedulePicker(
     statusText = 'Enter a date and time, such as tomorrow at 9am.'
   else if (interpretation.state === 'incomplete')
     statusText = interpretation.message
-  else if (proposalIsPast) statusText = 'Choose a time in the future.'
+  else if (constraintError === 'past')
+    statusText = 'Choose a time in the future.'
+  else if (constraintError === 'min')
+    statusText = `Choose ${formatSchedule(min, locale, zone)} or later.`
+  else if (constraintError === 'max')
+    statusText = `Choose ${formatSchedule(max, locale, zone)} or earlier.`
   else if (interpretation.state === 'proposal')
-    statusText = `Will schedule for ${interpretation.label} in ${zone}. Press Enter or leave the picker to use it.`
-  else statusText = `Scheduled for ${interpretation.label} in ${zone}.`
+    statusText = `${allowPast ? 'Use' : 'Will schedule for'} ${interpretation.label} in ${zone}. Press Enter or leave the picker to use it.`
+  else
+    statusText = `${allowPast ? 'Selected' : 'Scheduled for'} ${interpretation.label} in ${zone}.`
   const describedBy = [externalDescribedBy, statusId].filter(Boolean).join(' ')
 
   function updateValue(nextValue) {
@@ -119,6 +137,7 @@ const SchedulePicker = forwardRef(function SchedulePicker(
   }
 
   function readDraft(nextDraft) {
+    setValidationClock(Date.now())
     setDraft(nextDraft)
     if (!nextDraft.trim()) {
       updateValue('')
@@ -128,7 +147,8 @@ const SchedulePicker = forwardRef(function SchedulePicker(
     const next = interpretSchedule(nextDraft, {
       reference: new Date(),
       locale,
-      timeZone: zone
+      timeZone: zone,
+      allowPast
     })
     setInterpretation(next)
     if (next.date) setSelectedDate(next.date)
@@ -136,20 +156,36 @@ const SchedulePicker = forwardRef(function SchedulePicker(
   }
 
   function stage(date = selectedDate, time = selectedTime) {
-    const iso = wallClockToIso({ date, time, timeZone: zone })
+    if (disabled || readOnly) return
+    setValidationClock(Date.now())
+    // Reselecting an unchanged instant must not discard its seconds.
+    const iso =
+      interpretation.iso &&
+      interpretation.date === date &&
+      interpretation.time === time
+        ? interpretation.iso
+        : wallClockToIso({ date, time, timeZone: zone })
+    setSelectedDate(date)
+    setSelectedTime(time)
     if (!iso) {
       setInterpretation({ state: 'invalid' })
       return
     }
     const label = formatSchedule(iso, locale, zone)
-    setSelectedDate(date)
-    setSelectedTime(time)
     setDraft(label)
     setInterpretation({ state: 'proposal', iso, date, time, label })
   }
 
   function commitProposal({ restoreFocus = true } = {}) {
-    if (!committable || disabled || readOnly) return
+    const reference = new Date()
+    setValidationClock(reference.getTime())
+    if (
+      interpretation.state !== 'proposal' ||
+      disabled ||
+      readOnly ||
+      scheduleConstraint(interpretation.iso, { allowPast, min, max, reference })
+    )
+      return
     updateValue(interpretation.iso)
     setDraft(interpretation.label)
     setInterpretation({ ...interpretation, state: 'committed' })
@@ -166,46 +202,45 @@ const SchedulePicker = forwardRef(function SchedulePicker(
     commitProposal({ restoreFocus: false })
   }
 
+  function finish() {
+    const reference = new Date()
+    setValidationClock(reference.getTime())
+    if (
+      disabled ||
+      readOnly ||
+      scheduleConstraint(interpretation.iso, { allowPast, min, max, reference })
+    )
+      return
+    if (interpretation.state === 'committed') {
+      popoverRef.current?.close()
+      return
+    }
+    commitProposal()
+  }
+
   function handleOpenChange(nextOpen) {
+    setValidationClock(Date.now())
     onOpenChange?.(nextOpen)
     if (!nextOpen) return
-    queueMicrotask(() =>
-      panelRef.current
-        ?.querySelector(`[data-time="${selectedTime}"]`)
-        ?.scrollIntoView?.({ block: 'center' })
-    )
-  }
-
-  function timeIsUnavailable(time) {
-    const iso = wallClockToIso({ date: selectedDate, time, timeZone: zone })
-    return !iso || new Date(iso).getTime() <= minimumTimestamp
-  }
-
-  function handleTimeKeyDown(event, index) {
-    let nextIndex
-    if (event.key === 'ArrowDown')
-      nextIndex = Math.min(index + 1, choices.length - 1)
-    else if (event.key === 'ArrowUp') nextIndex = Math.max(index - 1, 0)
-    else if (event.key === 'Home') nextIndex = 0
-    else if (event.key === 'End') nextIndex = choices.length - 1
-    else return
-    event.preventDefault()
-    const movement = nextIndex >= index ? 1 : -1
-    while (
-      nextIndex >= 0 &&
-      nextIndex < choices.length &&
-      timeIsUnavailable(choices[nextIndex])
-    ) {
-      nextIndex += movement
+    if (interpretation.state === 'empty') {
+      const wall = initialScheduleWallClock('', {
+        allowPast,
+        min,
+        max,
+        timeZone: zone,
+        minuteStep
+      })
+      setSelectedDate(wall.date)
+      setSelectedTime(wall.time)
     }
-    const nextTime = choices[nextIndex]
-    if (!nextTime) return
-    setSelectedTime(nextTime)
-    queueMicrotask(() =>
-      panelRef.current
-        ?.querySelector(`[data-time="${nextTime}"]`)
-        ?.focus({ preventScroll: true })
-    )
+    requestAnimationFrame(() => {
+      if (!panelRef.current?.getClientRects().length) return
+      panelRef.current.parentElement.scrollTop = 0
+    })
+  }
+
+  function chooseTimeField(part, nextValue) {
+    stage(selectedDate, updateTimeField(selectedTime, part, nextValue, locale))
   }
 
   useEffect(() => {
@@ -232,10 +267,18 @@ const SchedulePicker = forwardRef(function SchedulePicker(
   useEffect(() => {
     if (!inputRef.current) return
     if (required && !committedValue)
-      inputRef.current.setCustomValidity('Choose a schedule.')
-    else if (invalid) inputRef.current.setCustomValidity(statusText)
+      inputRef.current.setCustomValidity('Choose a date and time.')
+    else if (invalid || interpretation.state === 'incomplete')
+      inputRef.current.setCustomValidity(statusText)
     else inputRef.current.setCustomValidity('')
-  }, [committable, committedValue, invalid, required, statusText])
+  }, [
+    committable,
+    committedValue,
+    interpretation.state,
+    invalid,
+    required,
+    statusText
+  ])
 
   useImperativeHandle(forwardedRef, () => ({
     input: inputRef.current,
@@ -269,7 +312,6 @@ const SchedulePicker = forwardRef(function SchedulePicker(
           readOnly={readOnly}
           aria-invalid={invalid || undefined}
           aria-describedby={describedBy}
-          data-slot="schedule-picker-input"
           onChange={(event) => {
             onChange?.(event)
             if (!event.defaultPrevented) {
@@ -284,8 +326,15 @@ const SchedulePicker = forwardRef(function SchedulePicker(
             if (event.key === 'ArrowDown' && !disabled && !readOnly) {
               event.preventDefault()
               popoverRef.current?.open()
-            } else if (event.key === 'Enter' && committable) {
+            } else if (
+              event.key === 'Enter' &&
+              (interpretation.state === 'proposal' ||
+                interpretation.state === 'incomplete' ||
+                interpretation.state === 'invalid' ||
+                constraintError)
+            ) {
               event.preventDefault()
+              setTouched(true)
               commitProposal({ restoreFocus: false })
             }
           }}
@@ -311,7 +360,14 @@ const SchedulePicker = forwardRef(function SchedulePicker(
           </svg>
         </button>
       </div>
-      {name ? <input type="hidden" name={name} value={committedValue} /> : null}
+      {name ? (
+        <input
+          type="hidden"
+          name={name}
+          value={committedValue}
+          disabled={disabled}
+        />
+      ) : null}
       <p
         id={statusId}
         data-slot="schedule-picker-status"
@@ -325,18 +381,20 @@ const SchedulePicker = forwardRef(function SchedulePicker(
       <Popover
         ref={popoverRef}
         id={popoverId}
+        anchor={inputId}
         open={open}
         defaultOpen={defaultOpen}
         onOpenChange={handleOpenChange}
         placement="bottom-start"
         data-slot="schedule-picker-popover"
-        className="w-[min(42rem,calc(100vw-1rem))] p-0"
+        className="max-h-[min(var(--klean-popover-available-height,100dvh),calc(100dvh-1rem))] w-[min(24rem,calc(100vw-1rem))] overflow-y-auto overscroll-contain rounded-xl p-0"
       >
         <div ref={panelRef} data-slot="schedule-picker-panel">
-          <div className="grid sm:grid-cols-[minmax(0,1fr)_10rem]">
+          <div className="grid">
             <Calendar
               value={selectedDate}
-              min={calendarMin}
+              min={calendarBounds.min}
+              max={calendarBounds.max}
               locale={locale}
               dir={dir}
               disabled={disabled}
@@ -346,57 +404,122 @@ const SchedulePicker = forwardRef(function SchedulePicker(
             />
             <section
               data-slot="schedule-picker-times"
-              className="border-t border-gray-200 p-3 sm:border-s sm:border-t-0 dark:border-gray-700"
+              className="sticky bottom-0 grid min-w-0 gap-2 border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-950"
               aria-labelledby={timeHeadingId}
             >
-              <h2
-                id={timeHeadingId}
-                className="px-2 pb-2 text-sm font-semibold"
-              >
-                Time
-              </h2>
-              <div
-                role="listbox"
-                aria-label="Choose a time"
-                className="max-h-64 overflow-y-auto overscroll-contain"
-              >
-                {choices.map((time, index) => (
-                  <button
-                    key={time}
-                    type="button"
-                    role="option"
-                    data-slot="schedule-picker-time"
-                    data-time={time}
-                    aria-selected={time === selectedTime}
-                    disabled={timeIsUnavailable(time)}
-                    tabIndex={time === selectedTime ? 0 : -1}
-                    className="block min-h-11 w-full rounded-md px-3 text-start text-sm tabular-nums hover:bg-gray-100 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:text-gray-300 aria-selected:bg-gray-950 aria-selected:font-semibold aria-selected:text-white dark:hover:bg-gray-800 dark:focus-visible:outline-white dark:disabled:text-gray-700 dark:aria-selected:bg-white dark:aria-selected:text-gray-950"
-                    onClick={() => stage(selectedDate, time)}
-                    onKeyDown={(event) => handleTimeKeyDown(event, index)}
-                  >
-                    {formatTimeLabel(time, locale)}
-                  </button>
-                ))}
+              <div className="flex min-w-0 items-baseline justify-between gap-3">
+                <h2 id={timeHeadingId} className="text-sm font-medium">
+                  Time
+                </h2>
+                <p
+                  id={`${inputId}-time-zone`}
+                  data-slot="schedule-picker-time-zone"
+                  className="min-w-0 text-end text-xs wrap-anywhere text-gray-500 dark:text-gray-400"
+                >
+                  {zone}
+                </p>
               </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div
+                  data-slot="schedule-picker-time-fields"
+                  role="group"
+                  aria-labelledby={timeHeadingId}
+                  aria-describedby={`${inputId}-time-zone`}
+                  dir="ltr"
+                  className="inline-flex shrink-0 items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 text-sm font-medium tabular-nums shadow-xs dark:border-gray-700 dark:bg-gray-900"
+                >
+                  <select
+                    data-slot="schedule-picker-hour"
+                    aria-label="Hour"
+                    className="h-11 w-11 cursor-pointer appearance-none rounded-md bg-transparent text-center text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                    value={fields.hour}
+                    disabled={disabled || readOnly}
+                    onChange={(event) =>
+                      chooseTimeField('hour', event.target.value)
+                    }
+                  >
+                    {fields.hours.map((hour) => (
+                      <option key={hour.value} value={hour.value}>
+                        {hour.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span aria-hidden="true" className="text-gray-400">
+                    :
+                  </span>
+                  <select
+                    data-slot="schedule-picker-minute"
+                    aria-label="Minute"
+                    className="h-11 w-11 cursor-pointer appearance-none rounded-md bg-transparent text-center text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                    value={fields.minute}
+                    disabled={disabled || readOnly}
+                    onChange={(event) =>
+                      chooseTimeField('minute', event.target.value)
+                    }
+                  >
+                    {minutes.map((minute) => (
+                      <option key={minute} value={minute}>
+                        {minute}
+                      </option>
+                    ))}
+                  </select>
+                  {fields.hour12 ? (
+                    <div className="relative ms-1 border-s border-gray-200 ps-1 dark:border-gray-700">
+                      <select
+                        data-slot="schedule-picker-period"
+                        aria-label="Period"
+                        className="h-11 min-w-16 cursor-pointer appearance-none rounded-md bg-transparent ps-2 pe-6 text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                        value={fields.period}
+                        disabled={disabled || readOnly}
+                        onChange={(event) =>
+                          chooseTimeField('period', event.target.value)
+                        }
+                      >
+                        {fields.periods.map((period) => (
+                          <option key={period.value} value={period.value}>
+                            {period.label}
+                          </option>
+                        ))}
+                      </select>
+                      <svg
+                        aria-hidden="true"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="pointer-events-none absolute inset-e-2 top-1/2 size-3 -translate-y-1/2 text-gray-500 dark:text-gray-400"
+                      >
+                        <path d="m7 10 5 5 5-5" />
+                      </svg>
+                    </div>
+                  ) : null}
+                </div>
+                <div data-slot="schedule-picker-footer">
+                  <button
+                    type="button"
+                    data-slot="schedule-picker-confirm"
+                    className="min-h-11 cursor-pointer rounded-lg bg-gray-950 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
+                    disabled={
+                      (!committable && interpretation.state !== 'committed') ||
+                      invalid ||
+                      disabled ||
+                      readOnly
+                    }
+                    onClick={finish}
+                  >
+                    Done
+                  </button>
+                </div>
+              </div>
+              {invalid ? (
+                <p className="text-sm text-red-700 dark:text-red-400">
+                  {statusText}
+                </p>
+              ) : null}
             </section>
           </div>
-          <footer
-            data-slot="schedule-picker-footer"
-            className="flex flex-col gap-3 border-t border-gray-200 p-4 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700"
-          >
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              {statusText}
-            </p>
-            <button
-              type="button"
-              data-slot="schedule-picker-confirm"
-              className="min-h-11 shrink-0 rounded-md bg-gray-950 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
-              disabled={!committable || disabled || readOnly}
-              onClick={() => commitProposal()}
-            >
-              Use this time
-            </button>
-          </footer>
         </div>
       </Popover>
     </div>

--- a/docs/klean-ui/sources/schedule-picker/SchedulePicker.svelte
+++ b/docs/klean-ui/sources/schedule-picker/SchedulePicker.svelte
@@ -6,12 +6,14 @@
   import Popover from "../popover/Popover.svelte";
   import {
     formatSchedule,
-    formatTimeLabel,
     instantToWallClock,
+    initialScheduleWallClock,
     interpretSchedule,
     resolveTimeZone,
-    roundedFutureWallClock,
-    timeOptions,
+    scheduleCalendarBounds,
+    scheduleConstraint,
+    timeFields,
+    updateTimeField,
     wallClockToIso,
   } from "./schedule.js";
 
@@ -25,7 +27,9 @@
     timeZone,
     locale,
     dir,
+    allowPast = false,
     min,
+    max,
     minuteStep = 15,
     open = $bindable(),
     defaultOpen = false,
@@ -50,16 +54,15 @@
     return Number.isNaN(new Date(candidate).getTime()) ? "" : candidate;
   });
   if (untrack(() => value) === undefined) value = initialValue;
-  const initialWall =
-    instantToWallClock(
-      initialValue,
-      untrack(() => zone),
-    ) ||
-    roundedFutureWallClock(
-      new Date(),
-      untrack(() => zone),
-      untrack(() => minuteStep),
-    );
+  const initialWall = untrack(() =>
+    initialScheduleWallClock(initialValue, {
+      allowPast,
+      min,
+      max,
+      timeZone: zone,
+      minuteStep,
+    }),
+  );
   let selectedDate = $state(initialWall.date);
   let selectedTime = $state(initialWall.time);
   let draft = $state(
@@ -86,32 +89,35 @@
       : { state: "empty" },
   );
   let touched = $state(false);
+  let validationClock = $state(Date.now());
   let input;
   let popover;
   let panel;
   let root;
-  let minimumTimestamp = $derived.by(() => {
-    const configured = new Date(min).getTime();
-    return Math.max(
-      Date.now(),
-      Number.isNaN(configured) ? -Infinity : configured,
-    );
+  let constraints = $derived({
+    allowPast,
+    min,
+    max,
+    reference: new Date(validationClock),
   });
-  let calendarMin = $derived(
-    instantToWallClock(new Date(minimumTimestamp + 1000).toISOString(), zone)
-      .date,
+  let calendarBounds = $derived(
+    scheduleCalendarBounds({ ...constraints, timeZone: zone }),
   );
-  let choices = $derived(timeOptions(minuteStep));
-  let proposalIsPast = $derived(
-    interpretation.state === "proposal" &&
-      new Date(interpretation.iso).getTime() <= minimumTimestamp,
+  let fields = $derived(timeFields(selectedTime, locale));
+  const minutes = Array.from({ length: 60 }, (_, minute) =>
+    String(minute).padStart(2, "0"),
+  );
+  let constraintError = $derived(
+    interpretation.iso
+      ? scheduleConstraint(interpretation.iso, constraints)
+      : "",
   );
   let committable = $derived(
-    interpretation.state === "proposal" && !proposalIsPast,
+    interpretation.state === "proposal" && !constraintError,
   );
   let invalid = $derived(
     interpretation.state === "invalid" ||
-      proposalIsPast ||
+      Boolean(constraintError) ||
       (touched && interpretation.state === "incomplete"),
   );
   let statusText = $derived.by(() => {
@@ -120,10 +126,14 @@
     if (interpretation.state === "invalid")
       return "Enter a date and time, such as tomorrow at 9am.";
     if (interpretation.state === "incomplete") return interpretation.message;
-    if (proposalIsPast) return "Choose a time in the future.";
+    if (constraintError === "past") return "Choose a time in the future.";
+    if (constraintError === "min")
+      return `Choose ${formatSchedule(min, locale, zone)} or later.`;
+    if (constraintError === "max")
+      return `Choose ${formatSchedule(max, locale, zone)} or earlier.`;
     if (interpretation.state === "proposal")
-      return `Will schedule for ${interpretation.label} in ${zone}. Press Enter or leave the picker to use it.`;
-    return `Scheduled for ${interpretation.label} in ${zone}.`;
+      return `${allowPast ? "Use" : "Will schedule for"} ${interpretation.label} in ${zone}. Press Enter or leave the picker to use it.`;
+    return `${allowPast ? "Selected" : "Scheduled for"} ${interpretation.label} in ${zone}.`;
   });
   let describedBy = $derived(
     [externalDescribedBy, statusId].filter(Boolean).join(" "),
@@ -135,6 +145,7 @@
   }
 
   function readDraft(nextDraft) {
+    validationClock = Date.now();
     draft = nextDraft;
     if (!nextDraft.trim()) {
       updateValue("");
@@ -145,6 +156,7 @@
       reference: new Date(),
       locale,
       timeZone: zone,
+      allowPast,
     });
     interpretation = next;
     if (next.date) selectedDate = next.date;
@@ -152,20 +164,36 @@
   }
 
   function stage(date = selectedDate, time = selectedTime) {
-    const iso = wallClockToIso({ date, time, timeZone: zone });
+    if (disabled || readonly) return;
+    validationClock = Date.now();
+    // Reselecting an unchanged instant must not discard its seconds.
+    const iso =
+      interpretation.iso &&
+      interpretation.date === date &&
+      interpretation.time === time
+        ? interpretation.iso
+        : wallClockToIso({ date, time, timeZone: zone });
+    selectedDate = date;
+    selectedTime = time;
     if (!iso) {
       interpretation = { state: "invalid" };
       return;
     }
     const label = formatSchedule(iso, locale, zone);
-    selectedDate = date;
-    selectedTime = time;
     draft = label;
     interpretation = { state: "proposal", iso, date, time, label };
   }
 
   function commitProposal({ restoreFocus = true } = {}) {
-    if (!committable || disabled || readonly) return;
+    const reference = new Date();
+    validationClock = reference.getTime();
+    if (
+      interpretation.state !== "proposal" ||
+      disabled ||
+      readonly ||
+      scheduleConstraint(interpretation.iso, { allowPast, min, max, reference })
+    )
+      return;
     updateValue(interpretation.iso);
     draft = interpretation.label;
     interpretation = { ...interpretation, state: "committed" };
@@ -178,71 +206,80 @@
     commitProposal({ restoreFocus: false });
   }
 
+  function finish() {
+    const reference = new Date();
+    validationClock = reference.getTime();
+    if (
+      disabled ||
+      readonly ||
+      scheduleConstraint(interpretation.iso, { allowPast, min, max, reference })
+    )
+      return;
+    if (interpretation.state === "committed") {
+      popover?.close();
+      return;
+    }
+    commitProposal();
+  }
+
   function handleOpenChange(nextOpen) {
+    validationClock = Date.now();
     onopenchange?.(nextOpen);
     if (!nextOpen) return;
-    queueMicrotask(() =>
-      panel
-        ?.querySelector(`[data-time="${selectedTime}"]`)
-        ?.scrollIntoView?.({ block: "center" }),
-    );
-  }
-
-  function timeIsUnavailable(time) {
-    const iso = wallClockToIso({ date: selectedDate, time, timeZone: zone });
-    return !iso || new Date(iso).getTime() <= minimumTimestamp;
-  }
-
-  function handleTimeKeydown(event, index) {
-    let nextIndex;
-    if (event.key === "ArrowDown")
-      nextIndex = Math.min(index + 1, choices.length - 1);
-    else if (event.key === "ArrowUp") nextIndex = Math.max(index - 1, 0);
-    else if (event.key === "Home") nextIndex = 0;
-    else if (event.key === "End") nextIndex = choices.length - 1;
-    else return;
-    event.preventDefault();
-    const movement = nextIndex >= index ? 1 : -1;
-    while (
-      nextIndex >= 0 &&
-      nextIndex < choices.length &&
-      timeIsUnavailable(choices[nextIndex])
-    ) {
-      nextIndex += movement;
+    if (interpretation.state === "empty") {
+      const wall = initialScheduleWallClock("", {
+        allowPast,
+        min,
+        max,
+        timeZone: zone,
+        minuteStep,
+      });
+      selectedDate = wall.date;
+      selectedTime = wall.time;
     }
-    const nextTime = choices[nextIndex];
-    if (!nextTime) return;
-    selectedTime = nextTime;
-    queueMicrotask(() =>
-      panel
-        ?.querySelector(`[data-time="${nextTime}"]`)
-        ?.focus({ preventScroll: true }),
-    );
+    requestAnimationFrame(() => {
+      if (!panel?.getClientRects().length) return;
+      panel.parentElement.scrollTop = 0;
+    });
+  }
+
+  function chooseTimeField(part, nextValue) {
+    stage(selectedDate, updateTimeField(selectedTime, part, nextValue, locale));
   }
 
   $effect(() => {
-    const wall = instantToWallClock(value, zone);
-    if (!wall) {
-      if (!value && interpretation.state === "committed") {
-        draft = "";
-        interpretation = { state: "empty" };
+    const committedValue = value;
+    const currentZone = zone;
+    const currentLocale = locale;
+    untrack(() => {
+      const wall = instantToWallClock(committedValue, currentZone);
+      if (!wall) {
+        if (!committedValue) {
+          draft = "";
+          interpretation = { state: "empty" };
+        }
+        return;
       }
-      return;
-    }
-    if (interpretation.state === "proposal" && interpretation.iso === value)
-      return;
-    const label = formatSchedule(value, locale, zone);
-    selectedDate = wall.date;
-    selectedTime = wall.time;
-    draft = label;
-    interpretation = { state: "committed", iso: value, ...wall, label };
+      const label = formatSchedule(committedValue, currentLocale, currentZone);
+      selectedDate = wall.date;
+      selectedTime = wall.time;
+      draft = label;
+      interpretation = {
+        state: "committed",
+        iso: committedValue,
+        ...wall,
+        label,
+      };
+    });
   });
 
   $effect(() => {
     const element = input?.getElement();
     if (!element) return;
-    if (required && !value) element.setCustomValidity("Choose a schedule.");
-    else if (invalid) element.setCustomValidity(statusText);
+    if (required && !value)
+      element.setCustomValidity("Choose a date and time.");
+    else if (invalid || interpretation.state === "incomplete")
+      element.setCustomValidity(statusText);
     else element.setCustomValidity("");
   });
 
@@ -283,7 +320,6 @@
       {readonly}
       aria-invalid={invalid || undefined}
       aria-describedby={describedBy}
-      data-slot="schedule-picker-input"
       oninput={(event) => {
         touched = false;
         readDraft(event.target.value);
@@ -295,8 +331,15 @@
         if (event.key === "ArrowDown" && !disabled && !readonly) {
           event.preventDefault();
           popover?.show();
-        } else if (event.key === "Enter" && committable) {
+        } else if (
+          event.key === "Enter" &&
+          (interpretation.state === "proposal" ||
+            interpretation.state === "incomplete" ||
+            interpretation.state === "invalid" ||
+            constraintError)
+        ) {
           event.preventDefault();
+          touched = true;
           commitProposal({ restoreFocus: false });
         }
       }}
@@ -323,7 +366,7 @@
     </button>
   </div>
   {#if name}
-    <input type="hidden" {name} {value} />
+    <input type="hidden" {name} {value} {disabled} />
   {/if}
   <p
     id={statusId}
@@ -338,17 +381,19 @@
     bind:this={popover}
     bind:open
     id={popoverId}
+    anchor={inputId}
     {defaultOpen}
     onOpenChange={handleOpenChange}
     placement="bottom-start"
     data-slot="schedule-picker-popover"
-    class="w-[min(42rem,calc(100vw-1rem))] p-0"
+    class="max-h-[min(var(--klean-popover-available-height,100dvh),calc(100dvh-1rem))] w-[min(24rem,calc(100vw-1rem))] overflow-y-auto overscroll-contain rounded-xl p-0"
   >
     <div bind:this={panel} data-slot="schedule-picker-panel">
-      <div class="grid sm:grid-cols-[minmax(0,1fr)_10rem]">
+      <div class="grid">
         <Calendar
           value={selectedDate}
-          min={calendarMin}
+          min={calendarBounds.min}
+          max={calendarBounds.max}
           {locale}
           {dir}
           {disabled}
@@ -358,51 +403,108 @@
         />
         <section
           data-slot="schedule-picker-times"
-          class="border-t border-gray-200 p-3 sm:border-s sm:border-t-0 dark:border-gray-700"
+          class="sticky bottom-0 grid min-w-0 gap-2 border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-950"
           aria-labelledby={timeHeadingId}
         >
-          <h2 id={timeHeadingId} class="px-2 pb-2 text-sm font-semibold">
-            Time
-          </h2>
-          <div
-            role="listbox"
-            aria-label="Choose a time"
-            class="max-h-64 overflow-y-auto overscroll-contain"
-          >
-            {#each choices as time, index (time)}
+          <div class="flex min-w-0 items-baseline justify-between gap-3">
+            <h2 id={timeHeadingId} class="text-sm font-medium">Time</h2>
+            <p
+              id={`${inputId}-time-zone`}
+              data-slot="schedule-picker-time-zone"
+              class="min-w-0 text-end text-xs wrap-anywhere text-gray-500 dark:text-gray-400"
+            >
+              {zone}
+            </p>
+          </div>
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <div
+              data-slot="schedule-picker-time-fields"
+              role="group"
+              aria-labelledby={timeHeadingId}
+              aria-describedby={`${inputId}-time-zone`}
+              dir="ltr"
+              class="inline-flex shrink-0 items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 text-sm font-medium tabular-nums shadow-xs dark:border-gray-700 dark:bg-gray-900"
+            >
+              <select
+                data-slot="schedule-picker-hour"
+                aria-label="Hour"
+                class="h-11 w-11 cursor-pointer appearance-none rounded-md bg-transparent text-center text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                value={fields.hour}
+                disabled={disabled || readonly}
+                onchange={(event) =>
+                  chooseTimeField("hour", event.target.value)}
+              >
+                {#each fields.hours as hour (hour.value)}
+                  <option value={hour.value}>{hour.label}</option>
+                {/each}
+              </select>
+              <span aria-hidden="true" class="text-gray-400">:</span>
+              <select
+                data-slot="schedule-picker-minute"
+                aria-label="Minute"
+                class="h-11 w-11 cursor-pointer appearance-none rounded-md bg-transparent text-center text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                value={fields.minute}
+                disabled={disabled || readonly}
+                onchange={(event) =>
+                  chooseTimeField("minute", event.target.value)}
+              >
+                {#each minutes as minute (minute)}
+                  <option value={minute}>{minute}</option>
+                {/each}
+              </select>
+              {#if fields.hour12}
+                <div
+                  class="relative ms-1 border-s border-gray-200 ps-1 dark:border-gray-700"
+                >
+                  <select
+                    data-slot="schedule-picker-period"
+                    aria-label="Period"
+                    class="h-11 min-w-16 cursor-pointer appearance-none rounded-md bg-transparent ps-2 pe-6 text-gray-950 hover:bg-gray-200/60 focus-visible:bg-white focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:bg-gray-800 dark:focus-visible:outline-white"
+                    value={fields.period}
+                    disabled={disabled || readonly}
+                    onchange={(event) =>
+                      chooseTimeField("period", event.target.value)}
+                  >
+                    {#each fields.periods as period (period.value)}
+                      <option value={period.value}>{period.label}</option>
+                    {/each}
+                  </select>
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="pointer-events-none absolute inset-e-2 top-1/2 size-3 -translate-y-1/2 text-gray-500 dark:text-gray-400"
+                  >
+                    <path d="m7 10 5 5 5-5" />
+                  </svg>
+                </div>
+              {/if}
+            </div>
+            <div data-slot="schedule-picker-footer">
               <button
                 type="button"
-                role="option"
-                data-slot="schedule-picker-time"
-                data-time={time}
-                aria-selected={time === selectedTime}
-                disabled={timeIsUnavailable(time)}
-                tabindex={time === selectedTime ? 0 : -1}
-                class="block min-h-11 w-full rounded-md px-3 text-start text-sm tabular-nums hover:bg-gray-100 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:text-gray-300 aria-selected:bg-gray-950 aria-selected:font-semibold aria-selected:text-white dark:hover:bg-gray-800 dark:focus-visible:outline-white dark:disabled:text-gray-700 dark:aria-selected:bg-white dark:aria-selected:text-gray-950"
-                onclick={() => stage(selectedDate, time)}
-                onkeydown={(event) => handleTimeKeydown(event, index)}
+                data-slot="schedule-picker-confirm"
+                class="min-h-11 cursor-pointer rounded-lg bg-gray-950 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
+                disabled={(!committable &&
+                  interpretation.state !== "committed") ||
+                  invalid ||
+                  disabled ||
+                  readonly}
+                onclick={finish}
               >
-                {formatTimeLabel(time, locale)}
+                Done
               </button>
-            {/each}
+            </div>
           </div>
+          {#if invalid}
+            <p class="text-sm text-red-700 dark:text-red-400">{statusText}</p>
+          {/if}
         </section>
       </div>
-      <footer
-        data-slot="schedule-picker-footer"
-        class="flex flex-col gap-3 border-t border-gray-200 p-4 sm:flex-row sm:items-center sm:justify-between dark:border-gray-700"
-      >
-        <p class="text-sm text-gray-600 dark:text-gray-400">{statusText}</p>
-        <button
-          type="button"
-          data-slot="schedule-picker-confirm"
-          class="min-h-11 shrink-0 rounded-md bg-gray-950 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
-          disabled={!committable || disabled || readonly}
-          onclick={() => commitProposal()}
-        >
-          Use this time
-        </button>
-      </footer>
     </div>
   </Popover>
 </div>

--- a/docs/klean-ui/sources/schedule-picker/schedule.react.js
+++ b/docs/klean-ui/sources/schedule-picker/schedule.react.js
@@ -58,7 +58,7 @@ export function wallClockToIso({
   }
 
   try {
-    return toZoned(
+    const zoned = toZoned(
       new CalendarDateTime(
         parsedDate.year,
         parsedDate.month,
@@ -71,8 +71,20 @@ export function wallClockToIso({
       resolveTimeZone(timeZone),
       'compatible'
     )
-      .toDate()
-      .toISOString()
+    // A gap must not silently move an entered time forward. During an overlap,
+    // compatible disambiguation keeps the earlier occurrence.
+    if (
+      zoned.year !== parsedDate.year ||
+      zoned.month !== parsedDate.month ||
+      zoned.day !== parsedDate.day ||
+      zoned.hour !== parsedTime.hour ||
+      zoned.minute !== parsedTime.minute ||
+      zoned.second !== second ||
+      zoned.millisecond !== millisecond
+    ) {
+      return undefined
+    }
+    return zoned.toDate().toISOString()
   } catch {
     return undefined
   }
@@ -111,8 +123,128 @@ export function formatTimeLabel(value, locale) {
   }).format(new Date(Date.UTC(2020, 0, 1, time.hour, time.minute)))
 }
 
+function timestamp(value) {
+  if (value === undefined || value === null || value === '') return NaN
+  return new Date(value).getTime()
+}
+
+function referenceTimestamp(reference) {
+  const value = timestamp(reference)
+  return Number.isFinite(value) ? value : Date.now()
+}
+
+export function scheduleConstraint(
+  value,
+  { allowPast = false, min, max, reference = new Date() } = {}
+) {
+  const instant = timestamp(value)
+  if (!Number.isFinite(instant)) return 'invalid'
+  if (!allowPast && instant <= referenceTimestamp(reference)) return 'past'
+  if (instant < timestamp(min)) return 'min'
+  if (instant > timestamp(max)) return 'max'
+  return ''
+}
+
+export function scheduleCalendarBounds({
+  allowPast = false,
+  min,
+  max,
+  timeZone,
+  reference = new Date()
+} = {}) {
+  const configuredMin = timestamp(min)
+  const lower = Math.max(
+    allowPast ? -Infinity : referenceTimestamp(reference) + 1,
+    Number.isFinite(configuredMin) ? configuredMin : -Infinity
+  )
+  const upper = timestamp(max)
+  return {
+    min: Number.isFinite(lower)
+      ? instantToWallClock(lower, timeZone)?.date
+      : undefined,
+    max: Number.isFinite(upper)
+      ? instantToWallClock(upper, timeZone)?.date
+      : undefined
+  }
+}
+
+export function timeFields(value, locale) {
+  const time = parseTime(value) ?? { hour: 0, minute: 0 }
+  const resolvedLocale = resolveLocale(locale)
+  const hour12 = new Intl.DateTimeFormat(resolvedLocale, {
+    hour: 'numeric'
+  }).resolvedOptions().hour12
+  const hoursFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+    timeZone: 'UTC',
+    hour: '2-digit',
+    hourCycle: hour12 ? 'h12' : 'h23'
+  })
+  const periodsFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+    timeZone: 'UTC',
+    hour: 'numeric',
+    hourCycle: 'h12'
+  })
+  const part = (formatter, hour, type) =>
+    formatter
+      .formatToParts(new Date(Date.UTC(2020, 0, 1, hour)))
+      .find((item) => item.type === type)?.value
+
+  return {
+    hour: String(hour12 ? time.hour % 12 || 12 : time.hour),
+    minute: String(time.minute).padStart(2, '0'),
+    period: time.hour < 12 ? 'am' : 'pm',
+    hour12,
+    periods: [
+      { value: 'am', label: part(periodsFormatter, 6, 'dayPeriod') ?? 'AM' },
+      { value: 'pm', label: part(periodsFormatter, 18, 'dayPeriod') ?? 'PM' }
+    ],
+    hours: Array.from({ length: hour12 ? 12 : 24 }, (_, index) => {
+      const hour = hour12 ? index + 1 : index
+      return {
+        value: String(hour),
+        label: part(hoursFormatter, hour, 'hour') ?? String(hour)
+      }
+    })
+  }
+}
+
+export function updateTimeField(time, part, value, locale) {
+  const current = parseTime(time)
+  if (!current) return time
+  const fields = timeFields(time, locale)
+  if (part === 'period') {
+    if (!fields.hour12 || !['am', 'pm'].includes(value)) return time
+    current.hour = (current.hour % 12) + (value === 'pm' ? 12 : 0)
+  } else {
+    if (!/^\d{1,2}$/.test(String(value))) return time
+    const number = Number(value)
+    if (part === 'minute') {
+      if (number > 59) return time
+      current.minute = number
+    } else if (part === 'hour') {
+      if (fields.hour12) {
+        if (number < 1 || number > 12) return time
+        current.hour = (number % 12) + (fields.period === 'pm' ? 12 : 0)
+      } else {
+        if (number > 23) return time
+        current.hour = number
+      }
+    } else {
+      return time
+    }
+  }
+  return formatTime(current)
+}
+
+function normalizeMinuteStep(step) {
+  const value = Number(step)
+  return Number.isFinite(value)
+    ? Math.min(60, Math.max(1, Math.round(value)))
+    : 15
+}
+
 export function timeOptions(step = 15) {
-  const safeStep = Math.min(60, Math.max(1, Math.round(step)))
+  const safeStep = normalizeMinuteStep(step)
   const values = []
   for (let minute = 0; minute < 24 * 60; minute += safeStep) {
     values.push(
@@ -122,20 +254,54 @@ export function timeOptions(step = 15) {
   return values
 }
 
-export function roundedFutureWallClock(reference, timeZone, step = 15) {
-  const amount = Math.min(60, Math.max(1, Math.round(step)))
-  const rounded = new Date(reference)
+function roundedFutureTimestamp(reference, step) {
+  const amount = normalizeMinuteStep(step)
+  const rounded = new Date(referenceTimestamp(reference))
   rounded.setSeconds(0, 0)
   const remainder = rounded.getMinutes() % amount
   rounded.setMinutes(
     rounded.getMinutes() + (remainder ? amount - remainder : amount)
   )
-  return instantToWallClock(rounded.toISOString(), timeZone)
+  return rounded.getTime()
+}
+
+export function roundedFutureWallClock(reference, timeZone, step = 15) {
+  return instantToWallClock(roundedFutureTimestamp(reference, step), timeZone)
+}
+
+export function initialScheduleWallClock(
+  value,
+  {
+    allowPast = false,
+    min,
+    max,
+    timeZone,
+    minuteStep = 15,
+    reference = new Date()
+  } = {}
+) {
+  const current = timestamp(value)
+  if (Number.isFinite(current)) return instantToWallClock(current, timeZone)
+
+  const now = referenceTimestamp(reference)
+  const initial = roundedFutureTimestamp(now, minuteStep)
+  const configuredMin = timestamp(min)
+  const configuredMax = timestamp(max)
+  const lower = Math.max(
+    allowPast ? -Infinity : now + 1,
+    Number.isFinite(configuredMin) ? configuredMin : -Infinity
+  )
+  const upper = Number.isFinite(configuredMax) ? configuredMax : Infinity
+  // Bounds still disable every choice when the allowed interval is empty.
+  // Initializing a view must not imply that a forbidden instant is valid.
+  const candidate =
+    lower <= upper ? Math.min(upper, Math.max(lower, initial)) : initial
+  return instantToWallClock(candidate, timeZone)
 }
 
 export function interpretSchedule(
   text,
-  { reference = new Date(), locale, timeZone } = {}
+  { reference = new Date(), locale, timeZone, allowPast = false } = {}
 ) {
   const source = text?.trim()
   if (!source) return { state: 'empty' }
@@ -153,7 +319,7 @@ export function interpretSchedule(
       instant: referenceInstant,
       timezone: zonedReference.offset / 60_000
     },
-    { forwardDate: true }
+    { forwardDate: !allowPast }
   )[0]
 
   if (!result) return { state: 'invalid' }
@@ -187,8 +353,7 @@ export function interpretSchedule(
 
   return {
     state: 'proposal',
-    date,
-    time,
+    ...instantToWallClock(iso, zone),
     iso,
     label: formatSchedule(iso, locale, zone),
     timeZone: zone

--- a/docs/klean-ui/sources/schedule-picker/schedule.svelte.js
+++ b/docs/klean-ui/sources/schedule-picker/schedule.svelte.js
@@ -58,7 +58,7 @@ export function wallClockToIso({
   }
 
   try {
-    return toZoned(
+    const zoned = toZoned(
       new CalendarDateTime(
         parsedDate.year,
         parsedDate.month,
@@ -71,8 +71,20 @@ export function wallClockToIso({
       resolveTimeZone(timeZone),
       'compatible'
     )
-      .toDate()
-      .toISOString()
+    // A gap must not silently move an entered time forward. During an overlap,
+    // compatible disambiguation keeps the earlier occurrence.
+    if (
+      zoned.year !== parsedDate.year ||
+      zoned.month !== parsedDate.month ||
+      zoned.day !== parsedDate.day ||
+      zoned.hour !== parsedTime.hour ||
+      zoned.minute !== parsedTime.minute ||
+      zoned.second !== second ||
+      zoned.millisecond !== millisecond
+    ) {
+      return undefined
+    }
+    return zoned.toDate().toISOString()
   } catch {
     return undefined
   }
@@ -111,8 +123,128 @@ export function formatTimeLabel(value, locale) {
   }).format(new Date(Date.UTC(2020, 0, 1, time.hour, time.minute)))
 }
 
+function timestamp(value) {
+  if (value === undefined || value === null || value === '') return NaN
+  return new Date(value).getTime()
+}
+
+function referenceTimestamp(reference) {
+  const value = timestamp(reference)
+  return Number.isFinite(value) ? value : Date.now()
+}
+
+export function scheduleConstraint(
+  value,
+  { allowPast = false, min, max, reference = new Date() } = {}
+) {
+  const instant = timestamp(value)
+  if (!Number.isFinite(instant)) return 'invalid'
+  if (!allowPast && instant <= referenceTimestamp(reference)) return 'past'
+  if (instant < timestamp(min)) return 'min'
+  if (instant > timestamp(max)) return 'max'
+  return ''
+}
+
+export function scheduleCalendarBounds({
+  allowPast = false,
+  min,
+  max,
+  timeZone,
+  reference = new Date()
+} = {}) {
+  const configuredMin = timestamp(min)
+  const lower = Math.max(
+    allowPast ? -Infinity : referenceTimestamp(reference) + 1,
+    Number.isFinite(configuredMin) ? configuredMin : -Infinity
+  )
+  const upper = timestamp(max)
+  return {
+    min: Number.isFinite(lower)
+      ? instantToWallClock(lower, timeZone)?.date
+      : undefined,
+    max: Number.isFinite(upper)
+      ? instantToWallClock(upper, timeZone)?.date
+      : undefined
+  }
+}
+
+export function timeFields(value, locale) {
+  const time = parseTime(value) ?? { hour: 0, minute: 0 }
+  const resolvedLocale = resolveLocale(locale)
+  const hour12 = new Intl.DateTimeFormat(resolvedLocale, {
+    hour: 'numeric'
+  }).resolvedOptions().hour12
+  const hoursFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+    timeZone: 'UTC',
+    hour: '2-digit',
+    hourCycle: hour12 ? 'h12' : 'h23'
+  })
+  const periodsFormatter = new Intl.DateTimeFormat(resolvedLocale, {
+    timeZone: 'UTC',
+    hour: 'numeric',
+    hourCycle: 'h12'
+  })
+  const part = (formatter, hour, type) =>
+    formatter
+      .formatToParts(new Date(Date.UTC(2020, 0, 1, hour)))
+      .find((item) => item.type === type)?.value
+
+  return {
+    hour: String(hour12 ? time.hour % 12 || 12 : time.hour),
+    minute: String(time.minute).padStart(2, '0'),
+    period: time.hour < 12 ? 'am' : 'pm',
+    hour12,
+    periods: [
+      { value: 'am', label: part(periodsFormatter, 6, 'dayPeriod') ?? 'AM' },
+      { value: 'pm', label: part(periodsFormatter, 18, 'dayPeriod') ?? 'PM' }
+    ],
+    hours: Array.from({ length: hour12 ? 12 : 24 }, (_, index) => {
+      const hour = hour12 ? index + 1 : index
+      return {
+        value: String(hour),
+        label: part(hoursFormatter, hour, 'hour') ?? String(hour)
+      }
+    })
+  }
+}
+
+export function updateTimeField(time, part, value, locale) {
+  const current = parseTime(time)
+  if (!current) return time
+  const fields = timeFields(time, locale)
+  if (part === 'period') {
+    if (!fields.hour12 || !['am', 'pm'].includes(value)) return time
+    current.hour = (current.hour % 12) + (value === 'pm' ? 12 : 0)
+  } else {
+    if (!/^\d{1,2}$/.test(String(value))) return time
+    const number = Number(value)
+    if (part === 'minute') {
+      if (number > 59) return time
+      current.minute = number
+    } else if (part === 'hour') {
+      if (fields.hour12) {
+        if (number < 1 || number > 12) return time
+        current.hour = (number % 12) + (fields.period === 'pm' ? 12 : 0)
+      } else {
+        if (number > 23) return time
+        current.hour = number
+      }
+    } else {
+      return time
+    }
+  }
+  return formatTime(current)
+}
+
+function normalizeMinuteStep(step) {
+  const value = Number(step)
+  return Number.isFinite(value)
+    ? Math.min(60, Math.max(1, Math.round(value)))
+    : 15
+}
+
 export function timeOptions(step = 15) {
-  const safeStep = Math.min(60, Math.max(1, Math.round(step)))
+  const safeStep = normalizeMinuteStep(step)
   const values = []
   for (let minute = 0; minute < 24 * 60; minute += safeStep) {
     values.push(
@@ -122,20 +254,54 @@ export function timeOptions(step = 15) {
   return values
 }
 
-export function roundedFutureWallClock(reference, timeZone, step = 15) {
-  const amount = Math.min(60, Math.max(1, Math.round(step)))
-  const rounded = new Date(reference)
+function roundedFutureTimestamp(reference, step) {
+  const amount = normalizeMinuteStep(step)
+  const rounded = new Date(referenceTimestamp(reference))
   rounded.setSeconds(0, 0)
   const remainder = rounded.getMinutes() % amount
   rounded.setMinutes(
     rounded.getMinutes() + (remainder ? amount - remainder : amount)
   )
-  return instantToWallClock(rounded.toISOString(), timeZone)
+  return rounded.getTime()
+}
+
+export function roundedFutureWallClock(reference, timeZone, step = 15) {
+  return instantToWallClock(roundedFutureTimestamp(reference, step), timeZone)
+}
+
+export function initialScheduleWallClock(
+  value,
+  {
+    allowPast = false,
+    min,
+    max,
+    timeZone,
+    minuteStep = 15,
+    reference = new Date()
+  } = {}
+) {
+  const current = timestamp(value)
+  if (Number.isFinite(current)) return instantToWallClock(current, timeZone)
+
+  const now = referenceTimestamp(reference)
+  const initial = roundedFutureTimestamp(now, minuteStep)
+  const configuredMin = timestamp(min)
+  const configuredMax = timestamp(max)
+  const lower = Math.max(
+    allowPast ? -Infinity : now + 1,
+    Number.isFinite(configuredMin) ? configuredMin : -Infinity
+  )
+  const upper = Number.isFinite(configuredMax) ? configuredMax : Infinity
+  // Bounds still disable every choice when the allowed interval is empty.
+  // Initializing a view must not imply that a forbidden instant is valid.
+  const candidate =
+    lower <= upper ? Math.min(upper, Math.max(lower, initial)) : initial
+  return instantToWallClock(candidate, timeZone)
 }
 
 export function interpretSchedule(
   text,
-  { reference = new Date(), locale, timeZone } = {}
+  { reference = new Date(), locale, timeZone, allowPast = false } = {}
 ) {
   const source = text?.trim()
   if (!source) return { state: 'empty' }
@@ -153,7 +319,7 @@ export function interpretSchedule(
       instant: referenceInstant,
       timezone: zonedReference.offset / 60_000
     },
-    { forwardDate: true }
+    { forwardDate: !allowPast }
   )[0]
 
   if (!result) return { state: 'invalid' }
@@ -187,8 +353,7 @@ export function interpretSchedule(
 
   return {
     state: 'proposal',
-    date,
-    time,
+    ...instantToWallClock(iso, zone),
     iso,
     label: formatSchedule(iso, locale, zone),
     timeZone: zone


### PR DESCRIPTION
## Summary

- Document historical datetime editing through `allowPast`, inclusive ISO `min` / `max`, caller-configured timezone and exact instant semantics.
- Add live historical-record and bounded-period examples, with Vue, React and Svelte usage and application-owned styling.
- Explain the compact time controls, locale-aware 12/24-hour display, Done/Enter/composite-blur behavior, and initial-only `minuteStep` rounding.
- Update related-component guidance and synchronize all nine SchedulePicker/helper/Popover source mirrors, including constrained popup positioning and teardown/focus guards.

## Verification

- Canonical docs production build passed (existing chunk-size warning only).
- All nine source mirrors match the final Klean UI implementation modulo docs formatting.
- Live docs verified at 375x667 and 1440x1000: no input overlap, visible Done/time controls, historical bounds, native controls, unchanged precision, form validation and Escape focus.
- `git diff --check` passed.

Companion implementation: https://github.com/sailscastshq/klean-ui/pull/157

Closes sailscastshq/klean-ui#156
